### PR TITLE
Layer C: doc↔code alignment + fix phantom SDK surfaces

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -1,0 +1,66 @@
+name: Doc Audit
+
+# Fails if a method referenced in docs/ or examples/ does not resolve in the
+# public SDK surface (see porting-sdk/python_surface.json) and is not listed
+# in DOC_AUDIT_IGNORE.md with a rationale. Also runs `python -m py_compile`
+# over every example script to catch syntax errors introduced by a drift fix.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Nightly at 07:13 UTC — catches drift introduced by changes in porting-sdk
+    # or in the Python SDK between PR cycles.
+    - cron: '13 7 * * *'
+  workflow_dispatch:
+
+jobs:
+  doc-audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out signalwire-python
+        uses: actions/checkout@v6
+        with:
+          path: signalwire-python
+
+      - name: Check out porting-sdk (provides audit scripts + surface JSON)
+        uses: actions/checkout@v6
+        with:
+          repository: signalwire/porting-sdk
+          path: porting-sdk
+          # porting-sdk is the source of truth for the Python surface — pin to
+          # main so the audit reflects the latest reference.
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Compile every example (catches syntax-level phantom APIs)
+        # py_compile only verifies syntax, but any example that calls a phantom
+        # import or syntax error will fail here before the audit even runs.
+        run: |
+          cd signalwire-python
+          python -m py_compile examples/*.py rest/examples/*.py relay/examples/*.py
+
+      - name: Run audit_docs.py against the Python surface
+        run: |
+          python3 porting-sdk/scripts/audit_docs.py \
+            --root signalwire-python \
+            --surface porting-sdk/python_surface.json \
+            --ignore signalwire-python/DOC_AUDIT_IGNORE.md
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "### Doc Audit" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Verifies every \`.method(\` reference in \`docs/\`, \`examples/\`, \`rest/**\`, \`relay/**\` resolves in \`python_surface.json\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Ignores listed in \`DOC_AUDIT_IGNORE.md\` (each entry has a rationale)" >> $GITHUB_STEP_SUMMARY
+          echo "- Also runs \`python -m py_compile\` on every example script" >> $GITHUB_STEP_SUMMARY

--- a/DOC_AUDIT_IGNORE.md
+++ b/DOC_AUDIT_IGNORE.md
@@ -1,0 +1,189 @@
+# DOC_AUDIT_IGNORE.md
+
+Identifiers that `scripts/audit_docs.py` (from the `porting-sdk` repo) would
+otherwise flag as unresolved. Every entry here has a rationale: external
+library, stdlib call, example-local user method, or explicit teaching-by-comparison
+reference to a third-party framework.
+
+Format: one identifier per line, optionally followed by `: <rationale>`.
+Blank lines and `# …` comments are ignored.
+
+---
+
+## Python stdlib: os / os.path / pathlib / tempfile / shutil / glob
+
+abspath: os.path.abspath — stdlib path helper
+dirname: os.path.dirname — stdlib path helper
+is_file: pathlib.Path.is_file — stdlib
+read_text: pathlib.Path.read_text — stdlib
+write_text: pathlib.Path.write_text — stdlib
+resolve: pathlib.Path.resolve — stdlib
+mkdtemp: tempfile.mkdtemp — stdlib
+rmtree: shutil.rmtree — stdlib
+glob: glob.glob / pathlib.Path.glob — stdlib
+
+## Python stdlib: datetime
+
+fromisoformat: datetime.fromisoformat — stdlib
+isoformat: datetime.isoformat — stdlib
+total_seconds: timedelta.total_seconds — stdlib
+
+## Python stdlib: hashlib / random / time / secrets
+
+hexdigest: hashlib digest.hexdigest — stdlib
+md5: hashlib.md5 — stdlib
+randint: random.randint — stdlib
+random: random.random — stdlib
+choice: random.choice — stdlib
+time: time.time / prometheus_client.Histogram().time() — stdlib / prometheus helper
+sleep: time.sleep — stdlib (one call); the remaining hit is `self.sleep(1000)` in auto_vivified_example.py demonstrating the SWML `sleep` verb auto-vivified on SWMLService (real, but dynamic so absent from the public surface).
+
+## Python stdlib: logging
+
+getLogger: logging.getLogger — stdlib
+basicConfig: logging.basicConfig — stdlib
+setLevel: logging.Logger.setLevel — stdlib
+debug: logging.Logger.debug — stdlib logger method (also used on self.log in service classes)
+info: logging.Logger.info — stdlib logger method (most common logger call)
+warning: logging.Logger.warning — stdlib logger method
+
+## Python stdlib: threading / sys / builtins
+
+Thread: threading.Thread — stdlib
+exit: sys.exit — stdlib
+insert: list.insert / sys.path.insert — stdlib builtin / list method
+input: builtin input() / pipecat `transport.input()` — stdlib or third-party
+add: set.add — stdlib builtin method
+title: str.title — stdlib builtin method
+setdefault: dict.setdefault / os.environ.setdefault — stdlib builtin method
+init: generic initializer name — stdlib / third-party (pinecone.init shown in search comparison)
+
+## argparse (stdlib)
+
+ArgumentParser: argparse.ArgumentParser — stdlib
+add_argument: argparse.ArgumentParser.add_argument — stdlib
+parse_known_args: argparse.ArgumentParser.parse_known_args — stdlib
+
+## structlog (third-party, used by examples/survey_agent_example.py)
+
+configure: structlog.configure — structlog top-level
+TimeStamper: structlog.processors.TimeStamper — structlog processor class
+StackInfoRenderer: structlog.processors.StackInfoRenderer — structlog processor
+JSONRenderer: structlog.processors.JSONRenderer — structlog processor
+UnicodeDecoder: structlog.processors.UnicodeDecoder — structlog processor
+PositionalArgumentsFormatter: structlog.stdlib.PositionalArgumentsFormatter — structlog
+LoggerFactory: structlog.stdlib.LoggerFactory — structlog
+
+## FastAPI / Starlette (third-party)
+
+include_router: FastAPI.include_router — framework method
+add_middleware: FastAPI.add_middleware — framework method
+
+## prometheus_client (third-party)
+
+inc: prometheus_client.Counter.inc — monitoring example in search_deployment.md
+
+## Search-subsystem references (skip-listed in porting-sdk checklist)
+
+# These come from docs/search_*.md and examples/search_*.py, plus
+# examples/sigmond_*.py and examples/local_search_agent.py. The porting-sdk
+# checklist marks search docs as SKIP_DOC_STEMS; the search skill is
+# Python-only so other ports don't need to implement these symbols.
+
+from_documents: langchain/pinecone Pinecone.from_documents — search comparison in docs/search_overview.md
+split_documents: langchain RecursiveCharacterTextSplitter.split_documents — search comparison
+similarity_search: langchain/pinecone Pinecone.similarity_search — search comparison
+argsort: numpy.argsort — DIY search example in docs/search_overview.md
+md: filename-extension regex false positive (matches `file.md (…`) in docs/search_overview.md processing listing
+do_search: user-defined method inside a caching example in docs/search_deployment.md
+_build_response: user-defined formatter callback in docs/search_troubleshooting.md
+_get_cache_key: user-defined method inside a caching example in docs/search_deployment.md
+_check_search_availability: user-defined method inside examples/local_search_agent.py
+_create_sample_index: user-defined method inside examples/local_search_agent.py
+_setup_search: user-defined method inside examples/local_search_agent.py
+_setup_remote_search: user-defined method inside examples/sigmond_remote_search.py
+_setup_search_skills: user-defined method inside examples/sigmond_native_search.py
+_add_sdk_knowledge: user-defined method inside examples/sigmond_simple.py
+_configure_personality: user-defined method inside sigmond_* examples
+_configure_parameters: user-defined method inside sigmond_* examples
+_configure_languages: user-defined method inside sigmond_* examples
+_configure_pronunciation: user-defined method inside sigmond_* examples
+
+## Platform-comparison docs (LiveKit, pipecat — also skip-listed)
+
+LLM: openai.LLM — third-party class shown in docs/livekit_comparison.md
+STT: deepgram.STT — third-party class shown in docs/livekit_comparison.md
+TTS: cartesia.TTS — third-party class shown in docs/livekit_comparison.md
+
+## Voice-name false positives (regex matches `inworld.Mark (…`)
+
+Mark: voice identifier "inworld.Mark" in examples/simple_static_agent.py comment string
+Blake: voice identifier "inworld.Blake" in examples/comprehensive_dynamic_agent.py docstring
+
+## Example-local private helpers (defined within the same example file)
+
+# These all match `def _foo` in the same file that calls `self._foo(...)`.
+# They are intentionally private helpers — not part of the SDK surface.
+
+_add_joke_function: defined in examples/joke_agent.py:54
+_register_routes: defined in examples/multi_endpoint_agent.py:64
+_configure_voice_and_language: defined in examples/comprehensive_dynamic_agent.py:132
+_configure_tier_parameters: defined in examples/comprehensive_dynamic_agent.py:165
+_configure_industry_prompts: defined in examples/comprehensive_dynamic_agent.py:206
+_configure_global_data: defined in examples/comprehensive_dynamic_agent.py:266
+_configure_debug_features: defined in examples/comprehensive_dynamic_agent.py:290
+_configure_ab_testing: defined in examples/comprehensive_dynamic_agent.py:312
+_get_enabled_features: defined in examples/comprehensive_dynamic_agent.py:331
+
+## Example-local public helpers (defined within the same example file)
+
+# These are public methods a user wrote on their own AgentBase/SWMLService
+# subclass inside an example. Not part of the SDK surface.
+
+setPersonality: defined in examples/simple_agent.py:277 (user-written wrapper over prompt_add_section)
+setGoal: defined in examples/simple_agent.py:293 (user-written wrapper over prompt_add_section)
+setInstructions: defined in examples/simple_agent.py:309 (user-written wrapper over prompt_add_section)
+register_data_map_tool: defined in examples/data_map_demo.py:156 (wraps register_swaig_function)
+build_default_document: defined in examples/dynamic_swml_service.py (user override of base build hook)
+build_document: defined in docs/swml_service_guide.md example (user override of base build hook)
+build_voicemail_document: defined in examples/basic_swml_service.py and auto_vivified_example.py (user helper)
+build_ivr_document: defined in examples/basic_swml_service.py and auto_vivified_example.py (user helper)
+build_transfer_document: defined in examples/basic_swml_service.py and auto_vivified_example.py (user helper)
+build_recording_document: defined in examples/basic_swml_service.py (user helper)
+register_customer_route: defined in examples/swml_service_routing_example.py:65 (user helper)
+register_product_route: defined in examples/swml_service_routing_example.py (user helper)
+
+## Docs-only user patterns (illustrating a pattern the user implements)
+
+# These appear in prose code blocks that teach users how to structure agents.
+# They are shown being called on `self`, but the method body is either
+# defined inline in the same code block or described as "override this".
+
+_check_basic_auth: real private method in signalwire/core/swml_service.py:894 (leading `_` excludes from public surface)
+_get_new_messages: user-defined override shown in docs/agent_guide.md:2297
+_configure_instructions: user-defined helper shown in docs/agent_guide.md:2503
+_register_default_tools: user-defined helper shown in docs/agent_guide.md:2517
+_register_custom_tools: user-defined helper shown in docs/api_reference.md:3291
+_setup_contexts: user-defined helper shown in docs/api_reference.md:3257
+_setup_static_config: user-defined helper shown in docs/agent_guide.md:1699
+_test_api_connection: user-defined helper shown in docs/third_party_skills.md:304
+
+register_default_tools: user-defined helper shown in docs/architecture.md:701
+register_knowledge_base_tool: user-defined helper shown in docs/agent_guide.md:2522
+get_customer_tier: user-defined helper shown in docs/agent_guide.md (tier-based config pattern)
+get_customer_settings: user-defined helper shown in docs/agent_guide.md (tier-based config pattern)
+get_customer_config: user-defined helper shown in docs/agent_guide.md (tier-based config pattern)
+apply_custom_config: user-defined helper shown in docs/agent_guide.md (tier-based config pattern)
+apply_default_config: user-defined helper shown in docs/agent_guide.md (tier-based config pattern)
+is_valid_customer: user-defined helper shown in docs/agent_guide.md (tier-based config pattern)
+load_user_preferences: user-defined helper shown in docs/agent_guide.md (lifecycle hook example)
+send_to_analytics: user-defined helper shown in docs/agent_guide.md (lifecycle hook example)
+alert_ops_team: user-defined helper shown in docs/api_reference.md (on_debug_event example)
+schedule_follow_up: user-defined helper shown in docs/api_reference.md (on_summary example)
+update_state: user-defined helper shown in docs/agent_guide.md lifecycle-hook examples; SDK does not ship built-in session storage (see agent_guide.md §Important Notes item 4)
+get_state: user-defined helper shown in docs/agent_guide.md lifecycle-hook examples; SDK does not ship built-in session storage
+delete_state: user-defined helper shown in docs/agent_guide.md lifecycle-hook examples; SDK does not ship built-in session storage
+
+## Teaching-by-comparison references
+
+setup_google_search: legacy-API straw-man shown in docs/skills_system.md §Migration Guide (labelled "Before (manual implementation)") to contrast against the modern `add_skill("web_search")` API

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -203,19 +203,28 @@ self.prompt_add_section("Context",
                                "Check for existing tickets"])
 ```
 
-For convenience, the SDK also provides wrapper methods that some users may prefer:
+If you prefer a more conversational API, you can define thin wrapper methods on
+your agent subclass that delegate to `prompt_add_section()`. The `simple_agent`
+example demonstrates this pattern:
 
 ```python
-# Convenience methods
-self.setPersonality("You are a friendly assistant.") 
-self.setGoal("Help users with their questions.")
-self.setInstructions([
-    "Answer questions clearly",
-    "Be helpful and polite"
-])
+# User-defined wrappers (see examples/simple_agent.py)
+class MyAgent(AgentBase):
+    def setPersonality(self, text):
+        self.prompt_add_section("Personality", body=text)
+        return self
+
+    def setGoal(self, text):
+        self.prompt_add_section("Goal", body=text)
+        return self
+
+    def setInstructions(self, items):
+        self.prompt_add_section("Instructions", bullets=items)
+        return self
 ```
 
-These convenience methods call `prompt_add_section()` internally with the appropriate section titles.
+These are not part of the SDK surface — they are one-line helpers you can copy
+into your own agent class if you prefer that style.
 
 ### 2. Using Raw Text Prompts
 
@@ -1917,7 +1926,12 @@ These hooks are particularly useful for:
 
 #### Implementation
 
-To implement lifecycle hooks, define them as regular SWAIG functions with these specific names:
+To implement lifecycle hooks, define them as regular SWAIG functions with these specific names.
+
+> **Note:** The SDK does not ship built-in session storage. The `update_state`,
+> `get_state`, and `delete_state` methods in the example below are helpers you
+> would implement yourself on top of Redis, a database, or another external
+> store — see **Important Notes** item 4 below.
 
 ```python
 from signalwire import AgentBase, FunctionResult
@@ -1925,7 +1939,7 @@ from signalwire import AgentBase, FunctionResult
 class MyAgent(AgentBase):
     def __init__(self):
         super().__init__(name="my-agent")
-    
+
     @AgentBase.tool(
         name="startup_hook",
         description="Called when the voice session starts"
@@ -1935,8 +1949,8 @@ class MyAgent(AgentBase):
         call_id = raw_data.get("call_id")
         from_number = raw_data.get("from_number")
         to_number = raw_data.get("to_number")
-        
-        # Initialize session state
+
+        # Initialize session state (using your own storage helpers)
         self.update_state(call_id, {
             "session_start": datetime.now().isoformat(),
             "from": from_number,

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1406,13 +1406,14 @@ Define structured workflow contexts for the agent.
 **Usage:**
 ```python
 contexts = agent.define_contexts()
-contexts.add_context("greeting") \
-    .add_step("welcome", "Welcome! How can I help?") \
-    .on_completion_go_to("main_menu")
 
-contexts.add_context("main_menu") \
-    .add_step("menu", "Choose: 1) Support 2) Sales 3) Billing") \
-    .allow_functions(["transfer_to_support", "transfer_to_sales"])
+greeting = contexts.add_context("greeting")
+greeting.add_step("welcome", task="Welcome! How can I help?",
+                  valid_steps=["main_menu"])
+
+main_menu = contexts.add_context("main_menu")
+main_menu.add_step("menu", task="Choose: 1) Support 2) Sales 3) Billing",
+                   functions=["transfer_to_support", "transfer_to_sales"])
 ```
 
 This concludes Part 1 of the API reference covering the AgentBase class. The document will continue with FunctionResult, DataMap, and other components in subsequent parts.

--- a/docs/sdk_features.md
+++ b/docs/sdk_features.md
@@ -404,8 +404,8 @@ agent.set_params({
 agent.set_native_functions(["check_time", "wait_for_user"])
 agent.add_internal_filler("check_time", "en", ["Let me check the time..."])
 
-# Call recording
-agent.enable_record_call(format="wav", stereo=True)
+# Call recording (background, non-blocking)
+agent.add_pre_answer_verb("record_call", {"format": "wav", "stereo": True})
 
 # Call flow verbs
 agent.add_pre_answer_verb("play", {"url": "ringback.wav"})

--- a/docs/swaig_reference.md
+++ b/docs/swaig_reference.md
@@ -45,12 +45,6 @@ result.execute_swml('{"version":"1.0.0","sections":{"main":[{"say":"Hello"}]}}')
 # SWML dictionary
 swml_dict = {"version": "1.0.0", "sections": {"main": [{"say": "Hello"}]}}
 result.execute_swml(swml_dict, transfer=True)
-
-# SWML SDK object
-from signalwire.swml import SWML
-swml_doc = SWML()
-swml_doc.add_application("main", "say", {"text": "Connecting now"})
-result.execute_swml(swml_doc)
 ```
 
 #### **[IMPLEMENTED]** - Transfer/connect call to another destination using SWML.

--- a/examples/auto_vivified_example.py
+++ b/examples/auto_vivified_example.py
@@ -163,10 +163,10 @@ class VoicemailService(SWMLService):
                 "url": "say:Thank you for your message. Goodbye!"
             })
             print("Fell back to add_verb")
-        
-        # Hang up - use the existing method
-        self.add_hangup_verb()
-        
+
+        # Hang up - use the add_verb method
+        self.add_verb("hangup", {})
+
         self.log.debug("voicemail_document_built")
 
 
@@ -327,10 +327,10 @@ class CallTransferService(SWMLService):
         self.add_verb("play", {
             "url": "say:Thank you for your message. We'll get back to you as soon as possible."
         })
-        
+
         # Hang up
-        self.add_hangup_verb()
-        
+        self.add_verb("hangup", {})
+
         self.log.debug("transfer_document_built")
 
 

--- a/examples/basic_swml_service.py
+++ b/examples/basic_swml_service.py
@@ -90,10 +90,10 @@ class VoicemailService(SWMLService):
         self.add_verb("play", {
             "url": "say:Thank you for your message. Goodbye!"
         })
-        
+
         # Hang up
-        self.add_hangup_verb()
-        
+        self.add_verb("hangup", {})
+
         self.log.debug("voicemail_document_built")
 
 
@@ -260,10 +260,10 @@ class CallTransferService(SWMLService):
         self.add_verb("play", {
             "url": "say:Thank you for your message. We'll get back to you as soon as possible."
         })
-        
+
         # Hang up
-        self.add_hangup_verb()
-        
+        self.add_verb("hangup", {})
+
         self.log.debug("transfer_document_built")
 
 
@@ -332,10 +332,10 @@ class CallRecordingService(SWMLService):
         self.add_verb("play", {
             "url": "say:Thank you for your time. Goodbye!"
         })
-        
+
         # Hang up
-        self.add_hangup_verb()
-        
+        self.add_verb("hangup", {})
+
         self.log.debug("recording_document_built")
 
 

--- a/examples/declarative_agent.py
+++ b/examples/declarative_agent.py
@@ -111,12 +111,10 @@ class DeclarativeAgent(AgentBase):
         
         # Notice we don't need any prompt building calls here - they're handled
         # automatically by the declarative PROMPT_SECTIONS
-        # This is different from the conventional approach:
-        #
-        # Conventional approach:
-        #   self.set_personality("You are a friendly AI assistant...")
-        #   self.add_goal("Help users with their questions...")
-        #   self.add_instruction("Be concise and direct...")
+        # This is different from the conventional approach using prompt_add_section:
+        #   self.prompt_add_section("Personality", body="You are a friendly AI assistant...")
+        #   self.prompt_add_section("Goal",        body="Help users with their questions...")
+        #   self.prompt_add_section("Instructions", bullets=["Be concise and direct..."])
         #   ...
         
         #------------------------------------------------------------------------

--- a/examples/dynamic_swml_service.py
+++ b/examples/dynamic_swml_service.py
@@ -67,12 +67,12 @@ class DynamicGreetingService(SWMLService):
             "max_digits": 1,
             "terminators": "#"
         })
-        
+
         # Add hang up
-        self.add_hangup_verb()
-        
+        self.add_verb("hangup", {})
+
         self.log.debug("default_document_built")
-    
+
     def on_request(self, request_data: dict = None) -> dict:
         """
         Customize the SWML document based on the request data
@@ -172,9 +172,9 @@ class DynamicGreetingService(SWMLService):
                 "timeout": 30,
                 "answer_on_bridge": True
             })
-        
+
         # Add hang up as fallback
-        self.add_hangup_verb()
+        self.add_verb("hangup", {})
         
         self.log.info("document_customized", 
                      caller_type=caller_type,
@@ -219,10 +219,10 @@ class CallRouterService(SWMLService):
             "to": "+15551234567",  # Fallback number
             "timeout": 30
         })
-        
+
         # Add hang up
-        self.add_hangup_verb()
-        
+        self.add_verb("hangup", {})
+
         self.log.debug("default_document_built")
     
     def on_request(self, request_data: dict = None) -> dict:
@@ -268,7 +268,7 @@ class CallRouterService(SWMLService):
             self.add_verb("play", {
                 "url": "say:We'll call you back at the number you provided. Thank you for your patience."
             })
-            self.add_hangup_verb()
+            self.add_verb("hangup", {})
             return None
         
         # Inform caller if we're experiencing high volume
@@ -344,7 +344,7 @@ class CallRouterService(SWMLService):
         self.add_verb("play", {
             "url": "say:We're sorry, but all of our agents are currently busy. Please try your call again later."
         })
-        self.add_hangup_verb()
+        self.add_verb("hangup", {})
         
         return None  # The document has already been modified
 


### PR DESCRIPTION
## Summary

Wires Layer C of the porting-sdk audit stack — doc↔code alignment. Every method or class reference in `docs/`, `rest/docs/`, `relay/docs/`, `examples/`, `rest/examples/`, `relay/examples/` now resolves to a real symbol in the SDK surface, or lives in `DOC_AUDIT_IGNORE.md` with a concrete rationale.

**6 phantom SDK surfaces found and fixed in-repo** (20+ call sites), not ignored:

- `add_hangup_verb` in 3 examples → replaced with `add_verb("hangup", {})` (Python auto-vivifies bare verb names, not `add_<verb>_verb` wrappers)
- `set_personality` / `add_goal` / `add_instruction` in `examples/declarative_agent.py` → replaced with `prompt_add_section(...)`
- `on_completion_go_to` / `allow_functions` in `docs/api_reference.md` Context block → real `Context.add_step(...)` signature
- `enable_record_call` in `docs/sdk_features.md` → `add_pre_answer_verb("record_call", {...})`
- `add_application` / `signalwire.swml.SWML` in `docs/swaig_reference.md` → class doesn't exist; snippet removed
- `get_state` / `update_state` / `delete_state` in `agent_guide.md` → preamble clarifies these are user-defined (SDK ships no session storage)

## Test plan

- [x] `python3 porting-sdk/scripts/audit_docs.py --surface porting-sdk/python_surface.json --ignore DOC_AUDIT_IGNORE.md` — `3018 resolved / 4214 total`, exit 0
- [x] `python -m py_compile examples/*.py rest/examples/*.py relay/examples/*.py` — clean
- [x] `pytest --no-cov` — 4967 passed, 7 pre-existing skips, 0 failures
- [x] 114 remaining unresolved names moved to `DOC_AUDIT_IGNORE.md` with rationales (grouped by category: stdlib, structlog, argparse, test framework, skip-listed search docs, regex false positives, example-local user helpers)

## CI

`.github/workflows/doc-audit.yml` runs on PR + push to main + nightly. Clones porting-sdk alongside, runs example compile-check, runs `audit_docs.py` with `--ignore DOC_AUDIT_IGNORE.md`. Fails on drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)