### PR TITLE
ci: add Dependabot config (pip + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot version + security updates.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Weekly cadence (not daily) keeps PR volume sane for an agent-maintained matrix;
+# minor/patch updates are grouped into one PR, majors land individually so they
+# get a focused review. github-actions keeps the workflow action pins current.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Adds `.github/dependabot.yml` enabling Dependabot version + security updates for the **pip** ecosystem (plus **github-actions** for workflow pins).

Weekly cadence; minor/patch grouped into one PR, majors land individually for focused review. This is the GitHub-native dependency-audit — it cross-references the GitHub Advisory Database and auto-PRs fixes, replacing the need for a per-PR CLI audit gate (no per-PR flakiness when a new CVE drops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)