### PR TITLE
test(relay,rest): shared session-isolated, parallel-safe mock harness (TS-parity)

### DIFF
--- a/signalwire/signalwire/relay/client.py
+++ b/signalwire/signalwire/relay/client.py
@@ -168,6 +168,11 @@ class RelayClient:
         # Sent back on reconnect to resume the same session.
         self._relay_protocol: str = ""
         self._identity: str = ""
+        # Server-assigned session id from the connect response's ``sessionid``
+        # key (test mock only; the real server omits it). Internal-only — used
+        # by the test harness to scope the mock journal to this client's
+        # session. Not part of the public surface.
+        self._session_id: str = ""
         # Encrypted authorization state from signalwire.authorization.state
         # events. Sent back on reconnect for fast re-auth without full
         # authentication round-trip.
@@ -281,6 +286,11 @@ class RelayClient:
         # Capture server-assigned protocol and identity
         self._relay_protocol = result.get("protocol", self._relay_protocol)
         self._identity = result.get("identity", self._identity)
+        # Capture the server-assigned session id when present. The real RELAY
+        # server omits this; the test mock returns it as ``sessionid`` (NO
+        # underscore) so a test can scope its journal/scenarios to its own
+        # session. Internal-only — not part of the public surface.
+        self._session_id = result.get("sessionid", self._session_id)
         logger.debug(f"Auth response: protocol={self._relay_protocol} identity={self._identity}")
 
     async def disconnect(self) -> None:

--- a/tests/unit/relay/conftest.py
+++ b/tests/unit/relay/conftest.py
@@ -2,43 +2,66 @@
 
 Two test backends coexist:
 
-1. The legacy ``MockWebSocket`` / ``connected_client`` fixtures — patches
-   ``websockets.connect`` and is used by the older RELAY unit tests
-   (``test_client.py``, ``test_call.py``, etc.).  Each test there pre-stages
-   responses on the mock WebSocket directly.
+1. The legacy ``MockWebSocket`` / ``connected_client`` fixtures — a WebSocket
+   transport double used by the RelayClient internal-mechanics unit tests
+   (``test_client.py``, ``test_message.py``).  These mirror the frozen
+   TypeScript reference's ``tests/relay/helpers.ts`` + ``RelayClient.test.ts`` /
+   ``Message.test.ts``, which keep an in-memory ``MockWebSocket`` for the same
+   resilience coverage (reconnect backoff, ping-failure backoff, recv-loop
+   exception handling, queue overflow, force-close, half-open detection) that a
+   conformant mock server can't reproduce — it would never emit a malformed
+   frame or drop the socket on cue.  They mock the transport on purpose.
 
-2. The newer ``signalwire_relay_client`` / ``mock_relay`` fixtures — back the
-   SDK with a real WebSocket server provided by the ``mock_relay`` package
+2. The ``signalwire_relay_client`` / ``mock_relay`` fixtures — back the SDK with
+   a real WebSocket server provided by the ``mock_relay`` package
    (``porting-sdk/test_harness/mock_relay``).  The mock loads RELAY's JSON
    schemas (extracted from switchblade) and synthesizes schema-conformant
    responses.  Tests written against this fixture exercise the SDK's actual
-   ``websockets`` transport and then assert on parsed SDK state and the
-   mock's HTTP-exposed journal / scenario plumbing.
+   ``websockets`` transport and then assert on parsed SDK state and the mock's
+   HTTP-exposed journal / scenario plumbing.
+
+   This is the parity-grade backend and mirrors the frozen TypeScript reference
+   harness ``tests/relay/mocktest.ts``: ONE shared mock server (probe-or-spawn,
+   adjacency discovery), and a per-test ``_MockRelayHarness`` *view* scoped to
+   the connected client's session so the whole RELAY suite is safe under
+   ``pytest -n auto``.
+
+   Isolation key: the connect handshake returns a server-assigned ``sessionid``
+   (NO underscore — reading ``session_id`` instead would make scoping a silent
+   no-op).  The SDK captures it into ``client._session_id``; when a test uses
+   ``signalwire_relay_client`` the ``mock_relay`` view for the same test is
+   scoped to that id, so its ``journal()``/``reset()`` and its
+   ``push``/``inbound_call``/``arm_*``/``scenario_play`` only ever touch this
+   test's session.  A test that builds its own client (e.g. the reconnect tests)
+   uses a bare unscoped ``mock_relay`` and filters by a unique protocol value.
 
    Usage::
 
-       def test_dial_round_trip(signalwire_relay_client, mock_relay):
-           # async usage; see test_outbound_call_mock.py for full pattern
+       async def test_dial_round_trip(signalwire_relay_client, mock_relay):
            call = await signalwire_relay_client.dial(...)
-           j = mock_relay.journal()
-           assert any(e["method"] == "calling.dial" for e in j if e["direction"] == "recv")
+           j = mock_relay.journal_recv(method="calling.dial")
+           assert j
 
-The two fixture families are independent — a test may use either, but not
-both at once (no one ever needs both).
+The two backends are independent — a test may use either, but not both at once.
 """
 
 from __future__ import annotations
 
 import asyncio
+import atexit
 import json
 import os
 import socket
+import subprocess
 import sys
+import threading
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Optional
 from unittest.mock import AsyncMock, patch
+from urllib.parse import quote
 
 import pytest
 import pytest_asyncio
@@ -52,20 +75,17 @@ from signalwire.relay.constants import METHOD_SIGNALWIRE_CONNECT
 # ---------------------------------------------------------------------------
 # Adjacency-based discovery for porting-sdk mock packages.
 #
-# Mirrors tests/unit/rest/conftest.py — must walk up to find
-# ``../porting-sdk/test_harness/mock_relay/`` and prepend it to ``sys.path``
-# so ``import mock_relay`` resolves without any pip install. The skipif
-# marker at module level guards every mock-backed test file.
+# Walk up to find ``../porting-sdk/test_harness/mock_relay/`` and prepend it to
+# ``sys.path`` so ``import mock_relay`` / ``python -m mock_relay`` resolve
+# without any pip install. Mirrors ``discoverPortingSdkPackage`` in the frozen
+# TypeScript reference harness ``tests/relay/mocktest.ts``; the walk ignores
+# ``$PORTING_SDK`` deliberately — the filesystem layout is the source of truth.
 # ---------------------------------------------------------------------------
 
 
-def _discover_mock_package(name: str) -> bool:
-    """Walk up from this file looking for ``../porting-sdk/test_harness/<name>/``.
-
-    Returns True when a sibling ``porting-sdk`` clone is found and the package
-    root has been prepended to ``sys.path``. Idempotent — multiple calls don't
-    duplicate ``sys.path`` entries.
-    """
+def _discover_mock_package(name: str) -> Optional[str]:
+    """Return the ``../porting-sdk/test_harness/<name>/`` package root (prepended
+    to ``sys.path``), or ``None`` when no adjacent ``porting-sdk`` is reachable."""
     here = Path(__file__).resolve()
     for parent in (here.parent, *here.parents):
         candidate = parent.parent / "porting-sdk" / "test_harness" / name
@@ -73,24 +93,16 @@ def _discover_mock_package(name: str) -> bool:
             entry = str(candidate)
             if entry not in sys.path:
                 sys.path.insert(0, entry)
-            return True
-    return False
+            return entry
+    return None
 
 
-# Try the relative-path discovery first; this works in fresh adjacent clones
-# without any prior pip install.
-_RELAY_MOCK_AVAILABLE = _discover_mock_package("mock_relay")
-
-try:
-    from mock_relay import MockRelayServer  # type: ignore
-    _RELAY_MOCK_AVAILABLE = True
-except ImportError:  # pragma: no cover - env without porting-sdk available
-    MockRelayServer = None  # type: ignore
-    _RELAY_MOCK_AVAILABLE = False
+_RELAY_MOCK_PKG_DIR = _discover_mock_package("mock_relay")
+_RELAY_MOCK_AVAILABLE = _RELAY_MOCK_PKG_DIR is not None
 
 
 # ---------------------------------------------------------------------------
-# Mock WebSocket
+# Mock WebSocket  (legacy transport double — see module docstring backend #1)
 # ---------------------------------------------------------------------------
 
 class MockWebSocket:
@@ -226,7 +238,7 @@ def make_calling_response(
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# Legacy fixtures (transport double)
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
@@ -285,7 +297,7 @@ def make_call():
 
 
 # ---------------------------------------------------------------------------
-# Real mock-relay server fixtures (mock_relay package, ws + http control plane)
+# Real mock-relay server — probe-or-spawn singleton (mirrors mocktest.ts)
 # ---------------------------------------------------------------------------
 
 
@@ -295,22 +307,136 @@ def make_call():
 # reconnect-with-protocol-string tests).
 os.environ.setdefault("RELAY_MAX_CONNECTIONS", "16")
 
+_DEFAULT_WS_PORT = 8773
+_STARTUP_TIMEOUT_S = 30.0
+_PROBE_TIMEOUT_S = 2.0
 
-def _free_port() -> int:
-    """Pick an unused localhost TCP port for the mock server."""
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
+
+def _resolve_ws_port() -> int:
+    raw = os.environ.get("MOCK_RELAY_WS_PORT")
+    if raw:
+        try:
+            p = int(raw)
+            if p > 0:
+                return p
+        except ValueError:
+            pass
+    return _DEFAULT_WS_PORT
+
+
+def _resolve_http_port(ws_port: int) -> int:
+    raw = os.environ.get("MOCK_RELAY_HTTP_PORT")
+    if raw:
+        try:
+            p = int(raw)
+            if p > 0:
+                return p
+        except ValueError:
+            pass
+    # Default behavior of mock_relay: HTTP = WS + 1000.
+    return ws_port + 1000
+
+
+def _probe_health(http_url: str) -> bool:
+    import requests
+    try:
+        resp = requests.get(f"{http_url}/__mock__/health", timeout=_PROBE_TIMEOUT_S)
+        if resp.status_code != 200:
+            return False
+        return "schemas_loaded" in resp.json()
+    except Exception:
+        return False
+
+
+class _SharedRelayServer:
+    """Process-wide handle to the one shared mock_relay server (WS + HTTP)."""
+
+    def __init__(self) -> None:
+        self.http_url: Optional[str] = None
+        self.ws_url: Optional[str] = None
+        self.relay_host: Optional[str] = None
+        self._child: Optional[subprocess.Popen] = None
+        self._lock = threading.Lock()
+        self._error: Optional[str] = None
+
+    def ensure(self) -> "_SharedRelayServer":
+        with self._lock:
+            if self.http_url is not None:
+                return self
+            if self._error is not None:
+                pytest.skip(self._error)
+
+            ws_port = _resolve_ws_port()
+            http_port = _resolve_http_port(ws_port)
+            http_url = f"http://127.0.0.1:{http_port}"
+            ws_url = f"ws://127.0.0.1:{ws_port}"
+            relay_host = f"127.0.0.1:{ws_port}"
+
+            if _probe_health(http_url):
+                self.http_url, self.ws_url, self.relay_host = http_url, ws_url, relay_host
+                return self
+
+            if not _RELAY_MOCK_AVAILABLE:
+                self._error = (
+                    "mock_relay not adjacent — clone porting-sdk next to signalwire-python"
+                )
+                pytest.skip(self._error)
+
+            child_env = dict(os.environ)
+            if _RELAY_MOCK_PKG_DIR:
+                existing = child_env.get("PYTHONPATH", "")
+                child_env["PYTHONPATH"] = (
+                    f"{_RELAY_MOCK_PKG_DIR}{os.pathsep}{existing}"
+                    if existing else _RELAY_MOCK_PKG_DIR
+                )
+            self._child = subprocess.Popen(
+                [
+                    sys.executable, "-m", "mock_relay",
+                    "--host", "127.0.0.1",
+                    "--ws-port", str(ws_port),
+                    "--http-port", str(http_port),
+                    "--log-level", "error",
+                ],
+                env=child_env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            atexit.register(self._terminate)
+
+            deadline = time.time() + _STARTUP_TIMEOUT_S
+            while time.time() < deadline:
+                if _probe_health(http_url):
+                    self.http_url, self.ws_url, self.relay_host = http_url, ws_url, relay_host
+                    return self
+                time.sleep(0.1)
+
+            self._terminate()
+            self._error = (
+                f"mock_relay did not become ready within {_STARTUP_TIMEOUT_S}s on "
+                f"ws={ws_port} http={http_port} (clone porting-sdk next to "
+                f"signalwire-python, or set MOCK_RELAY_WS_PORT to a pre-running instance)"
+            )
+            pytest.skip(self._error)
+
+    def _terminate(self) -> None:
+        child = self._child
+        self._child = None
+        if child is not None and child.poll() is None:
+            child.terminate()
+            try:
+                child.wait(timeout=5)
+            except Exception:
+                child.kill()
+
+
+_SHARED_RELAY = _SharedRelayServer()
 
 
 @dataclass
 class _RelayJournalEntry:
     """Lightweight view of a single journal entry the mock server recorded.
 
-    Mirrors the dict shape exposed at ``/__mock__/journal`` but is decoupled
-    from the upstream type so this conftest doesn't import internal modules.
+    Mirrors the dict shape exposed at ``/__mock__/journal``.
     """
 
     timestamp: float
@@ -335,41 +461,37 @@ class _RelayJournalEntry:
 
 
 class _MockRelayHarness:
-    """Test-facing harness around the running ``MockRelayServer``.
+    """Per-test view of the shared ``mock_relay`` server's HTTP control plane.
 
-    Wraps the server's HTTP control plane in a typed surface so tests don't
-    have to hand-roll ``requests`` calls. All methods talk to the mock over
-    plain HTTP — synchronous from the test thread, even though the server's
-    WebSocket handler runs on its own asyncio loop.
+    When ``session_id`` is set (done automatically by ``signalwire_relay_client``
+    from the connected client's ``_session_id``), journal reads and
+    ``push``/``inbound_call``/``arm_*``/``scenario_play`` are scoped to that one
+    session, so a test only ever sees / targets its own frames — making the
+    shared mock safe under ``pytest -n auto``.  Left empty => global (unscoped),
+    used by tests that build their own clients and filter by a unique value.
     """
 
-    def __init__(self, server: "MockRelayServer") -> None:  # type: ignore[name-defined]
-        # Local import so the type only resolves when discovery succeeded.
+    def __init__(self, http_url: str, ws_url: str, relay_host: str) -> None:
         import requests as _requests
 
-        self._server = server
+        self.http_url = http_url
+        self.ws_url = ws_url
+        self.relay_host = relay_host
+        self.session_id = ""
         self._requests = _requests
 
-    # -- exposed addresses ---------------------------------------------------
+    # -- scoping helper ------------------------------------------------------
 
-    @property
-    def ws_url(self) -> str:
-        return self._server.ws_url
-
-    @property
-    def http_url(self) -> str:
-        return self._server.http_url
-
-    @property
-    def relay_host(self) -> str:
-        """Host:port for the SDK ``host=`` parameter (no scheme)."""
-        return self._server.relay_host
+    def _session_query(self) -> str:
+        return f"?session_id={quote(self.session_id, safe='')}" if self.session_id else ""
 
     # -- journal -------------------------------------------------------------
 
     def journal(self) -> list[_RelayJournalEntry]:
-        """Return every journaled frame in arrival order."""
-        resp = self._requests.get(f"{self.http_url}/__mock__/journal", timeout=5)
+        """Every journaled frame for this session (or all when unscoped)."""
+        resp = self._requests.get(
+            f"{self.http_url}/__mock__/journal{self._session_query()}", timeout=5
+        )
         resp.raise_for_status()
         return [_RelayJournalEntry.from_dict(d) for d in resp.json()]
 
@@ -401,7 +523,15 @@ class _MockRelayHarness:
         return out
 
     def reset(self) -> None:
-        """Clear journal + scenario queues. Called between tests automatically."""
+        """Clear journal + scenarios.
+
+        A scoped harness leaves the shared state alone (it only reads its own
+        session's entries, and a brand-new session starts empty — a global wipe
+        would race a concurrent test).  Unscoped harnesses do the legacy global
+        reset.
+        """
+        if self.session_id:
+            return
         self._requests.post(f"{self.http_url}/__mock__/journal/reset", timeout=5)
         self._requests.post(f"{self.http_url}/__mock__/scenarios/reset", timeout=5)
 
@@ -410,18 +540,24 @@ class _MockRelayHarness:
     def arm_method(
         self, method: str, events: Iterable[dict[str, Any]]
     ) -> None:
-        """Queue scripted post-RPC events for ``method`` (FIFO consume-once)."""
+        """Queue scripted post-RPC events for ``method`` (FIFO consume-once).
+
+        Scoped to this session so a concurrent test can't consume the queue.
+        """
         resp = self._requests.post(
-            f"{self.http_url}/__mock__/scenarios/{method}",
+            f"{self.http_url}/__mock__/scenarios/{method}{self._session_query()}",
             json=list(events),
             timeout=5,
         )
         resp.raise_for_status()
 
     def arm_dial(self, **kwargs: Any) -> None:
-        """Queue a dial-dance scenario (winner state events + final dial event)."""
+        """Queue a dial-dance scenario (winner state events + final dial event).
+
+        Scoped to this session so a concurrent dial test can't consume it.
+        """
         resp = self._requests.post(
-            f"{self.http_url}/__mock__/scenarios/dial",
+            f"{self.http_url}/__mock__/scenarios/dial{self._session_query()}",
             json=kwargs,
             timeout=5,
         )
@@ -435,10 +571,16 @@ class _MockRelayHarness:
         *,
         session_id: Optional[str] = None,
     ) -> dict[str, Any]:
-        """Push a single ``signalwire.event`` (or other) frame to the SDK."""
+        """Push a single ``signalwire.event`` (or other) frame to the SDK.
+
+        Targets this harness's session by default (so a parallel test's client
+        never receives it); an explicit ``session_id`` overrides, and an
+        unscoped harness with no arg broadcasts (legacy single-threaded).
+        """
+        target = session_id or self.session_id
         url = f"{self.http_url}/__mock__/push"
-        if session_id:
-            url = f"{url}?session_id={session_id}"
+        if target:
+            url = f"{url}?session_id={quote(target, safe='')}"
         resp = self._requests.post(url, json={"frame": frame}, timeout=5)
         resp.raise_for_status()
         return resp.json()
@@ -454,7 +596,12 @@ class _MockRelayHarness:
         delay_ms: int = 50,
         session_id: Optional[str] = None,
     ) -> dict[str, Any]:
-        """Inject an inbound call announcement into one or every session."""
+        """Inject an inbound call announcement.
+
+        Targets this harness's session by default so the inbound-call sequence
+        reaches only this test's client (an unscoped harness broadcasts, as
+        before); an explicit ``session_id`` overrides.
+        """
         body: dict[str, Any] = {
             "from_number": from_number,
             "to_number": to_number,
@@ -464,8 +611,9 @@ class _MockRelayHarness:
         }
         if call_id is not None:
             body["call_id"] = call_id
-        if session_id is not None:
-            body["session_id"] = session_id
+        target = session_id or self.session_id
+        if target:
+            body["session_id"] = target
         resp = self._requests.post(
             f"{self.http_url}/__mock__/inbound_call", json=body, timeout=5
         )
@@ -473,12 +621,29 @@ class _MockRelayHarness:
         return resp.json()
 
     def scenario_play(self, ops: list[dict[str, Any]]) -> dict[str, Any]:
-        """Run a scripted timeline of pushes/sleeps/expect_recv on the server."""
+        """Run a scripted timeline of pushes/sleeps/expect_recv on the server.
+
+        When scoped, each push/expect_recv op is stamped with this session id
+        (unless it already carries one), so the timeline targets only this
+        test's client and expect_recv matches only this session's frames.
+        """
+        if self.session_id:
+            ops = [self._scope_op(op) for op in ops]
         resp = self._requests.post(
             f"{self.http_url}/__mock__/scenario_play", json=ops, timeout=15
         )
         resp.raise_for_status()
         return resp.json()
+
+    def _scope_op(self, op: dict[str, Any]) -> dict[str, Any]:
+        """Inject this.session_id into a timeline op's push/expect_recv spec when
+        the op doesn't already specify a session_id.  Leaves sleep ops alone."""
+        out = dict(op)
+        for key in ("push", "expect_recv"):
+            spec = out.get(key)
+            if isinstance(spec, dict) and "session_id" not in spec:
+                out[key] = {**spec, "session_id": self.session_id}
+        return out
 
     def sessions(self) -> list[dict[str, Any]]:
         """List active WebSocket session metadata."""
@@ -487,54 +652,33 @@ class _MockRelayHarness:
         return resp.json().get("sessions", [])
 
 
-@pytest.fixture(scope="session")
-def _mock_relay_server_instance():
-    """Boot one real mock-relay server for the whole test session."""
-    if not _RELAY_MOCK_AVAILABLE:
-        pytest.skip(
-            "mock_relay not adjacent — clone porting-sdk next to signalwire-python"
-        )
-    server = MockRelayServer(  # type: ignore[misc]
-        host="127.0.0.1",
-        ws_port=_free_port(),
-        http_port=_free_port(),
-        log_level="error",
-    ).start()
-    try:
-        yield server
-    finally:
-        server.stop()
-
-
 @pytest.fixture
-def mock_relay(_mock_relay_server_instance):
-    """Test-facing harness around the mock-relay server.
+def mock_relay():
+    """Test-facing harness around the shared mock-relay server (unscoped view).
 
-    The journal and scenario queues are reset before every test so each test
-    starts from a clean slate.
+    Used directly by tests that build their own client(s).  When a test also
+    uses ``signalwire_relay_client``, that fixture scopes THIS same harness
+    object to the connected client's session id.
     """
-    harness = _MockRelayHarness(_mock_relay_server_instance)
-    harness.reset()
-    yield harness
+    shared = _SHARED_RELAY.ensure()
+    return _MockRelayHarness(shared.http_url, shared.ws_url, shared.relay_host)
 
 
-def _ws_redirect_to_mock(mock_relay_server) -> Any:
+def _ws_redirect_to_mock(shared: "_SharedRelayServer") -> Any:
     """Build the websockets.connect override that points the SDK at the mock.
 
-    The SDK builds its URI as ``f"wss://{self.host}"`` — wss://, no port. We
-    replace ``websockets.connect`` so any URI the SDK passes is ignored and
-    the connection lands on ``ws://host:port`` instead.
-
-    The patch only changes the URL; behavior is identical to the real
-    websockets.connect. This keeps the dual-contract (touch the real symbol /
-    behavioral assertions / journal assertions) intact — see
-    ``INTENTIONAL_THIN_TESTS.md`` adjacent to the audit script.
+    The SDK builds its URI as ``f"wss://{self.host}"`` — wss://, no port.  We
+    replace ``websockets.connect`` so any URI the SDK passes is ignored and the
+    connection lands on ``ws://host:port`` instead.  This is the one allowed
+    transport touch (URL-only redirect; behavior is identical to the real
+    ``websockets.connect`` — the SDK still drives the real WS transport against
+    a real server).  It mirrors the frozen TS reference passing ``scheme: 'ws'``
+    to ``RelayClient`` (Python's client has no scheme option).
     """
-    target_url = mock_relay_server.ws_url
+    target_url = shared.ws_url
     real_connect = __import__("websockets").connect
 
     def proxy(uri, *args, **kwargs):
-        # Ignore any URI the SDK passed, dial the mock instead.
         return real_connect(target_url, *args, **kwargs)
 
     return patch("signalwire.relay.client.websockets.connect", side_effect=proxy)
@@ -542,33 +686,33 @@ def _ws_redirect_to_mock(mock_relay_server) -> Any:
 
 @pytest_asyncio.fixture
 async def signalwire_relay_client(mock_relay):
-    """A real ``RelayClient`` connected to the mock relay server.
+    """A real ``RelayClient`` connected to the shared mock relay server.
 
-    Yields a connected RelayClient inside the ``websockets.connect`` URL
-    redirect.  The fixture handles connect+disconnect; tests just use the
-    client.
+    Connects inside the ``websockets.connect`` URL redirect, then scopes the
+    ``mock_relay`` view (the same object handed to this test) to the connected
+    client's server-assigned session id, so the test's journal reads/pushes are
+    isolated to its own session — safe under ``pytest -n auto``.  The fixture
+    handles connect+disconnect; tests just use the client.
 
-    The yield expression is a bare ``RelayClient(...)`` call so static
-    coverage tools resolve ``signalwire_relay_client`` to ``RelayClient``.
+    The yield expression is a bare ``RelayClient(...)`` call so static coverage
+    tools resolve ``signalwire_relay_client`` to ``RelayClient``.
     """
     _active_clients.clear()
+    shared = _SHARED_RELAY.ensure()
 
-    server = mock_relay._server  # the underlying MockRelayServer
-    target_url = server.ws_url
-    real_connect = __import__("websockets").connect
-
-    def proxy(uri, *args, **kwargs):
-        return real_connect(target_url, *args, **kwargs)
-
-    with patch("signalwire.relay.client.websockets.connect", side_effect=proxy):
+    with _ws_redirect_to_mock(shared):
         client = RelayClient(
             project="test_proj",
             token="test_tok",
-            host=server.relay_host,
+            host=shared.relay_host,
             contexts=["default"],
         )
         try:
             await client.connect()
+            # Scope this test's harness view to the client's session. The mock
+            # returns the session id as ``sessionid`` (no underscore) in the
+            # connect result; the SDK captures it into ``_session_id``.
+            mock_relay.session_id = client._session_id
             yield client
         finally:
             try:
@@ -587,4 +731,4 @@ def relay_ws_redirect(mock_relay):
     different creds, or to cover the failure path on connect()) instead of
     relying on the auto-connected ``signalwire_relay_client`` fixture.
     """
-    return _ws_redirect_to_mock(mock_relay._server)
+    return _ws_redirect_to_mock(_SHARED_RELAY.ensure())

--- a/tests/unit/relay/test_client.py
+++ b/tests/unit/relay/test_client.py
@@ -220,10 +220,17 @@ class TestConnectionLimits:
         _active_clients.clear()
 
     @pytest.mark.asyncio
-    async def test_default_limit_is_one(self):
+    async def test_limit_of_one_is_enforced(self):
+        # Pin the limit to 1 for this test rather than relying on the module
+        # default: the real-mock relay conftest raises RELAY_MAX_CONNECTIONS to
+        # 16 (so a single test can hold several live clients), and that env var
+        # is read once at client-module import — making any assertion about the
+        # *default* value order-dependent under pytest-xdist. Patching the
+        # module global makes the limit-enforcement behavior deterministic.
         ws1 = AutoAuthMockWebSocket()
         ws2 = AutoAuthMockWebSocket()
-        with patch("signalwire.relay.client.websockets.connect",
+        with patch("signalwire.relay.client._MAX_CONNECTIONS", 1), \
+             patch("signalwire.relay.client.websockets.connect",
                    new_callable=AsyncMock, return_value=ws1):
             c1 = RelayClient(project="p", token="t")
             await c1.connect()

--- a/tests/unit/relay/test_connect_mock.py
+++ b/tests/unit/relay/test_connect_mock.py
@@ -233,8 +233,16 @@ async def test_connect_with_jwt_carries_jwt_on_wire(mock_relay, relay_ws_redirec
             await client.disconnect()
     _active_clients.clear()
 
-    [entry] = mock_relay.journal_recv(method=METHOD_SIGNALWIRE_CONNECT)
-    auth = entry.frame["params"]["authentication"]
+    # This test uses a bare (unscoped) ``mock_relay`` because it builds its own
+    # client, so the shared mock's journal also holds connect frames from other
+    # tests/sessions. Identify ours by the unique jwt_token we sent.
+    jwt_connects = [
+        e for e in mock_relay.journal_recv(method=METHOD_SIGNALWIRE_CONNECT)
+        if e.frame["params"].get("authentication", {}).get("jwt_token")
+        == "fake-jwt-eyJ.AaaA.BbB"
+    ]
+    assert jwt_connects, "no connect frame carried our jwt_token"
+    auth = jwt_connects[-1].frame["params"]["authentication"]
     assert auth.get("jwt_token") == "fake-jwt-eyJ.AaaA.BbB"
     # JWT path doesn't include project/token.
     assert "token" not in auth or not auth["token"]

--- a/tests/unit/relay/test_event_dispatch_mock.py
+++ b/tests/unit/relay/test_event_dispatch_mock.py
@@ -275,6 +275,10 @@ async def test_dial_event_routes_via_tag_when_no_top_level_call_id(
         )
         try:
             await client.connect()
+            # Scope the harness view to THIS client's session so arm_dial /
+            # journal_send don't collide with a concurrent dial test under
+            # ``pytest -n auto`` (the bare ``mock_relay`` is otherwise unscoped).
+            mock_relay.session_id = client._session_id
             mock_relay.arm_dial(
                 tag="ec-tag-route",
                 winner_call_id="WINTAG",

--- a/tests/unit/relay/test_inbound_call_mock.py
+++ b/tests/unit/relay/test_inbound_call_mock.py
@@ -497,8 +497,15 @@ async def test_inbound_without_handler_does_not_crash(mock_relay, relay_ws_redir
         )
         try:
             await client.connect()
-            # No on_call registered.
-            mock_relay.inbound_call(call_id="c-nohandler", auto_states=["created"])
+            # No on_call registered. Target THIS client's session explicitly
+            # (the bare ``mock_relay`` is unscoped; without a target the inbound
+            # call would broadcast to every connected session, including a
+            # concurrent test's client under ``pytest -n auto``).
+            mock_relay.inbound_call(
+                call_id="c-nohandler",
+                auto_states=["created"],
+                session_id=client._session_id,
+            )
             # Give the recv loop time to process.
             await asyncio.sleep(0.2)
             # Client is still alive.

--- a/tests/unit/rest/conftest.py
+++ b/tests/unit/rest/conftest.py
@@ -3,15 +3,38 @@
 Two test backends coexist:
 
 1. The legacy ``mock_session`` fixture — patches ``requests.Session`` and is
-   used by the older REST tests (``test_namespaces.py``, ``test_calling.py``,
-   etc.).  Each test there pre-stages the response on ``mock_session.request``.
+   used by the transport-contract unit tests (``test_base.py``,
+   ``test_calling.py``, ``test_client.py``, ``test_namespaces.py``,
+   ``test_phone_numbers.py``, ``test_fabric.py``).  These mirror the frozen
+   TypeScript reference's ``HttpClient.test.ts`` / ``calling.test.ts`` /
+   ``phoneNumbers.test.ts`` / ``fabric.test.ts``, which keep a ``createMockFetch``
+   transport double for the same plumbing-level coverage.  They mock the
+   transport on purpose to assert the exact ``(method, url, json, params)`` the
+   client builds for arbitrary paths the spec mock would 404.
 
-2. The newer ``signalwire_client`` / ``mock`` fixtures — back the SDK with a
-   real HTTP server provided by the ``mock_signalwire`` package
+2. The ``signalwire_client`` / ``mock`` fixtures — back the SDK with a real
+   HTTP server provided by the ``mock_signalwire`` package
    (``porting-sdk/test_harness/mock_signalwire``).  The mock loads SignalWire's
    13 OpenAPI specs and synthesises schema-conformant responses.  Tests written
    against this fixture exercise the SDK's actual ``requests`` transport and
    then assert on both the parsed response body and a recorded request journal.
+
+   This is the parity-grade backend and mirrors the frozen TypeScript reference
+   harness ``tests/rest/mocktest.ts``: ONE shared mock server (probe-or-spawn,
+   adjacency discovery), and a per-test ``MockHarness`` *view* scoped to that
+   test's client so the whole REST suite is safe under ``pytest -n auto``.
+
+   Isolation key (REST is pure request/response, no session handshake): each
+   ``signalwire_client`` authenticates with a unique random token
+   ``test_tok_<12 hex>`` (project stays the constant ``test_proj`` so the LAML
+   ``Accounts/test_proj/...`` paths the compat tests assert on stay stable), so
+   its ``Authorization: Basic base64(project:token)`` header is unique.  ``mock``
+   filters the shared global journal by that header
+   (lowercased ``authorization``); ``mock.reset()`` is a no-op for a scoped view
+   (a fresh client already sees an empty filtered journal, and a global wipe
+   would race a concurrent test); and ``mock.push_scenario(...)`` scopes the
+   override to this client (``?session_id=<auth header>``) so a concurrent test
+   can't consume it.
 
    Usage::
 
@@ -22,20 +45,28 @@ Two test backends coexist:
            assert j.method == "GET"
            assert j.path.endswith("/Calls/CA_TEST_SID")
 
-The two fixtures are independent — a test may use either, but not both at
-once (no one ever needs both).
+The two backends are independent — a test may use either, but not both at once.
 """
 
 from __future__ import annotations
 
+import atexit
+import base64
+import os
 import socket
+import subprocess
 import sys
+import threading
+import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import MagicMock, patch
+from urllib.parse import quote
 
 import pytest
+import requests
 
 from signalwire.rest._base import HttpClient
 from signalwire.rest.client import RestClient
@@ -49,18 +80,19 @@ from signalwire.rest.client import RestClient
 # install of ``mock_signalwire`` / ``mock_relay`` is required.
 #
 # We walk this file's parents looking for ``../porting-sdk/test_harness/<name>/``
-# and prepend it to ``sys.path`` so ``import mock_signalwire`` resolves. If the
-# discovery fails we fall back to whatever is on ``sys.path`` (e.g. a prior
-# editable install) and ultimately to the per-fixture skip.
+# and return that directory so it can be prepended to ``sys.path`` /
+# ``PYTHONPATH``.  This mirrors ``discoverPortingSdkPackage`` in the frozen
+# TypeScript reference harness ``tests/rest/mocktest.ts``.  The walk ignores
+# ``$PORTING_SDK`` deliberately — the filesystem layout is the source of truth.
 # ---------------------------------------------------------------------------
 
 
-def _discover_mock_package(name: str) -> bool:
+def _discover_mock_package(name: str) -> Optional[str]:
     """Walk up from this file looking for ``../porting-sdk/test_harness/<name>/``.
 
-    Returns True when a sibling ``porting-sdk`` clone is found and the package
-    root has been prepended to ``sys.path``. Idempotent — multiple calls don't
-    duplicate ``sys.path`` entries.
+    Returns the package-root directory (the value to put on ``sys.path`` so
+    ``import <name>`` / ``python -m <name>`` resolve), or ``None`` when no
+    adjacent ``porting-sdk`` clone is reachable.  Idempotent on ``sys.path``.
     """
     here = Path(__file__).resolve()
     for parent in (here.parent, *here.parents):
@@ -69,21 +101,12 @@ def _discover_mock_package(name: str) -> bool:
             entry = str(candidate)
             if entry not in sys.path:
                 sys.path.insert(0, entry)
-            return True
-    return False
+            return entry
+    return None
 
 
-# Try the relative-path discovery first; this works in fresh adjacent clones
-# without any prior pip install.
-_MOCK_AVAILABLE = _discover_mock_package("mock_signalwire")
-_RELAY_MOCK_AVAILABLE = _discover_mock_package("mock_relay")
-
-try:
-    from mock_signalwire import MockServer  # type: ignore
-    _MOCK_AVAILABLE = True
-except ImportError:  # pragma: no cover - env without porting-sdk available
-    MockServer = None  # type: ignore
-    _MOCK_AVAILABLE = False
+_MOCK_PKG_DIR = _discover_mock_package("mock_signalwire")
+_MOCK_AVAILABLE = _MOCK_PKG_DIR is not None
 
 
 class MockResponse:
@@ -128,121 +151,267 @@ def client(mock_session):
 
 
 # ---------------------------------------------------------------------------
-# Real mock-server fixtures (mock_signalwire package)
+# Shared mock-signalwire server — probe-or-spawn singleton (mirrors mocktest.ts)
+#
+# The mock's lifetime is per-process: the first time a test needs it we probe
+# ``http://127.0.0.1:<port>/__mock__/health`` and either reuse a running server
+# or spawn one as a detached subprocess.  Under ``pytest -n auto`` every xdist
+# worker is a separate process; the FIRST worker to look spawns the shared
+# server, the rest probe and reuse it.  Session isolation (below) is what makes
+# that one shared server safe under concurrency — not a per-worker server.
 # ---------------------------------------------------------------------------
 
 
-def _free_port() -> int:
-    """Pick an unused localhost TCP port for the mock server."""
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
+_DEFAULT_PORT = 8765
+_STARTUP_TIMEOUT_S = 30.0
+_PROBE_TIMEOUT_S = 2.0
+# Project stays constant so LAML ``Accounts/test_proj/...`` paths are stable;
+# per-test isolation comes from a unique random token (below).
+_REST_PROJECT = "test_proj"
+
+
+def _resolve_port() -> int:
+    raw = os.environ.get("MOCK_SIGNALWIRE_PORT")
+    if raw:
+        try:
+            p = int(raw)
+            if p > 0:
+                return p
+        except ValueError:
+            pass
+    return _DEFAULT_PORT
+
+
+def _probe_health(base_url: str) -> bool:
+    try:
+        resp = requests.get(f"{base_url}/__mock__/health", timeout=_PROBE_TIMEOUT_S)
+        if resp.status_code != 200:
+            return False
+        return "specs_loaded" in resp.json()
+    except Exception:
+        return False
+
+
+class _SharedServer:
+    """Process-wide handle to the one shared mock_signalwire server."""
+
+    def __init__(self) -> None:
+        self.url: Optional[str] = None
+        self.port: Optional[int] = None
+        self._child: Optional[subprocess.Popen] = None
+        self._lock = threading.Lock()
+        self._error: Optional[str] = None
+
+    def ensure(self) -> "_SharedServer":
+        with self._lock:
+            if self.url is not None:
+                return self
+            if self._error is not None:
+                pytest.skip(self._error)
+
+            port = _resolve_port()
+            url = f"http://127.0.0.1:{port}"
+
+            if _probe_health(url):
+                self.url, self.port = url, port
+                return self
+
+            if not _MOCK_AVAILABLE:
+                self._error = (
+                    "mock_signalwire package not found - clone porting-sdk "
+                    "adjacent to this repo so tests can find "
+                    "porting-sdk/test_harness/mock_signalwire/"
+                )
+                pytest.skip(self._error)
+
+            child_env = dict(os.environ)
+            if _MOCK_PKG_DIR:
+                existing = child_env.get("PYTHONPATH", "")
+                child_env["PYTHONPATH"] = (
+                    f"{_MOCK_PKG_DIR}{os.pathsep}{existing}" if existing else _MOCK_PKG_DIR
+                )
+            self._child = subprocess.Popen(
+                [
+                    sys.executable, "-m", "mock_signalwire",
+                    "--host", "127.0.0.1",
+                    "--port", str(port),
+                    "--log-level", "error",
+                ],
+                env=child_env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            atexit.register(self._terminate)
+
+            deadline = time.time() + _STARTUP_TIMEOUT_S
+            while time.time() < deadline:
+                if _probe_health(url):
+                    self.url, self.port = url, port
+                    return self
+                # Another worker may have won the spawn race; either way the
+                # probe above will succeed once *some* server is up.
+                time.sleep(0.1)
+
+            self._terminate()
+            self._error = (
+                f"mock_signalwire did not become ready within {_STARTUP_TIMEOUT_S}s "
+                f"on port {port} (clone porting-sdk next to signalwire-python, or "
+                f"set MOCK_SIGNALWIRE_PORT to a pre-running instance)"
+            )
+            pytest.skip(self._error)
+
+    def _terminate(self) -> None:
+        child = self._child
+        self._child = None
+        if child is not None and child.poll() is None:
+            child.terminate()
+            try:
+                child.wait(timeout=5)
+            except Exception:
+                child.kill()
+
+
+_SHARED = _SharedServer()
 
 
 @dataclass
 class _JournalEntry:
-    """Lightweight view of a single request the mock server recorded.
-
-    Mirrors the dataclass in mock_signalwire.journal but is decoupled from
-    the upstream type so this conftest doesn't import internal modules.
-    """
+    """Lightweight view of a single request the mock server recorded."""
 
     method: str
     path: str
     query_params: dict[str, list[str]]
     headers: dict[str, str]
     body: Any
-    matched_route: str | None
-    response_status: int | None
+    matched_route: Optional[str]
+    response_status: Optional[int]
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "_JournalEntry":
+        return cls(
+            method=str(d.get("method", "")),
+            path=str(d.get("path", "")),
+            query_params=d.get("query_params") or {},
+            headers=d.get("headers") or {},
+            body=d.get("body"),
+            matched_route=d.get("matched_route"),
+            response_status=d.get("response_status"),
+        )
 
 
 class _MockHarness:
-    """Convenience wrapper around the running ``MockServer`` for tests.
+    """Per-test view of the shared ``mock_signalwire`` server.
 
-    Keeps the journal/scenario plumbing reachable without leaking the
-    underlying Starlette/uvicorn types.
+    Scoped to ONE client's ``Authorization`` header so concurrent tests against
+    the shared server never see each other's requests.  Mirrors ``MockHarness``
+    in the frozen TypeScript reference ``tests/rest/mocktest.ts``.
     """
 
-    def __init__(self, server: "MockServer") -> None:  # type: ignore[name-defined]
-        self._server = server
+    def __init__(self, url: str, port: int) -> None:
+        self.url = url
+        self.port = port
+        # The unique random project this view's client authenticates with
+        # (``test_proj_<hex>``).  Empty on an unscoped/raw harness.
+        self.project = ""
+        # ``Authorization: Basic ...`` of this view's client (lowercased match
+        # key for the journal filter).  Empty => unscoped (legacy global view).
+        self.auth_header = ""
 
-    @property
-    def url(self) -> str:
-        return self._server.url
-
-    @property
-    def port(self) -> int:
-        return self._server.port
+    def _raw_journal(self) -> list[_JournalEntry]:
+        resp = requests.get(f"{self.url}/__mock__/journal", timeout=5)
+        resp.raise_for_status()
+        return [_JournalEntry.from_dict(d) for d in resp.json()]
 
     @property
     def journal(self) -> list[_JournalEntry]:
-        """Return all recorded entries in arrival order."""
-        raw = self._server.app.state.mock_state.journal.all()
-        return [
-            _JournalEntry(
-                method=e.method,
-                path=e.path,
-                query_params=e.query_params,
-                headers=e.headers,
-                body=e.body,
-                matched_route=e.matched_route,
-                response_status=e.response_status,
-            )
-            for e in raw
-        ]
+        """This client's recorded requests in arrival order.
+
+        Scoped to this harness's ``auth_header`` when set (so a parallel test
+        never sees another test's requests); an unscoped harness sees the whole
+        journal.
+        """
+        entries = self._raw_journal()
+        if not self.auth_header:
+            return entries
+        return [e for e in entries if e.headers.get("authorization") == self.auth_header]
 
     def last_request(self) -> _JournalEntry:
-        """Return the most recent journal entry. Raises if empty."""
+        """Most recent journal entry for THIS client.  Raises if empty."""
         entries = self.journal
         if not entries:
-            raise AssertionError("mock journal is empty - no request was recorded")
+            raise AssertionError(
+                "mock journal is empty - no request was recorded for this client"
+            )
         return entries[-1]
 
     def reset(self) -> None:
-        """Clear journal + scenarios. Called automatically between tests."""
-        self._server.app.state.mock_state.journal.reset()
-        self._server.app.state.mock_state.scenarios.reset()
+        """No-op for a scoped view.
 
+        A scoped harness reads only its own entries (by auth header), so there
+        is nothing to clear and a global wipe would race a concurrent test.  A
+        fresh per-test client already starts with an empty filtered journal.
+        Unscoped harnesses do the legacy global reset.
+        """
+        if self.auth_header:
+            return
+        requests.post(f"{self.url}/__mock__/journal/reset", timeout=5)
+        requests.post(f"{self.url}/__mock__/scenarios/reset", timeout=5)
 
-@pytest.fixture(scope="session")
-def _mock_server_instance():
-    """Boot one real mock server for the whole test session."""
-    if not _MOCK_AVAILABLE:
-        pytest.skip(
-            "mock_signalwire package not found - clone porting-sdk adjacent "
-            "to this repo so tests can find porting-sdk/test_harness/mock_signalwire/"
-        )
-    server = MockServer(host="127.0.0.1", port=_free_port(), log_level="error").start()
-    try:
-        yield server
-    finally:
-        server.stop()
+    def push_scenario(self, endpoint_id: str, status: int, response: Any) -> None:
+        """Stage a consume-once response override for ``endpoint_id``.
+
+        Scoped to THIS client's auth header (REST's session key is the
+        ``Authorization`` header), so a concurrent test can't consume the
+        override and a stale one can't bleed across tests.
+        """
+        url = f"{self.url}/__mock__/scenarios/{endpoint_id}"
+        if self.auth_header:
+            url = f"{url}?session_id={quote(self.auth_header, safe='')}"
+        resp = requests.post(url, json={"status": status, "response": response}, timeout=5)
+        resp.raise_for_status()
 
 
 @pytest.fixture
-def mock(_mock_server_instance):
-    """Test-facing harness around the mock server.
+def mock():
+    """Test-facing harness around the shared mock server (unscoped view).
 
-    Starts empty (journal + scenarios) before every test.
+    Most tests use the scoped view via ``signalwire_client`` instead; this bare
+    fixture is the underlying handle (the ``signalwire_client`` fixture scopes
+    its returned ``mock`` to the client's auth header).
     """
-    harness = _MockHarness(_mock_server_instance)
-    harness.reset()
-    yield harness
+    shared = _SHARED.ensure()
+    return _MockHarness(shared.url, shared.port)
 
 
 @pytest.fixture
 def signalwire_client(mock, monkeypatch):
-    """A real ``RestClient`` whose HTTP transport hits the local mock.
+    """A real ``RestClient`` whose HTTP transport hits the shared mock.
 
-    Patches ``HttpClient.__init__`` to overwrite the ``_base_url`` field
-    immediately after the client is built so the connection hits
-    ``http://127.0.0.1:<port>`` rather than ``https://<host>``.  The yield
-    expression is a bare ``RestClient(...)`` constructor call so the static
-    coverage audit (porting-sdk/scripts/audit_python_test_coverage.py)
-    resolves ``signalwire_client`` to the ``RestClient`` class.
+    Each client authenticates with the constant project ``test_proj`` and a
+    unique random token (``test_tok_<12 hex>``), so its Basic-Auth header is
+    unique while the LAML ``Accounts/test_proj/...`` paths stay stable.  The
+    ``mock`` fixture handed to the same test is scoped to that header, so the
+    test reads only its own journal entries — making the shared mock safe under
+    ``pytest -n auto`` with no SDK change and no mock-server change.  Random
+    (not a counter) so concurrent xdist workers can't collide on the same token.
+
+    Patches ``HttpClient.__init__`` to overwrite ``_base_url`` immediately after
+    the client is built so the connection hits ``http://127.0.0.1:<port>``
+    rather than ``https://<host>`` (the SDK always prepends ``https://``; this
+    only rewrites the URL, exactly like the frozen TS reference passes an
+    ``http://`` host).  The yield expression is a bare ``RestClient(...)``
+    constructor call so the static coverage audit resolves ``signalwire_client``
+    to the ``RestClient`` class.
     """
+    token = f"test_tok_{uuid.uuid4().hex[:12]}"
+    auth_header = "Basic " + base64.b64encode(
+        f"{_REST_PROJECT}:{token}".encode()
+    ).decode()
+
+    # Scope the harness view to this client's auth header.
+    mock.project = _REST_PROJECT
+    mock.auth_header = auth_header
+
     original_init = HttpClient.__init__
 
     def _patched_init(self, project, token, host):
@@ -252,7 +421,7 @@ def signalwire_client(mock, monkeypatch):
     monkeypatch.setattr(HttpClient, "__init__", _patched_init)
 
     yield RestClient(
-        project="test_proj",
-        token="test_tok",
+        project=_REST_PROJECT,
+        token=token,
         host=f"127.0.0.1:{mock.port}",
     )

--- a/tests/unit/rest/test_pagination_mock.py
+++ b/tests/unit/rest/test_pagination_mock.py
@@ -13,8 +13,6 @@ following the ``links.next`` cursor. We test it end-to-end by:
 
 from __future__ import annotations
 
-import requests
-
 from signalwire.rest._pagination import PaginatedIterator
 
 
@@ -26,12 +24,12 @@ _FABRIC_ADDRESSES_ENDPOINT_ID = "fabric.list_fabric_addresses"
 
 
 def _push_scenario(mock, endpoint_id: str, status: int, response: dict) -> None:
-    """Push one consume-once scenario via the mock control plane."""
-    r = requests.post(
-        f"{mock.url}/__mock__/scenarios/{endpoint_id}",
-        json={"status": status, "response": response},
-    )
-    r.raise_for_status()
+    """Push one consume-once scenario, scoped to THIS client's auth header.
+
+    Scoping (``mock.push_scenario`` -> ``?session_id=<auth header>``) keeps a
+    concurrent test from consuming this override under ``pytest -n auto``.
+    """
+    mock.push_scenario(endpoint_id, status, response)
 
 
 class TestPaginatedIterator:
@@ -70,7 +68,11 @@ class TestPaginatedIterator:
         assert mock.journal == []
 
     def test_next_pages_through_all_items(self, signalwire_client, mock):
-        """Walks two pages and stops on the page without ``links.next``."""
+        """Walks two pages and stops on the page without ``links.next``.
+
+        A fresh per-test client starts with an empty (auth-scoped) journal and
+        scenario queue, so we stage the two pages exactly once — no reset dance.
+        """
         # Page 1 — has a next cursor.
         _push_scenario(
             mock, _FABRIC_ADDRESSES_ENDPOINT_ID,
@@ -84,31 +86,6 @@ class TestPaginatedIterator:
             },
         )
         # Page 2 — terminal (no next).
-        _push_scenario(
-            mock, _FABRIC_ADDRESSES_ENDPOINT_ID,
-            status=200,
-            response={
-                "data": [
-                    {"id": "addr-3", "name": "third"},
-                ],
-                "links": {},
-            },
-        )
-
-        # Reset journal so only our paginated fetches are recorded.
-        mock.reset()
-        # Re-stage scenarios after reset (reset() clears scenarios too).
-        _push_scenario(
-            mock, _FABRIC_ADDRESSES_ENDPOINT_ID,
-            status=200,
-            response={
-                "data": [
-                    {"id": "addr-1", "name": "first"},
-                    {"id": "addr-2", "name": "second"},
-                ],
-                "links": {"next": "http://example.com/api/fabric/addresses?cursor=page2"},
-            },
-        )
         _push_scenario(
             mock, _FABRIC_ADDRESSES_ENDPOINT_ID,
             status=200,


### PR DESCRIPTION
## What

Bring signalwire-python's *own* real-mock-backed test suites to full parity
with the ports: **shared mock server, session-isolated, parallel-safe under
`pytest -n auto`** — mirroring the frozen TypeScript reference harnesses
`tests/relay/mocktest.ts` + `tests/rest/mocktest.ts`. **Test-infra only.**

Before: the `signalwire_client`/`mock` (REST) and `signalwire_relay_client`/
`mock_relay` (RELAY) fixtures booted an **in-process, per-worker** mock with a
**global per-test `reset()`** — fine serially, not the shared-mock +
session-scoping model the ports use.

After: ONE shared mock per default port, found by **adjacency discovery**
(walk up to `porting-sdk/test_harness/<name>/`, ignores `$PORTING_SDK`) and
**probe-or-spawn** (first xdist worker spawns; the rest probe and reuse), with
**per-test session-scoped harness views**.

## How (mirrors mocktest.ts)

- **REST** — REST is pure request/response (no handshake). Each
  `signalwire_client` keeps the constant project `test_proj` (so the LAML
  `Accounts/test_proj/...` paths the compat tests assert on stay stable) and a
  **unique random token** `test_tok_<12 hex>` → unique `Authorization: Basic`
  header. `mock` filters the shared global journal by that header (lowercased
  `authorization`); scoped `reset()` is a **no-op**; `push_scenario` scopes the
  override via `?session_id=<auth header>`.
- **RELAY** — scope by the handshake **`sessionid`** (NO underscore — the mock
  ConnectResult key; the wrong key would make scoping a silent no-op). The SDK
  now captures it into a **private** `client._session_id`
  (`result.get("sessionid", ...)`); the real server omits it so production is
  unaffected. `signalwire_relay_client` scopes its `mock_relay` view to that
  session: `journal*/push/inbound_call/arm_*/scenario_play` only touch this
  test's session, `reset()` is a no-op. Own-client tests (reconnect / jwt /
  no-handler / dial-by-tag) target/filter by their own session or a unique
  value so they never broadcast to or read another worker's session.

## What was intentionally NOT migrated

The transport-double unit suites stay as-is because the **frozen reference
keeps its own equivalents**:

| Python (kept) | Frozen TS reference equivalent (kept) |
|---|---|
| rest/`test_base.py` (`requests.Session` mock) | `HttpClient.test.ts` (`createMockFetch`) |
| rest/`test_calling.py`, `test_phone_numbers.py`, `test_fabric.py`, `test_client.py`, `test_namespaces.py` | `calling.test.ts`, `phoneNumbers.test.ts`, `fabric.test.ts`, `client.test.ts` (`mockClientOptions`) |
| relay/`test_client.py`, `test_message.py` (`MockWebSocket`) | `helpers.ts` `MockWebSocket` + `RelayClient.test.ts`, `Message.test.ts` |

These cover transport-contract plumbing (exact method/URL/json for synthetic
paths the spec mock would 404) and resilience mechanics (reconnect backoff,
ping-failure backoff, recv-loop faults, queue overflow, force-close, half-open)
a conformant mock can't reproduce. Converting them would diverge **from** the
reference, not toward it.

## Oracle

`python_signatures.json` and `python_surface.json` regenerate **byte-identical**
(`_session_id` is private → invisible to both). No public surface change.

## Verify

- `bash scripts/run-ci.sh` → TEST / SIGNATURES / DRIFT / NO-CHEAT all PASS.
- Full unit suite: 5246 passed, 3 skipped.
- rest+relay under `pytest -n auto` (8 workers) + 2 background `yes` CPU-load
  procs: **6 runs, 755 passed each, zero failures, deterministic**.

NEVER MERGE — for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ab1ghK8PCd2PzW79nzsAqT
