### PR TITLE
fix(mcp_gateway): forward MCP tool required-argument list to define_tool

### DIFF
--- a/signalwire/signalwire/skills/mcp_gateway/skill.py
+++ b/signalwire/signalwire/skills/mcp_gateway/skill.py
@@ -265,12 +265,17 @@ class MCPGatewaySkill(SkillBase):
         def handler(args, raw_data):
             return self._call_mcp_tool(service_name, tool_name, args, raw_data)
         
-        # Register the SWAIG function
+        # Register the SWAIG function. Forward the MCP tool's required-argument
+        # list so the model sees which parameters are mandatory; without this the
+        # registered tool would advertise no required arguments regardless of the
+        # upstream MCP schema. `required` is `[]` when the schema omits it, which
+        # SWAIGFunction treats as "no required key emitted".
         self.define_tool(
             name=swaig_name,
             description=f"[{service_name}] {tool_def.get('description', tool_name)}",
             parameters=swaig_params,
-            handler=handler
+            handler=handler,
+            required=required
         )
         
         self.logger.info(f"Registered SWAIG function: {swaig_name}")

--- a/tests/unit/skills/test_mcp_gateway_skill.py
+++ b/tests/unit/skills/test_mcp_gateway_skill.py
@@ -635,6 +635,44 @@ class TestRegisterMCPTool:
 
         assert params["kind"]["enum"] == ["a", "b"]
 
+    def test_register_mcp_tool_forwards_required_list(self):
+        """The MCP inputSchema's required list must be forwarded to define_tool
+        so the registered SWAIG tool advertises its mandatory arguments."""
+        skill, agent = _make_skill()
+
+        tool_def = {
+            "name": "create",
+            "description": "Create item",
+            "inputSchema": {
+                "properties": {
+                    "name": {"type": "string", "description": "Item name"},
+                    "tag": {"type": "string", "description": "Optional tag"},
+                },
+                "required": ["name"],
+            },
+        }
+
+        skill._register_mcp_tool("svc", tool_def)
+
+        call_kwargs = agent.define_tool.call_args.kwargs
+        assert call_kwargs["required"] == ["name"]
+
+    def test_register_mcp_tool_required_defaults_empty(self):
+        """A tool whose inputSchema omits 'required' forwards an empty list
+        (SWAIGFunction omits the wire key for an empty required list)."""
+        skill, agent = _make_skill()
+
+        tool_def = {
+            "name": "ping",
+            "description": "Ping",
+            "inputSchema": {"properties": {"msg": {"type": "string"}}},
+        }
+
+        skill._register_mcp_tool("svc", tool_def)
+
+        call_kwargs = agent.define_tool.call_args.kwargs
+        assert call_kwargs["required"] == []
+
     def test_register_mcp_tool_skips_tool_without_name(self):
         """Should skip tools without a name."""
         skill, agent = _make_skill()


### PR DESCRIPTION
## What

`mcp_gateway`'s `_register_mcp_tool` reads the discovered MCP tool's `inputSchema.required` — and uses it to gate per-property defaults — but **never passes it to `define_tool`**. So every dynamically-registered MCP tool advertised **no required arguments**, regardless of what the upstream MCP schema declared.

## Impact

The model could omit a genuinely-required argument and the SWAIG layer wouldn't flag it; the under-specified call would go out to the gateway (failing there, or executing with a silently-absent parameter) instead of being caught at schema validation where required-ness exists to be enforced. The information was already in hand (`required` is a live local) — it was simply not wired through the final call.

## Fix

Forward `required=required` to `define_tool`. It's `[]` when the schema omits it, which `SWAIGFunction` treats as "no required key emitted", so the change is safe unconditionally and only adds the key when the MCP tool actually declares required args.

## Tests

- `test_register_mcp_tool_forwards_required_list` — `inputSchema.required: ["name"]` is forwarded as `define_tool(..., required=["name"])`.
- `test_register_mcp_tool_required_defaults_empty` — absent `required` → `[]`.

All mcp tests pass (96 passed, 2 skipped).

---
Found during the cross-port SDK review: the TypeScript/Go/Rust/.NET ports already forward this required list correctly; this brings the Python reference in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)