### PR TITLE
Update publish workflows for signalwire_agents → signalwire rename

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -51,14 +51,14 @@ jobs:
           sed -i "s/^version = \".*\"/version = \"$DEV_VERSION\"/" pyproject.toml
 
           # Update __init__.py
-          sed -i "s/__version__ = \".*\"/__version__ = \"$DEV_VERSION\"/" signalwire_agents/__init__.py
+          sed -i "s/__version__ = \".*\"/__version__ = \"$DEV_VERSION\"/" signalwire/__init__.py
 
           # Update agent_server.py
-          sed -i "s/version=\"[^\"]*\"/version=\"$DEV_VERSION\"/" signalwire_agents/agent_server.py
+          sed -i "s/version=\"[^\"]*\"/version=\"$DEV_VERSION\"/" signalwire/agent_server.py
 
           echo "Updated version to $DEV_VERSION"
           grep "version" pyproject.toml | head -1
-          grep "__version__" signalwire_agents/__init__.py
+          grep "__version__" signalwire/__init__.py
 
       - name: Build package
         run: python -m build
@@ -78,7 +78,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Install with:**" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "pip install signalwire-agents==${{ steps.version.outputs.dev_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "pip install signalwire==${{ steps.version.outputs.dev_version }}" >> $GITHUB_STEP_SUMMARY
           echo "# or for latest dev:" >> $GITHUB_STEP_SUMMARY
-          echo "pip install signalwire-agents --pre" >> $GITHUB_STEP_SUMMARY
+          echo "pip install signalwire --pre" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -99,7 +99,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Install with:**" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "pip install signalwire-agents==${{ steps.tag_version.outputs.tag_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "pip install signalwire==${{ steps.tag_version.outputs.tag_version }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**PyPI:** https://pypi.org/project/signalwire-agents/${{ steps.tag_version.outputs.tag_version }}/" >> $GITHUB_STEP_SUMMARY
+          echo "**PyPI:** https://pypi.org/project/signalwire/${{ steps.tag_version.outputs.tag_version }}/" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Fix module paths and package name references in both publish-dev and publish-release workflows to match the SDK 2.0 rename.

## Description

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

<!-- Link any related issues: Fixes #123 or Relates to #456 -->

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
