### PR TITLE
Add PhoneCallHandler enum and typed phone-binding helpers

### DIFF
--- a/rest/examples/rest_bind_phone_to_swml_webhook.py
+++ b/rest/examples/rest_bind_phone_to_swml_webhook.py
@@ -1,0 +1,57 @@
+"""Example: bind an inbound phone number to an SWML webhook (the happy path).
+
+This is the simplest way to route a SignalWire phone number to a backend
+that returns an SWML document per inbound call. You set ``call_handler``
+on the phone number; the server auto-materializes a ``swml_webhook``
+Fabric resource pointing at your URL. You do **not** need to create the
+Fabric webhook resource manually; you do **not** call
+``assign_phone_route``.
+
+Set these env vars (or pass them directly to RestClient):
+  SIGNALWIRE_PROJECT_ID   - your SignalWire project ID
+  SIGNALWIRE_API_TOKEN    - your SignalWire API token
+  SIGNALWIRE_SPACE        - your SignalWire space (e.g. example.signalwire.com)
+  PHONE_NUMBER_SID        - SID of a phone number you own (pn-...)
+  SWML_WEBHOOK_URL        - your backend's SWML endpoint
+"""
+
+import os
+
+from signalwire.rest import RestClient, PhoneCallHandler
+
+
+def main() -> None:
+    pn_sid = os.environ["PHONE_NUMBER_SID"]
+    webhook_url = os.environ["SWML_WEBHOOK_URL"]
+
+    client = RestClient()
+
+    # The typed helper — one line:
+    print(f"Binding {pn_sid} to {webhook_url} ...")
+    client.phone_numbers.set_swml_webhook(pn_sid, url=webhook_url)
+
+    # The equivalent wire-level form (use this if you need unusual fields):
+    #
+    # client.phone_numbers.update(
+    #     pn_sid,
+    #     call_handler=PhoneCallHandler.RELAY_SCRIPT.value,
+    #     call_relay_script_url=webhook_url,
+    # )
+
+    # Verify: the server auto-created a swml_webhook Fabric resource.
+    pn = client.phone_numbers.get(pn_sid)
+    print(f"  call_handler = {pn.get('call_handler')!r}")
+    print(f"  call_relay_script_url = {pn.get('call_relay_script_url')!r}")
+    print(f"  calling_handler_resource_id (server-derived) = "
+          f"{pn.get('calling_handler_resource_id')!r}")
+
+    # To route to something other than an SWML webhook, use:
+    #   client.phone_numbers.set_cxml_webhook(sid, url=...)       # LAML / Twilio-compat
+    #   client.phone_numbers.set_ai_agent(sid, agent_id=...)      # AI Agent
+    #   client.phone_numbers.set_call_flow(sid, flow_id=...)      # Call Flow
+    #   client.phone_numbers.set_relay_application(sid, name=...) # Named RELAY app
+    #   client.phone_numbers.set_relay_topic(sid, topic=...)      # RELAY topic
+
+
+if __name__ == "__main__":
+    main()

--- a/rest/examples/rest_fabric_conferences_and_routing.py
+++ b/rest/examples/rest_fabric_conferences_and_routing.py
@@ -69,17 +69,7 @@ def main():
         detail = client.fabric.resources.get(first["id"])
         print(f"  Resource detail: {detail.get('display_name', 'N/A')} ({detail.get('type', 'N/A')})")
 
-    # 8. Assign a phone route to a resource (demo)
-    print("\nAssigning phone route (demo)...")
-    try:
-        client.fabric.resources.assign_phone_route(
-            relay_id, phone_number="+15551234567",
-        )
-        print("  Phone route assigned")
-    except SignalWireRestError as e:
-        print(f"  Route assignment failed (expected in demo): {e.status_code}")
-
-    # 9. Assign a domain application (demo)
+    # 8. Assign a domain application (demo)
     print("\nAssigning domain application (demo)...")
     try:
         client.fabric.resources.assign_domain_application(
@@ -89,7 +79,11 @@ def main():
     except SignalWireRestError as e:
         print(f"  Domain assignment failed (expected in demo): {e.status_code}")
 
-    # 10. Generate tokens
+    # NOTE: To bind a phone number to a webhook/agent/flow, set call_handler
+    # on the phone number directly — see rest_bind_phone_to_swml_webhook.py.
+    # assign_phone_route does NOT work for swml_webhook / cxml_webhook / ai_agent.
+
+    # 9. Generate tokens
     print("\nGenerating tokens...")
     try:
         guest = client.fabric.tokens.create_guest_token(resource_id=relay_id)
@@ -109,7 +103,7 @@ def main():
     except SignalWireRestError as e:
         print(f"  Embed token failed (expected in demo): {e.status_code}")
 
-    # 11. Clean up
+    # 10. Clean up
     print("\nCleaning up...")
     client.fabric.relay_applications.delete(relay_id)
     print(f"  Deleted relay application {relay_id}")

--- a/signalwire/signalwire/rest/__init__.py
+++ b/signalwire/signalwire/rest/__init__.py
@@ -13,5 +13,6 @@ SignalWire REST API client module.
 
 from .client import RestClient
 from ._base import SignalWireRestError
+from .call_handler import PhoneCallHandler
 
-__all__ = ["RestClient", "SignalWireRestError"]
+__all__ = ["RestClient", "SignalWireRestError", "PhoneCallHandler"]

--- a/signalwire/signalwire/rest/call_handler.py
+++ b/signalwire/signalwire/rest/call_handler.py
@@ -1,0 +1,62 @@
+"""
+Copyright (c) 2025 SignalWire
+
+This file is part of the SignalWire SDK.
+
+Licensed under the MIT License.
+See LICENSE file in the project root for full license information.
+"""
+
+"""
+PhoneCallHandler — enum of ``call_handler`` values accepted by phone_numbers.update.
+
+Named ``PhoneCallHandler`` (not ``CallHandler``) to avoid colliding with the
+RELAY client's inbound-call-handler callback type.
+
+Setting a phone number's ``call_handler`` + the handler-specific companion
+field routes inbound calls and auto-materializes the matching Fabric
+resource on the server. See the high-level helpers on
+:class:`signalwire.rest.namespaces.phone_numbers.PhoneNumbersResource`.
+"""
+
+from enum import Enum
+
+
+class PhoneCallHandler(str, Enum):
+    """``call_handler`` values for ``phone_numbers.update``.
+
+    Each value is a ``str`` subclass, so passing the enum member directly into
+    ``phone_numbers.update(..., call_handler=PhoneCallHandler.RELAY_SCRIPT)``
+    serializes to the wire value without ``.value`` indirection.
+
+    ================= ============================= =======================
+    Enum member       Companion field (required)    Auto-creates resource
+    ================= ============================= =======================
+    RELAY_SCRIPT      call_relay_script_url         swml_webhook
+    LAML_WEBHOOKS     call_request_url              cxml_webhook
+    LAML_APPLICATION  call_laml_application_id      cxml_application
+    AI_AGENT          call_ai_agent_id              ai_agent
+    CALL_FLOW         call_flow_id                  call_flow
+    RELAY_APPLICATION call_relay_application        relay_application
+    RELAY_TOPIC       call_relay_topic              (routes via RELAY)
+    RELAY_CONTEXT     call_relay_context            (legacy, prefer topic)
+    RELAY_CONNECTOR   (connector config)            (internal)
+    VIDEO_ROOM        call_video_room_id            (routes to Video API)
+    DIALOGFLOW        call_dialogflow_agent_id      (none)
+    ================= ============================= =======================
+
+    Note: ``LAML_WEBHOOKS`` (wire value ``laml_webhooks``) produces a **cXML**
+    handler, not a generic webhook. For SWML, use ``RELAY_SCRIPT``.
+    """
+
+    RELAY_SCRIPT = "relay_script"
+    LAML_WEBHOOKS = "laml_webhooks"
+    LAML_APPLICATION = "laml_application"
+    AI_AGENT = "ai_agent"
+    CALL_FLOW = "call_flow"
+    RELAY_APPLICATION = "relay_application"
+    RELAY_TOPIC = "relay_topic"
+    RELAY_CONTEXT = "relay_context"
+    RELAY_CONNECTOR = "relay_connector"
+    VIDEO_ROOM = "video_room"
+    DIALOGFLOW = "dialogflow"

--- a/signalwire/signalwire/rest/namespaces/fabric.py
+++ b/signalwire/signalwire/rest/namespaces/fabric.py
@@ -11,6 +11,8 @@ See LICENSE file in the project root for full license information.
 Fabric API namespace — resource composition, addresses, and tokens.
 """
 
+import warnings
+
 from .._base import BaseResource, CrudWithAddresses
 
 
@@ -22,6 +24,38 @@ class FabricResource(CrudWithAddresses):
 class FabricResourcePUT(CrudWithAddresses):
     """Fabric resource that uses PUT for updates."""
     _update_method = "PUT"
+
+
+class AutoMaterializedWebhook(FabricResource):
+    """Fabric webhook resource that's normally auto-created by phone_numbers.set_*.
+
+    Exposed for backwards compatibility. The binding model for these resources
+    is on the phone number (see ``phone_numbers.set_swml_webhook`` /
+    ``set_cxml_webhook``) — setting ``call_handler`` on a phone number
+    auto-materializes the webhook. Calling ``create`` here produces an orphan
+    resource that isn't bound to any phone number.
+    """
+
+    _auto_helper_name = "phone_numbers.set_*_webhook"
+
+    def create(self, **kwargs):
+        warnings.warn(
+            f"Creating a webhook Fabric resource directly produces an orphan not "
+            f"bound to any phone number. Use {self._auto_helper_name} instead; "
+            f"it updates the phone number and the server auto-materializes the "
+            f"resource. See porting-sdk's phone-binding.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return super().create(**kwargs)
+
+
+class SwmlWebhooksResource(AutoMaterializedWebhook):
+    _auto_helper_name = "phone_numbers.set_swml_webhook(sid, url=...)"
+
+
+class CxmlWebhooksResource(AutoMaterializedWebhook):
+    _auto_helper_name = "phone_numbers.set_cxml_webhook(sid, url=...)"
 
 
 class CallFlowsResource(FabricResourcePUT):
@@ -110,6 +144,25 @@ class GenericResources(BaseResource):
         )
 
     def assign_phone_route(self, resource_id, **kwargs):
+        """Deprecated for the common binding cases. Use ``phone_numbers.set_*`` helpers.
+
+        This endpoint (``POST /api/fabric/resources/{id}/phone_routes``) accepts
+        only a narrow set of legacy resource types as the attach target. It
+        **does not work** for ``swml_webhook`` / ``cxml_webhook`` / ``ai_agent``
+        bindings — those are configured on the phone number and the Fabric
+        resource is auto-materialized (see ``phone_numbers.set_swml_webhook``
+        etc.). The authoritative list of accepting resource types lives in the
+        OpenAPI spec; routing here for those types returns 404 or 422.
+        """
+        warnings.warn(
+            "assign_phone_route does not bind phone numbers to "
+            "swml_webhook/cxml_webhook/ai_agent resources — those are "
+            "configured via phone_numbers.set_swml_webhook / set_cxml_webhook "
+            "/ set_ai_agent. This method applies only to a narrow set of "
+            "legacy resource types. See porting-sdk's phone-binding.md.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._http.post(self._path(resource_id, "phone_routes"), body=kwargs)
 
     def assign_domain_application(self, resource_id, **kwargs):
@@ -166,10 +219,13 @@ class FabricNamespace:
         self.cxml_applications = CxmlApplicationsResource(http, f"{base}/cxml_applications")
 
         # PATCH-update resources
-        self.swml_webhooks = FabricResource(http, f"{base}/swml_webhooks")
+        # swml_webhooks and cxml_webhooks are normally auto-materialized by
+        # phone_numbers.set_swml_webhook / set_cxml_webhook. Direct create
+        # still works for backcompat but emits a DeprecationWarning.
+        self.swml_webhooks = SwmlWebhooksResource(http, f"{base}/swml_webhooks")
         self.ai_agents = FabricResource(http, f"{base}/ai_agents")
         self.sip_gateways = FabricResource(http, f"{base}/sip_gateways")
-        self.cxml_webhooks = FabricResource(http, f"{base}/cxml_webhooks")
+        self.cxml_webhooks = CxmlWebhooksResource(http, f"{base}/cxml_webhooks")
 
         # Special resources
         self.resources = GenericResources(http, base)

--- a/signalwire/signalwire/rest/namespaces/phone_numbers.py
+++ b/signalwire/signalwire/rest/namespaces/phone_numbers.py
@@ -8,14 +8,26 @@ See LICENSE file in the project root for full license information.
 """
 
 """
-Phone Numbers namespace — list, search, purchase, get, update, release.
+Phone Numbers namespace — list, search, purchase, get, update, release, bind.
 """
 
+from typing import Optional
+
 from .._base import CrudResource
+from ..call_handler import PhoneCallHandler
 
 
 class PhoneNumbersResource(CrudResource):
-    """Phone number management."""
+    """Phone number management.
+
+    Supports the standard CRUD surface plus typed helpers for binding an
+    inbound call to a handler (SWML webhook, cXML webhook, AI agent, call
+    flow, RELAY application/topic). The binding model is: set
+    ``call_handler`` + the handler-specific companion field on the phone
+    number; the server auto-materializes the matching Fabric resource.
+    See :mod:`signalwire.rest.call_handler` for the enum, and the
+    porting-sdk's ``phone-binding.md`` for the full model.
+    """
 
     _update_method = "PUT"
 
@@ -24,3 +36,114 @@ class PhoneNumbersResource(CrudResource):
 
     def search(self, **params):
         return self._http.get(self._path("search"), params=params or None)
+
+    # -- Typed binding helpers -------------------------------------------
+    #
+    # Each helper is a one-line wrapper over ``update`` with the right
+    # ``call_handler`` value and companion field already set. Pass through
+    # extra kwargs for cases the helper doesn't name explicitly (e.g.
+    # ``call_fallback_url`` on cXML webhooks).
+
+    def set_swml_webhook(self, resource_id: str, url: str, **extra) -> dict:
+        """Route inbound calls to an SWML webhook URL.
+
+        Your backend returns an SWML document per call. The server
+        auto-creates a ``swml_webhook`` Fabric resource keyed off this URL.
+        """
+        return self.update(
+            resource_id,
+            call_handler=PhoneCallHandler.RELAY_SCRIPT.value,
+            call_relay_script_url=url,
+            **extra,
+        )
+
+    def set_cxml_webhook(
+        self,
+        resource_id: str,
+        url: str,
+        fallback_url: Optional[str] = None,
+        status_callback_url: Optional[str] = None,
+        **extra,
+    ) -> dict:
+        """Route inbound calls to a cXML (Twilio-compat / LAML) webhook.
+
+        Despite the wire value ``laml_webhooks`` being plural, this creates
+        a single ``cxml_webhook`` Fabric resource. ``fallback_url`` is used
+        when the primary URL fails; ``status_callback_url`` receives call
+        status updates.
+        """
+        body = {
+            "call_handler": PhoneCallHandler.LAML_WEBHOOKS.value,
+            "call_request_url": url,
+        }
+        if fallback_url is not None:
+            body["call_fallback_url"] = fallback_url
+        if status_callback_url is not None:
+            body["call_status_callback_url"] = status_callback_url
+        body.update(extra)
+        return self.update(resource_id, **body)
+
+    def set_cxml_application(self, resource_id: str, application_id: str, **extra) -> dict:
+        """Route inbound calls to an existing cXML application by ID."""
+        return self.update(
+            resource_id,
+            call_handler=PhoneCallHandler.LAML_APPLICATION.value,
+            call_laml_application_id=application_id,
+            **extra,
+        )
+
+    def set_ai_agent(self, resource_id: str, agent_id: str, **extra) -> dict:
+        """Route inbound calls to an AI Agent Fabric resource by ID."""
+        return self.update(
+            resource_id,
+            call_handler=PhoneCallHandler.AI_AGENT.value,
+            call_ai_agent_id=agent_id,
+            **extra,
+        )
+
+    def set_call_flow(
+        self,
+        resource_id: str,
+        flow_id: str,
+        version: Optional[str] = None,
+        **extra,
+    ) -> dict:
+        """Route inbound calls to a Call Flow by ID.
+
+        ``version`` accepts ``"working_copy"`` or ``"current_deployed"``
+        (server default when omitted).
+        """
+        body = {
+            "call_handler": PhoneCallHandler.CALL_FLOW.value,
+            "call_flow_id": flow_id,
+        }
+        if version is not None:
+            body["call_flow_version"] = version
+        body.update(extra)
+        return self.update(resource_id, **body)
+
+    def set_relay_application(self, resource_id: str, name: str, **extra) -> dict:
+        """Route inbound calls to a named RELAY application."""
+        return self.update(
+            resource_id,
+            call_handler=PhoneCallHandler.RELAY_APPLICATION.value,
+            call_relay_application=name,
+            **extra,
+        )
+
+    def set_relay_topic(
+        self,
+        resource_id: str,
+        topic: str,
+        status_callback_url: Optional[str] = None,
+        **extra,
+    ) -> dict:
+        """Route inbound calls to a RELAY topic (client subscription)."""
+        body = {
+            "call_handler": PhoneCallHandler.RELAY_TOPIC.value,
+            "call_relay_topic": topic,
+        }
+        if status_callback_url is not None:
+            body["call_relay_topic_status_callback_url"] = status_callback_url
+        body.update(extra)
+        return self.update(resource_id, **body)

--- a/tests/unit/rest/test_fabric.py
+++ b/tests/unit/rest/test_fabric.py
@@ -1,5 +1,9 @@
 """Tests for fabric namespace — resource types, addresses, tokens."""
 
+import warnings
+
+import pytest
+
 from .conftest import MockResponse
 
 
@@ -82,13 +86,54 @@ class TestFabricSubscribers:
 
 
 class TestGenericResources:
-    def test_assign_phone_route(self, client, mock_session):
+    def test_assign_phone_route_still_posts_but_warns(self, client, mock_session):
+        """assign_phone_route still posts for backcompat, but emits DeprecationWarning.
+
+        The endpoint exists for a narrow set of legacy resource types. For
+        swml_webhook/cxml_webhook/ai_agent bindings, users should reach for
+        phone_numbers.set_* helpers instead. See the phone-binding post-mortem.
+        """
         mock_session.request.return_value = MockResponse(200, {})
-        client.fabric.resources.assign_phone_route("res-1", phone_route_id="pr-1")
+        with pytest.warns(DeprecationWarning, match="phone_numbers.set_"):
+            client.fabric.resources.assign_phone_route("res-1", phone_route_id="pr-1")
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/fabric/resources/res-1/phone_routes",
             json={"phone_route_id": "pr-1"}, params=None,
         )
+
+
+class TestAutoMaterializedWebhooks:
+    """swml_webhooks and cxml_webhooks are normally auto-created by phone_numbers.set_*.
+
+    Direct create() still works (backcompat) but must emit DeprecationWarning
+    pointing at the right helper. Creating an orphan resource without binding
+    it to a phone number does nothing useful.
+    """
+
+    def test_swml_webhooks_create_warns(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(201, {"id": "sw-1"})
+        with pytest.warns(DeprecationWarning, match="phone_numbers.set_swml_webhook"):
+            client.fabric.swml_webhooks.create(
+                name="Orphan", primary_request_url="https://example.com/swml",
+            )
+
+    def test_cxml_webhooks_create_warns(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(201, {"id": "cw-1"})
+        with pytest.warns(DeprecationWarning, match="phone_numbers.set_cxml_webhook"):
+            client.fabric.cxml_webhooks.create(
+                name="Orphan", primary_request_url="https://example.com/voice.xml",
+            )
+
+    def test_webhooks_read_update_delete_still_work_without_warning(self, client, mock_session):
+        """Only create is deprecated — list/get/update/delete are the normal surface."""
+        mock_session.request.return_value = MockResponse(200, {"data": []})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            client.fabric.swml_webhooks.list()
+            client.fabric.swml_webhooks.get("sw-1")
+            client.fabric.swml_webhooks.update("sw-1", name="Updated")
+            client.fabric.swml_webhooks.delete("sw-1")
+            client.fabric.cxml_webhooks.list()
 
 
 class TestFabricTokens:

--- a/tests/unit/rest/test_phone_numbers.py
+++ b/tests/unit/rest/test_phone_numbers.py
@@ -1,0 +1,281 @@
+"""Tests for phone_numbers namespace — CRUD, search, and typed binding helpers.
+
+The typed helpers wrap ``phone_numbers.update`` with the correct
+``call_handler`` + companion field combination for each handler type. A
+regression test asserts the full happy-path binding flow does NOT require
+pre-creating a Fabric webhook resource and does NOT call
+``assign_phone_route`` — the two traps found in the phone-binding
+post-mortem.
+"""
+
+import warnings
+
+import pytest
+
+from signalwire.rest import PhoneCallHandler
+
+from .conftest import MockResponse
+
+
+BASE = "https://test.signalwire.com/api/relay/rest/phone_numbers"
+
+
+class TestPhoneNumbersCrud:
+    def test_list(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {"data": []})
+        client.phone_numbers.list()
+        mock_session.request.assert_called_with(
+            "GET", BASE, json=None, params=None,
+        )
+
+    def test_search(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {"data": []})
+        client.phone_numbers.search(area_code="512")
+        mock_session.request.assert_called_with(
+            "GET", f"{BASE}/search", json=None, params={"area_code": "512"},
+        )
+
+    def test_update_uses_put(self, client, mock_session):
+        """phone_numbers uses PUT for update (not PATCH)."""
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.update("pn-1", name="Main")
+        mock_session.request.assert_called_with(
+            "PUT", f"{BASE}/pn-1", json={"name": "Main"}, params=None,
+        )
+
+
+class TestPhoneCallHandlerEnum:
+    def test_all_wire_values_present(self):
+        """Every call_handler value accepted by the API is in the enum."""
+        expected = {
+            "relay_script", "laml_webhooks", "laml_application",
+            "ai_agent", "call_flow", "relay_application",
+            "relay_topic", "relay_context", "relay_connector",
+            "video_room", "dialogflow",
+        }
+        assert {h.value for h in PhoneCallHandler} == expected
+
+    def test_enum_members_are_strings(self):
+        """Members are str subclasses so they serialize without .value."""
+        assert PhoneCallHandler.RELAY_SCRIPT == "relay_script"
+        assert f"{PhoneCallHandler.AI_AGENT}" == "PhoneCallHandler.AI_AGENT"
+
+    def test_no_collision_with_relay_callhandler(self):
+        """PhoneCallHandler is explicitly named to dodge the RELAY CallHandler type."""
+        # Just assert the import path is the rest module; RELAY has its own
+        # callback types elsewhere and won't reuse this symbol.
+        from signalwire.rest.call_handler import PhoneCallHandler as ReimportedHandler
+        assert ReimportedHandler is PhoneCallHandler
+
+
+class TestSetSwmlWebhook:
+    def test_happy_path(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_swml_webhook(
+            "pn-1", url="https://example.com/swml",
+        )
+        mock_session.request.assert_called_with(
+            "PUT", f"{BASE}/pn-1",
+            json={
+                "call_handler": "relay_script",
+                "call_relay_script_url": "https://example.com/swml",
+            },
+            params=None,
+        )
+
+    def test_extra_kwargs_pass_through(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_swml_webhook(
+            "pn-1", url="https://example.com/swml", name="Support Line",
+        )
+        body = mock_session.request.call_args.kwargs["json"]
+        assert body["name"] == "Support Line"
+        assert body["call_handler"] == "relay_script"
+        assert body["call_relay_script_url"] == "https://example.com/swml"
+
+
+class TestSetCxmlWebhook:
+    def test_minimal(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_cxml_webhook(
+            "pn-1", url="https://example.com/voice.xml",
+        )
+        mock_session.request.assert_called_with(
+            "PUT", f"{BASE}/pn-1",
+            json={
+                "call_handler": "laml_webhooks",
+                "call_request_url": "https://example.com/voice.xml",
+            },
+            params=None,
+        )
+
+    def test_with_fallback_and_status(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_cxml_webhook(
+            "pn-1",
+            url="https://example.com/voice.xml",
+            fallback_url="https://example.com/fallback.xml",
+            status_callback_url="https://example.com/status",
+        )
+        body = mock_session.request.call_args.kwargs["json"]
+        assert body == {
+            "call_handler": "laml_webhooks",
+            "call_request_url": "https://example.com/voice.xml",
+            "call_fallback_url": "https://example.com/fallback.xml",
+            "call_status_callback_url": "https://example.com/status",
+        }
+
+
+class TestSetCxmlApplication:
+    def test_happy_path(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_cxml_application("pn-1", application_id="app-1")
+        body = mock_session.request.call_args.kwargs["json"]
+        assert body == {
+            "call_handler": "laml_application",
+            "call_laml_application_id": "app-1",
+        }
+
+
+class TestSetAiAgent:
+    def test_happy_path(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_ai_agent("pn-1", agent_id="agent-1")
+        body = mock_session.request.call_args.kwargs["json"]
+        assert body == {
+            "call_handler": "ai_agent",
+            "call_ai_agent_id": "agent-1",
+        }
+
+
+class TestSetCallFlow:
+    def test_minimal(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_call_flow("pn-1", flow_id="cf-1")
+        body = mock_session.request.call_args.kwargs["json"]
+        assert body == {
+            "call_handler": "call_flow",
+            "call_flow_id": "cf-1",
+        }
+
+    def test_with_version(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_call_flow(
+            "pn-1", flow_id="cf-1", version="current_deployed",
+        )
+        body = mock_session.request.call_args.kwargs["json"]
+        assert body == {
+            "call_handler": "call_flow",
+            "call_flow_id": "cf-1",
+            "call_flow_version": "current_deployed",
+        }
+
+
+class TestSetRelayApplication:
+    def test_happy_path(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_relay_application("pn-1", name="my-app")
+        body = mock_session.request.call_args.kwargs["json"]
+        assert body == {
+            "call_handler": "relay_application",
+            "call_relay_application": "my-app",
+        }
+
+
+class TestSetRelayTopic:
+    def test_minimal(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_relay_topic("pn-1", topic="office")
+        body = mock_session.request.call_args.kwargs["json"]
+        assert body == {
+            "call_handler": "relay_topic",
+            "call_relay_topic": "office",
+        }
+
+    def test_with_status_callback(self, client, mock_session):
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_relay_topic(
+            "pn-1", topic="office",
+            status_callback_url="https://example.com/status",
+        )
+        body = mock_session.request.call_args.kwargs["json"]
+        assert body == {
+            "call_handler": "relay_topic",
+            "call_relay_topic": "office",
+            "call_relay_topic_status_callback_url": "https://example.com/status",
+        }
+
+
+class TestBindingRegressionPostMortem:
+    """Guards against the phone-binding post-mortem anti-patterns.
+
+    The post-mortem identified two traps:
+      1. ``fabric.swml_webhooks.create(...)`` looks right but produces orphans
+      2. ``fabric.resources.assign_phone_route(...)`` rejects swml_webhook bindings
+
+    The correct happy-path binding is entirely through ``phone_numbers.update``
+    (directly or via the typed helpers). This test pins that contract.
+    """
+
+    def test_swml_binding_uses_only_phone_numbers_update(self, client, mock_session):
+        """The full happy path is a single PUT to /api/relay/rest/phone_numbers/{sid}."""
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.set_swml_webhook(
+            "pn-1", url="https://example.com/swml",
+        )
+
+        calls = mock_session.request.call_args_list
+        # Exactly one HTTP call
+        assert len(calls) == 1
+        method, url = calls[0].args[0], calls[0].args[1]
+        # PUT on phone_numbers
+        assert method == "PUT"
+        assert url == f"{BASE}/pn-1"
+        # No fabric.swml_webhooks.create (that URL would be
+        # /api/fabric/resources/swml_webhooks)
+        assert "/api/fabric/resources/swml_webhooks" not in url
+        # No assign_phone_route (that URL would be
+        # /api/fabric/resources/.../phone_routes)
+        assert "/phone_routes" not in url
+
+    def test_wire_level_form_works_without_enum(self, client, mock_session):
+        """Passing the raw string value also works — for users who don't import the enum."""
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.update(
+            "pn-1",
+            call_handler="relay_script",
+            call_relay_script_url="https://example.com/swml",
+        )
+        body = mock_session.request.call_args.kwargs["json"]
+        assert body["call_handler"] == "relay_script"
+        assert body["call_relay_script_url"] == "https://example.com/swml"
+
+    def test_enum_value_is_accepted_by_update(self, client, mock_session):
+        """Passing PhoneCallHandler.RELAY_SCRIPT.value serializes identically."""
+        mock_session.request.return_value = MockResponse(200, {})
+        client.phone_numbers.update(
+            "pn-1",
+            call_handler=PhoneCallHandler.RELAY_SCRIPT.value,
+            call_relay_script_url="https://example.com/swml",
+        )
+        body = mock_session.request.call_args.kwargs["json"]
+        assert body["call_handler"] == "relay_script"
+
+
+class TestHelperCoverage:
+    """Every PhoneCallHandler member that maps to a helper has one."""
+
+    def test_all_helpers_present(self, client):
+        expected = {
+            "set_swml_webhook",
+            "set_cxml_webhook",
+            "set_cxml_application",
+            "set_ai_agent",
+            "set_call_flow",
+            "set_relay_application",
+            "set_relay_topic",
+        }
+        for name in expected:
+            assert hasattr(client.phone_numbers, name), (
+                f"phone_numbers missing binding helper: {name}"
+            )


### PR DESCRIPTION
## Summary

Ships the good path for binding a phone number to a handler (SWML webhook, cXML webhook, AI agent, call flow, RELAY app/topic). Driven by a user post-mortem documenting hours lost on the SDK's existing trap — `client.fabric.swml_webhooks.create(...)` + `client.fabric.resources.assign_phone_route(...)` looked canonical but always failed against the live API. The working path was hidden in an external REST reference.

- New `signalwire.rest.PhoneCallHandler` enum — all 11 `call_handler` wire values from the OpenAPI spec. Name chosen to avoid colliding with the RELAY client's `CallHandler` callback type already in the SDK.
- Seven typed helpers on `phone_numbers`: `set_swml_webhook`, `set_cxml_webhook`, `set_cxml_application`, `set_ai_agent`, `set_call_flow`, `set_relay_application`, `set_relay_topic`. Each wraps `phone_numbers.update` with the right `call_handler` + companion field.
- `DeprecationWarning` on `fabric.resources.assign_phone_route` with a docstring naming its narrow applicability (does NOT work for `swml_webhook`/`cxml_webhook`/`ai_agent`).
- `DeprecationWarning` on `fabric.swml_webhooks.create` and `fabric.cxml_webhooks.create` — those resources are auto-materialized by the phone_numbers helpers. Direct create still works for backcompat; list/get/update/delete untouched.
- New `rest/examples/rest_bind_phone_to_swml_webhook.py` — the one-page recipe.
- Fixed `rest/examples/rest_fabric_conferences_and_routing.py:72-80` which demonstrated the anti-pattern.

Matches the porting-sdk Phase 8 § Phone-number binding spec just landed in `41e3c00` on main.

## Test plan

- [x] \`pytest --no-cov\` — 4967 passed, 7 pre-existing skips, 0 failures
- [x] 21 new tests in \`test_phone_numbers.py\` covering every helper, enum contract, and two regression guards pinning the post-mortem fix: (1) the SWML binding path makes exactly one PUT to \`/api/relay/rest/phone_numbers/{sid}\` — no fabric webhook create, no \`assign_phone_route\`; (2) the wire-level form works without importing the enum
- [x] Updated fabric tests assert \`DeprecationWarning\` on \`assign_phone_route\`, \`swml_webhooks.create\`, and \`cxml_webhooks.create\`, and confirm list/get/update/delete on those webhooks remain warning-free

## Non-breaking

Every previously-working code path still works. Only new signals:
- Three methods emit \`DeprecationWarning\` with a concrete pointer to the helper to use instead.
- The misleading example is replaced, not removed.

## Next

Python is the reference. The 6 port repos (TypeScript, Go, Java, Ruby, Perl, C++) will pick this up next — a fanned-out set of agents will apply the same enum + helpers + deprecation + example per the updated porting-sdk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)