### PR TITLE
chore(lint): enable ruff pyupgrade (UP) — py3.10+ modernization + gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ line-length = 88
 # E4/E7/E9 + F are the ruff defaults (E501 line-length intentionally excluded —
 # formatting is owned by `ruff format`, not the linter). B = flake8-bugbear
 # (likely-bug patterns), S = flake8-bandit (security smells).
-select = ["E4", "E7", "E9", "F", "B", "S", "C4", "PERF", "SIM", "PTH", "RET", "RUF"]
+select = ["E4", "E7", "E9", "F", "B", "S", "C4", "PERF", "SIM", "PTH", "RET", "RUF", "UP"]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests are built on assert; bandit's S101 is noise there.

--- a/signalwire/signalwire/agent_server.py
+++ b/signalwire/signalwire/agent_server.py
@@ -12,7 +12,8 @@ AgentServer - Class for hosting multiple SignalWire AI Agents in a single server
 import os
 import re
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Callable
+from typing import Any
+from collections.abc import Callable
 
 try:
     from fastapi import FastAPI, Request, Response
@@ -88,12 +89,12 @@ class AgentServer:
             return response
 
         # Keep track of registered agents
-        self.agents: Dict[str, AgentBase] = {}
+        self.agents: dict[str, AgentBase] = {}
 
         # Keep track of SIP routing configuration
         self._sip_routing_enabled = False
-        self._sip_route: Optional[str] = None
-        self._sip_username_mapping: Dict[str, str] = {}  # Maps SIP usernames to routes
+        self._sip_route: str | None = None
+        self._sip_username_mapping: dict[str, str] = {}  # Maps SIP usernames to routes
 
         # Register health endpoints immediately so they're available
         # whether using server.run() or server.app with gunicorn
@@ -106,7 +107,7 @@ class AgentServer:
         async def _setup_catch_all():
             self._register_catch_all_handler()
 
-    def register(self, agent: AgentBase, route: Optional[str] = None) -> None:
+    def register(self, agent: AgentBase, route: str | None = None) -> None:
         """
         Register an agent with the server
 
@@ -188,8 +189,8 @@ class AgentServer:
 
         # Create a unified routing callback that checks all registered usernames
         def server_sip_routing_callback(
-            request: Request, body: Dict[str, Any]
-        ) -> Optional[str]:
+            request: Request, body: dict[str, Any]
+        ) -> str | None:
             """Unified SIP routing callback that checks all registered usernames"""
             # Extract the SIP username
             sip_username = SWMLService.extract_sip_username(body)
@@ -248,7 +249,7 @@ class AgentServer:
         self._sip_username_mapping[username.lower()] = route
         self.logger.info(f"Registered SIP username '{username}' to route '{route}'")
 
-    def _lookup_sip_route(self, username: str) -> Optional[str]:
+    def _lookup_sip_route(self, username: str) -> str | None:
         """
         Look up the route for a SIP username
 
@@ -313,7 +314,7 @@ class AgentServer:
         self.logger.info("agent_unregistered", extra={"route": route})
         return True
 
-    def get_agents(self) -> List[Tuple[str, AgentBase]]:
+    def get_agents(self) -> list[tuple[str, AgentBase]]:
         """
         Get all registered agents
 
@@ -322,7 +323,7 @@ class AgentServer:
         """
         return [(route, agent) for route, agent in self.agents.items()]
 
-    def get_agent(self, route: str) -> Optional[AgentBase]:
+    def get_agent(self, route: str) -> AgentBase | None:
         """
         Get an agent by route
 
@@ -344,8 +345,8 @@ class AgentServer:
         self,
         event=None,
         context=None,
-        host: Optional[str] = None,
-        port: Optional[int] = None,
+        host: str | None = None,
+        port: int | None = None,
     ) -> Any:
         """
         Universal run method that automatically detects environment and handles accordingly
@@ -644,9 +645,7 @@ class AgentServer:
         def readiness_check():
             return {"status": "ready", "agents": len(self.agents)}
 
-    def _run_server(
-        self, host: Optional[str] = None, port: Optional[int] = None
-    ) -> None:
+    def _run_server(self, host: str | None = None, port: int | None = None) -> None:
         """Original server mode logic"""
         if not self.agents:
             self.logger.warning("Starting server with no registered agents")
@@ -710,7 +709,7 @@ class AgentServer:
             uvicorn.run(self.app, host=host, port=port, log_level=self.log_level)
 
     def register_global_routing_callback(
-        self, callback_fn: Callable[[Request, Dict[str, Any]], Optional[str]], path: str
+        self, callback_fn: Callable[[Request, dict[str, Any]], str | None], path: str
     ) -> None:
         """
         Register a routing callback across all agents
@@ -781,9 +780,7 @@ class AgentServer:
             f"Serving static files from '{directory}' at route '{route or '/'}'"
         )
 
-    def _serve_static_file(
-        self, file_path: str, route: str = "/"
-    ) -> Optional[Response]:
+    def _serve_static_file(self, file_path: str, route: str = "/") -> Response | None:
         """
         Internal method to serve a static file.
 

--- a/signalwire/signalwire/agents/bedrock.py
+++ b/signalwire/signalwire/agents/bedrock.py
@@ -14,7 +14,7 @@ with all SignalWire agent features like skills, POM, and SWAIG functions.
 """
 
 import json
-from typing import Dict, Any, Optional
+from typing import Any
 from signalwire.core.agent_base import AgentBase
 from signalwire.core.logging_config import get_logger
 
@@ -41,7 +41,7 @@ class BedrockAgent(AgentBase):
         self,
         name: str = "bedrock_agent",
         route: str = "/bedrock",
-        system_prompt: Optional[str] = None,
+        system_prompt: str | None = None,
         voice_id: str = "matthew",
         temperature: float = 0.7,
         top_p: float = 0.9,
@@ -77,7 +77,7 @@ class BedrockAgent(AgentBase):
         logger.info(f"BedrockAgent initialized: {name} on route {route}")
 
     def _render_swml(
-        self, call_id: Optional[str] = None, modifications: Optional[dict] = None
+        self, call_id: str | None = None, modifications: dict | None = None
     ) -> str:
         """
         Render SWML document with amazon_bedrock verb
@@ -143,7 +143,7 @@ class BedrockAgent(AgentBase):
         # Convert back to JSON string
         return json.dumps(swml)
 
-    def _add_voice_to_prompt(self, prompt_config: Dict[str, Any]) -> Dict[str, Any]:
+    def _add_voice_to_prompt(self, prompt_config: dict[str, Any]) -> dict[str, Any]:
         """
         Add voice configuration to the prompt object
 
@@ -176,7 +176,7 @@ class BedrockAgent(AgentBase):
 
         return filtered_config
 
-    def _build_bedrock_params(self, base_params: Dict[str, Any]) -> Dict[str, Any]:
+    def _build_bedrock_params(self, base_params: dict[str, Any]) -> dict[str, Any]:
         """
         Build Bedrock-specific parameters
 
@@ -214,9 +214,9 @@ class BedrockAgent(AgentBase):
 
     def set_inference_params(
         self,
-        temperature: Optional[float] = None,
-        top_p: Optional[float] = None,
-        max_tokens: Optional[int] = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        max_tokens: int | None = None,
     ) -> None:
         """
         Update Bedrock inference parameters

--- a/signalwire/signalwire/cli/build_search.py
+++ b/signalwire/signalwire/cli/build_search.py
@@ -11,7 +11,7 @@ import argparse
 import sys
 from pathlib import Path
 from datetime import datetime
-from typing import List, cast
+from typing import cast
 from urllib.parse import urlparse, urlunparse
 
 from signalwire.search.models import MODEL_ALIASES, DEFAULT_MODEL, resolve_model_alias
@@ -866,9 +866,7 @@ def search_command():
                         print("  help           - Show this help")
                         print("  exit/quit/q    - Exit shell")
                         print(
-                            "  count=N        - Set result count (current: {})".format(
-                                args.count
-                            )
+                            f"  count=N        - Set result count (current: {args.count})"
                         )
                         print(
                             "  tags=tag1,tag2 - Set tag filter (current: {})".format(
@@ -927,7 +925,7 @@ def search_command():
                     # Perform search
                     results = engine.search(
                         query_vector=cast(
-                            List[float], enhanced.get("vector")
+                            list[float], enhanced.get("vector")
                         ),  # vector is None for keyword-only search; search() tolerates it at runtime
                         enhanced_text=enhanced.get("enhanced_text", query),
                         count=args.count,
@@ -1012,7 +1010,7 @@ def search_command():
         # Perform search
         results = engine.search(
             query_vector=cast(
-                List[float], enhanced.get("vector")
+                list[float], enhanced.get("vector")
             ),  # vector is None for keyword-only search; search() tolerates it at runtime
             enhanced_text=enhanced.get("enhanced_text", args.query),
             count=args.count,

--- a/signalwire/signalwire/cli/core/agent_loader.py
+++ b/signalwire/signalwire/cli/core/agent_loader.py
@@ -12,7 +12,7 @@ Agent discovery and loading functionality
 
 import importlib.util
 from pathlib import Path
-from typing import List, Dict, Any, Optional, cast, Type, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 
 # Import after checking if available
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ else:
         NEW_LOADER_AVAILABLE = False
 
 
-def discover_services_in_file(service_path: str) -> List[Dict[str, Any]]:
+def discover_services_in_file(service_path: str) -> list[dict[str, Any]]:
     """
     Discover all available SWML services (including agents) in a Python file without instantiating them
 
@@ -74,7 +74,7 @@ def discover_services_in_file(service_path: str) -> List[Dict[str, Any]]:
     return _discover_services_impl(service_path)
 
 
-def discover_agents_in_file(agent_path: str) -> List[Dict[str, Any]]:
+def discover_agents_in_file(agent_path: str) -> list[dict[str, Any]]:
     """
     Backward compatibility wrapper - discovers agents in a file
 
@@ -89,7 +89,7 @@ def discover_agents_in_file(agent_path: str) -> List[Dict[str, Any]]:
     return [s for s in all_services if s.get("is_agent", False)]
 
 
-def _discover_services_impl(service_path: str) -> List[Dict[str, Any]]:
+def _discover_services_impl(service_path: str) -> list[dict[str, Any]]:
     """
     Internal implementation for discovering services
     """
@@ -130,7 +130,7 @@ def _discover_services_impl(service_path: str) -> List[Dict[str, Any]]:
         if sys_path_added and module_dir in sys.path:
             sys.path.remove(module_dir)
 
-    services_found: List[Dict[str, Any]] = []
+    services_found: list[dict[str, Any]] = []
 
     # Look for SWMLService instances (including AgentBase which inherits from it)
     for name, obj in vars(module).items():
@@ -198,7 +198,7 @@ def _discover_services_impl(service_path: str) -> List[Dict[str, Any]]:
 
 def load_service_from_file(
     service_path: str,
-    service_identifier: Optional[str] = None,
+    service_identifier: str | None = None,
     prefer_route: bool = True,
 ) -> "SWMLService":
     """
@@ -226,7 +226,7 @@ def load_service_from_file(
 
 
 def load_agent_from_file(
-    agent_path: str, agent_class_name: Optional[str] = None
+    agent_path: str, agent_class_name: str | None = None
 ) -> "AgentBase":
     """
     Load an agent from a Python file
@@ -271,7 +271,7 @@ def load_agent_from_file(
 
 def _load_service_impl(
     service_path: str,
-    service_identifier: Optional[str] = None,
+    service_identifier: str | None = None,
     prefer_route: bool = True,
 ) -> "SWMLService":
     """
@@ -340,7 +340,7 @@ def _load_service_impl(
                     try:
                         # Discovered subclasses define their own (often no-arg)
                         # constructors; cast away the abstract base signature.
-                        temp_instance = cast(Type[Any], obj)()
+                        temp_instance = cast(type[Any], obj)()
                         if (
                             hasattr(temp_instance, "route")
                             and temp_instance.route == service_identifier
@@ -356,7 +356,7 @@ def _load_service_impl(
             obj = getattr(module, service_identifier)
             if isinstance(obj, type) and issubclass(obj, SWMLService):
                 try:
-                    service = cast(Type[Any], obj)()
+                    service = cast(type[Any], obj)()
                 except Exception as e:
                     raise ValueError(
                         f"No service found with route '{service_identifier}' and failed to instantiate class '{service_identifier}': {e}"
@@ -373,14 +373,14 @@ def _load_service_impl(
             obj = getattr(module, service_identifier)
             if isinstance(obj, type) and issubclass(obj, SWMLService):
                 try:
-                    service = cast(Type[Any], obj)()
+                    service = cast(type[Any], obj)()
                     if service and not service.route.endswith(
                         "dummy"
                     ):  # Avoid test services with dummy routes
                         pass  # Successfully created specific service
                     else:
                         service = cast(
-                            Type[Any], obj
+                            type[Any], obj
                         )()  # Create anyway if requested specifically
                 except Exception as e:
                     raise ValueError(
@@ -443,7 +443,7 @@ def _load_service_impl(
 
         if len(service_classes_found) == 1:
             try:
-                service = cast(Type[Any], service_classes_found[0][1])()
+                service = cast(type[Any], service_classes_found[0][1])()
             except Exception as e:
                 print(
                     f"Warning: Failed to instantiate {service_classes_found[0][0]}: {e}"
@@ -454,7 +454,7 @@ def _load_service_impl(
             for name, cls in service_classes_found:
                 try:
                     # Try to instantiate temporarily to get route
-                    temp_instance = cast(Type[Any], cls)()
+                    temp_instance = cast(type[Any], cls)()
                     route = getattr(temp_instance, "route", "Unknown")
                     service_name = getattr(temp_instance, "name", "Unknown")
                     service_info.append(
@@ -496,7 +496,7 @@ def _load_service_impl(
                     and obj not in (SWMLService, AgentBase)
                 ):
                     try:
-                        service = cast(Type[Any], obj)()
+                        service = cast(type[Any], obj)()
                         break
                     except Exception as e:
                         print(f"Warning: Failed to instantiate {name}: {e}")

--- a/signalwire/signalwire/cli/core/argparse_helpers.py
+++ b/signalwire/signalwire/cli/core/argparse_helpers.py
@@ -12,7 +12,7 @@ Custom argument parsing and function argument parsing
 
 import sys
 import argparse
-from typing import List, Dict, Any
+from typing import Any
 
 
 class CustomArgumentParser(argparse.ArgumentParser):
@@ -82,8 +82,8 @@ class CustomArgumentParser(argparse.ArgumentParser):
 
 
 def parse_function_arguments(
-    function_args_list: List[str], func_schema: Any
-) -> Dict[str, Any]:
+    function_args_list: list[str], func_schema: Any
+) -> dict[str, Any]:
     """
     Parse function arguments from command line with type coercion based on schema
 
@@ -94,7 +94,7 @@ def parse_function_arguments(
     Returns:
         Dictionary of parsed function arguments
     """
-    parsed_args: Dict[str, Any] = {}
+    parsed_args: dict[str, Any] = {}
     i = 0
 
     # Get parameter schema

--- a/signalwire/signalwire/cli/core/dynamic_config.py
+++ b/signalwire/signalwire/cli/core/dynamic_config.py
@@ -10,7 +10,7 @@ See LICENSE file in the project root for full license information.
 Apply dynamic configuration to agents
 """
 
-from typing import Optional, Dict, Any, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from signalwire.core.agent_base import AgentBase
@@ -47,7 +47,7 @@ def apply_dynamic_config(
 
             # Extract request data
             query_params = dict(mock_request.query_params)
-            body_params: Dict[str, Any] = {}  # Empty for GET requests
+            body_params: dict[str, Any] = {}  # Empty for GET requests
             headers = dict(mock_request.headers)
 
             if verbose:

--- a/signalwire/signalwire/cli/core/service_loader.py
+++ b/signalwire/signalwire/cli/core/service_loader.py
@@ -12,7 +12,7 @@ Service discovery and loading functionality - new simplified approach
 
 import importlib.util
 from pathlib import Path
-from typing import List, Dict, Any, Optional, cast, TYPE_CHECKING
+from typing import Any, cast, TYPE_CHECKING
 import asyncio
 import io
 import contextlib
@@ -45,12 +45,12 @@ class ServiceCapture:
     """Captures SWMLService instances when they try to run/serve"""
 
     def __init__(self):
-        self.captured_services: List[SWMLService] = []
+        self.captured_services: list[SWMLService] = []
         self.original_methods = {}
 
     def capture(
         self, service_path: str, suppress_output: bool = False
-    ) -> List[SWMLService]:
+    ) -> list[SWMLService]:
         """
         Execute a service file and capture any services that try to run
 
@@ -156,9 +156,9 @@ class ServiceCapture:
 async def simulate_request_to_service(
     service: SWMLService,
     method: str = "POST",
-    body: Optional[dict] = None,
-    query_params: Optional[dict] = None,
-    headers: Optional[dict] = None,
+    body: dict | None = None,
+    query_params: dict | None = None,
+    headers: dict | None = None,
 ) -> dict:
     """
     Simulate a request to a SWMLService instance
@@ -204,11 +204,11 @@ async def simulate_request_to_service(
 
 def load_and_simulate_service(
     service_path: str,
-    route: Optional[str] = None,
+    route: str | None = None,
     method: str = "POST",
-    body: Optional[dict] = None,
-    query_params: Optional[dict] = None,
-    headers: Optional[dict] = None,
+    body: dict | None = None,
+    query_params: dict | None = None,
+    headers: dict | None = None,
     suppress_output: bool = False,
 ) -> dict:
     """
@@ -277,7 +277,7 @@ def load_and_simulate_service(
 # Backward compatibility
 def load_agent_from_file(
     agent_path: str,
-    agent_class_name: Optional[str] = None,
+    agent_class_name: str | None = None,
     suppress_output: bool = False,
 ) -> "AgentBase":
     """
@@ -308,7 +308,7 @@ def load_agent_from_file(
     return agents[0]
 
 
-def discover_agents_in_file(agent_path: str) -> List[Dict[str, Any]]:
+def discover_agents_in_file(agent_path: str) -> list[dict[str, Any]]:
     """
     Backward compatibility wrapper
     """

--- a/signalwire/signalwire/cli/dokku.py
+++ b/signalwire/signalwire/cli/dokku.py
@@ -23,7 +23,7 @@ import secrets
 import argparse
 import shutil
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any
 
 
 # =============================================================================
@@ -1814,7 +1814,7 @@ swaig-test app.py --list-tools
 class DokkuProjectGenerator:
     """Generates Dokku deployment files for SignalWire agents."""
 
-    def __init__(self, app_name: str, options: Dict[str, Any]):
+    def __init__(self, app_name: str, options: dict[str, Any]):
         self.app_name = app_name
         self.options = options
         self.project_dir = Path(options.get("project_dir", f"./{app_name}"))

--- a/signalwire/signalwire/cli/execution/datamap_exec.py
+++ b/signalwire/signalwire/cli/execution/datamap_exec.py
@@ -13,11 +13,11 @@ DataMap function execution and template expansion
 import re
 import json
 import requests
-from typing import Dict, Any
+from typing import Any
 from ..config import HTTP_REQUEST_TIMEOUT
 
 
-def simple_template_expand(template: str, data: Dict[str, Any]) -> str:
+def simple_template_expand(template: str, data: dict[str, Any]) -> str:
     """
     Simple template expansion for DataMap testing
     Supports both ${key} and %{key} syntax with nested object access and array indexing
@@ -120,7 +120,7 @@ def simple_template_expand(template: str, data: Dict[str, Any]) -> str:
 
 
 def execute_datamap_function(
-    datamap_config: Dict[str, Any], args: Dict[str, Any], verbose: bool = False
+    datamap_config: dict[str, Any], args: dict[str, Any], verbose: bool = False
 ) -> Any:
     """
     Execute a DataMap function following the actual DataMap processing pipeline:
@@ -151,7 +151,7 @@ def execute_datamap_function(
         print(f"Extracted data_map: {json.dumps(actual_datamap, indent=2)}")
 
     # Initialize context with function arguments
-    context: Dict[str, Any] = {"args": args}
+    context: dict[str, Any] = {"args": args}
     context.update(
         args
     )  # Also make args available at top level for backward compatibility

--- a/signalwire/signalwire/cli/execution/webhook_exec.py
+++ b/signalwire/signalwire/cli/execution/webhook_exec.py
@@ -12,7 +12,7 @@ Webhook function execution (including external)
 
 import json
 import requests
-from typing import Dict, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from ..config import HTTP_REQUEST_TIMEOUT
 
 if TYPE_CHECKING:
@@ -22,10 +22,10 @@ if TYPE_CHECKING:
 def execute_external_webhook_function(
     func: "SWAIGFunction",
     function_name: str,
-    function_args: Dict[str, Any],
-    post_data: Dict[str, Any],
+    function_args: dict[str, Any],
+    post_data: dict[str, Any],
     verbose: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Execute an external webhook SWAIG function by making an HTTP request to the external service.
     This simulates what SignalWire would do when calling an external webhook function.
@@ -51,7 +51,7 @@ def execute_external_webhook_function(
         print("-" * 60)
 
     # Prepare the SWAIG function call payload that SignalWire would send
-    swaig_payload: Dict[str, Any] = {
+    swaig_payload: dict[str, Any] = {
         "function": function_name,
         "argument": {
             "parsed": [function_args] if function_args else [{}],

--- a/signalwire/signalwire/cli/init_project.py
+++ b/signalwire/signalwire/cli/init_project.py
@@ -15,7 +15,7 @@ import sys
 import secrets
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Any
 
 
 # Cloud platform options
@@ -79,7 +79,7 @@ def prompt_yes_no(question: str, default: bool = True) -> bool:
     return result in ("y", "yes")
 
 
-def prompt_select(question: str, options: List[str], default: int = 1) -> int:
+def prompt_select(question: str, options: list[str], default: int = 1) -> int:
     """Prompt user to select from numbered options. Returns 1-based index."""
     print(f"\n{question}")
     for i, opt in enumerate(options, 1):
@@ -98,8 +98,8 @@ def prompt_select(question: str, options: List[str], default: int = 1) -> int:
 
 
 def prompt_multiselect(
-    question: str, options: List[str], defaults: List[bool]
-) -> List[bool]:
+    question: str, options: list[str], defaults: list[bool]
+) -> list[bool]:
     """Prompt user to toggle multiple options. Returns list of booleans."""
     selected = defaults.copy()
 
@@ -128,7 +128,7 @@ def mask_token(token: str) -> str:
     return f"{token[:4]}...{token[-3:]}"
 
 
-def get_env_credentials() -> Dict[str, str]:
+def get_env_credentials() -> dict[str, str]:
     """Get SignalWire credentials from environment variables."""
     return {
         "space": os.environ.get("SIGNALWIRE_SPACE_NAME", ""),
@@ -1175,7 +1175,7 @@ echo ""
 """
 
 
-def get_agent_template(agent_type: str, features: Dict[str, bool]) -> str:
+def get_agent_template(agent_type: str, features: dict[str, bool]) -> str:
     """Generate the main agent template based on type and features."""
 
     has_tool = features.get("example_tool", True)
@@ -1327,7 +1327,7 @@ class MainAgent(AgentBase):
 '''
 
 
-def get_app_template(features: Dict[str, bool]) -> str:
+def get_app_template(features: dict[str, bool]) -> str:
     """Generate the app.py template based on features."""
 
     has_debug = features.get("debug_webhooks", False)
@@ -1656,7 +1656,7 @@ if __name__ == "__main__":
 '''
 
 
-def get_readme_template(project_name: str, features: Dict[str, bool]) -> str:
+def get_readme_template(project_name: str, features: dict[str, bool]) -> str:
     """Generate README template."""
 
     endpoints = [
@@ -1859,7 +1859,7 @@ pytest tests/ -v</pre>
 class ProjectGenerator:
     """Generates a new SignalWire agent project."""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         self.config = config
         self.project_dir = Path(config["project_dir"])
         self.project_name = config["project_name"]
@@ -2031,7 +2031,7 @@ class ProjectGenerator:
 
         return True
 
-    def _get_template_vars(self) -> Dict[str, str]:
+    def _get_template_vars(self) -> dict[str, str]:
         """Get template variables for cloud function templates."""
         # Convert project name to various formats
         agent_name = self.project_name
@@ -2422,7 +2422,7 @@ DEBUG_WEBHOOK_LEVEL=1
 # =============================================================================
 
 
-def run_interactive() -> Dict[str, Any]:
+def run_interactive() -> dict[str, Any]:
     """Run interactive prompts and return configuration."""
     print(f"\n{Colors.BOLD}{Colors.CYAN}Welcome to SignalWire Agent Init!{Colors.NC}\n")
 
@@ -2556,7 +2556,7 @@ def run_interactive() -> Dict[str, Any]:
     }
 
 
-def run_quick(project_name: str, args: Any) -> Dict[str, Any]:
+def run_quick(project_name: str, args: Any) -> dict[str, Any]:
     """Run in quick mode with minimal prompts."""
     project_dir = str(Path(project_name).absolute())
 

--- a/signalwire/signalwire/cli/simulation/data_generation.py
+++ b/signalwire/signalwire/cli/simulation/data_generation.py
@@ -13,7 +13,7 @@ Generate fake SWML post_data and related helpers
 import uuid
 import json
 from datetime import datetime
-from typing import Dict, Any, Optional
+from typing import Any
 
 
 def generate_fake_uuid() -> str:
@@ -42,7 +42,7 @@ def generate_fake_sip_to(call_type: str) -> str:
     return f"agent-{uuid.uuid4().hex[:8]}@test.domain"
 
 
-def adapt_for_call_type(call_data: Dict[str, Any], call_type: str) -> Dict[str, Any]:
+def adapt_for_call_type(call_data: dict[str, Any], call_type: str) -> dict[str, Any]:
     """
     Adapt call data structure based on call type (sip vs webrtc)
 
@@ -83,7 +83,7 @@ def generate_fake_swml_post_data(
     call_type: str = "webrtc",
     call_direction: str = "inbound",
     call_state: str = "created",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Generate fake SWML post_data that matches real SignalWire structure
 
@@ -139,9 +139,9 @@ def generate_fake_swml_post_data(
 
 def generate_comprehensive_post_data(
     function_name: str,
-    args: Dict[str, Any],
-    custom_data: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    args: dict[str, Any],
+    custom_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """
     Generate comprehensive post_data that matches what SignalWire would send
 
@@ -163,7 +163,7 @@ def generate_comprehensive_post_data(
     current_time = datetime.now().isoformat()
 
     # Base structure with all keys
-    post_data: Dict[str, Any] = {
+    post_data: dict[str, Any] = {
         "call_id": call_id,
         "call": {
             "call_id": call_id,
@@ -333,8 +333,8 @@ def generate_comprehensive_post_data(
 
 
 def generate_minimal_post_data(
-    function_name: str, args: Dict[str, Any]
-) -> Dict[str, Any]:
+    function_name: str, args: dict[str, Any]
+) -> dict[str, Any]:
     """
     Generate minimal post_data with only essential keys
 

--- a/signalwire/signalwire/cli/simulation/data_overrides.py
+++ b/signalwire/signalwire/cli/simulation/data_overrides.py
@@ -13,10 +13,10 @@ Handle CLI overrides and mapping to nested data
 import json
 import uuid
 import argparse
-from typing import Dict, Any, List
+from typing import Any
 
 
-def set_nested_value(data: Dict[str, Any], path: str, value: Any) -> None:
+def set_nested_value(data: dict[str, Any], path: str, value: Any) -> None:
     """
     Set a nested value using dot notation path
 
@@ -75,8 +75,8 @@ def parse_value(value_str: str) -> Any:
 
 
 def apply_overrides(
-    data: Dict[str, Any], overrides: List[str], json_overrides: List[str]
-) -> Dict[str, Any]:
+    data: dict[str, Any], overrides: list[str], json_overrides: list[str]
+) -> dict[str, Any]:
     """
     Apply override values to data using dot notation paths
 
@@ -113,8 +113,8 @@ def apply_overrides(
 
 
 def apply_convenience_mappings(
-    data: Dict[str, Any], args: argparse.Namespace
-) -> Dict[str, Any]:
+    data: dict[str, Any], args: argparse.Namespace
+) -> dict[str, Any]:
     """
     Apply convenience CLI arguments to data structure
 

--- a/signalwire/signalwire/cli/simulation/mock_env.py
+++ b/signalwire/signalwire/cli/simulation/mock_env.py
@@ -13,16 +13,16 @@ Mock environment and serverless simulation functionality
 import os
 import json
 from pathlib import Path
-from typing import Optional, Dict, Any, ClassVar, List
+from typing import Any, ClassVar
 
 
 class MockQueryParams:
     """Mock FastAPI QueryParams (simple dict-like)"""
 
-    def __init__(self, params: Optional[Dict[str, str]] = None):
+    def __init__(self, params: dict[str, str] | None = None):
         self._params = params or {}
 
-    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+    def get(self, key: str, default: str | None = None) -> str | None:
         return self._params.get(key, default)
 
     def __getitem__(self, key: str) -> str:
@@ -44,14 +44,14 @@ class MockQueryParams:
 class MockHeaders:
     """Mock FastAPI Headers (case-insensitive dict-like)"""
 
-    def __init__(self, headers: Optional[Dict[str, str]] = None):
+    def __init__(self, headers: dict[str, str] | None = None):
         # Store headers with lowercase keys for case-insensitive lookup
         self._headers = {}
         if headers:
             for k, v in headers.items():
                 self._headers[k.lower()] = v
 
-    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+    def get(self, key: str, default: str | None = None) -> str | None:
         return self._headers.get(key.lower(), default)
 
     def __getitem__(self, key: str) -> str:
@@ -105,9 +105,9 @@ class MockRequest:
         self,
         method: str = "POST",
         url: str = "http://localhost:8080/swml",
-        headers: Optional[Dict[str, str]] = None,
-        query_params: Optional[Dict[str, str]] = None,
-        json_body: Optional[Dict[str, Any]] = None,
+        headers: dict[str, str] | None = None,
+        query_params: dict[str, str] | None = None,
+        json_body: dict[str, Any] | None = None,
     ):
         self.method = method
         self.url = MockURL(url)
@@ -118,7 +118,7 @@ class MockRequest:
         # Add state object for request state (used by FastAPI)
         self.state = type("State", (), {})()
 
-    async def json(self) -> Dict[str, Any]:
+    async def json(self) -> dict[str, Any]:
         """Return the JSON body"""
         return self._json_body
 
@@ -134,9 +134,9 @@ class MockRequest:
 def create_mock_request(
     method: str = "POST",
     url: str = "http://localhost:8080/swml",
-    headers: Optional[Dict[str, str]] = None,
-    query_params: Optional[Dict[str, str]] = None,
-    body: Optional[Dict[str, Any]] = None,
+    headers: dict[str, str] | None = None,
+    query_params: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
 ) -> MockRequest:
     """
     Factory function to create a mock FastAPI Request object
@@ -154,7 +154,7 @@ class ServerlessSimulator:
     """Manages serverless environment simulation for different platforms"""
 
     # Default environment presets for each platform
-    PLATFORM_PRESETS: ClassVar[Dict[str, Dict[str, str]]] = {
+    PLATFORM_PRESETS: ClassVar[dict[str, dict[str, str]]] = {
         "lambda": {
             "AWS_LAMBDA_FUNCTION_NAME": "test-agent-function",
             "AWS_LAMBDA_FUNCTION_URL": "https://abc123.lambda-url.us-east-1.on.aws/",
@@ -181,13 +181,13 @@ class ServerlessSimulator:
         },
     }
 
-    def __init__(self, platform: str, overrides: Optional[Dict[str, str]] = None):
+    def __init__(self, platform: str, overrides: dict[str, str] | None = None):
         self.platform = platform
         self.original_env = dict(os.environ)
         self.preset_env = self.PLATFORM_PRESETS.get(platform, {}).copy()
         self.overrides = overrides or {}
         self.active = False
-        self._cleared_vars: Dict[str, str] = {}
+        self._cleared_vars: dict[str, str] = {}
 
     def activate(self, verbose: bool = False):
         """Apply serverless environment simulation"""
@@ -261,7 +261,7 @@ class ServerlessSimulator:
     def _clear_conflicting_env(self):
         """Clear environment variables that might conflict with simulation"""
         # Remove variables from other platforms
-        conflicting_vars: List[str] = []
+        conflicting_vars: list[str] = []
         for platform, preset in self.PLATFORM_PRESETS.items():
             if platform != self.platform:
                 conflicting_vars.extend(preset.keys())
@@ -281,14 +281,14 @@ class ServerlessSimulator:
         if self.active:
             os.environ[key] = value
 
-    def get_current_env(self) -> Dict[str, str]:
+    def get_current_env(self) -> dict[str, str]:
         """Get the current environment that would be applied"""
         env = self.preset_env.copy()
         env.update(self.overrides)
         return env
 
 
-def load_env_file(env_file_path: str) -> Dict[str, str]:
+def load_env_file(env_file_path: str) -> dict[str, str]:
     """Load environment variables from a file"""
     env_vars = {}
     if not Path(env_file_path).exists():

--- a/signalwire/signalwire/cli/test_swaig.py
+++ b/signalwire/signalwire/cli/test_swaig.py
@@ -23,7 +23,7 @@ if "--raw" in sys.argv or "--dump-swml" in sys.argv:
 import json
 import argparse
 from pathlib import Path
-from typing import Any, Dict, cast
+from typing import Any, cast
 
 # Import submodules
 from .config import (
@@ -745,7 +745,7 @@ def main():
 
                 # Execute DataMap function (is_datamap implies func is a dict)
                 result = execute_datamap_function(
-                    cast(Dict[str, Any], func), function_args, args.verbose
+                    cast(dict[str, Any], func), function_args, args.verbose
                 )
                 print("RESULT:")
                 print(format_result(result))

--- a/signalwire/signalwire/cli/types.py
+++ b/signalwire/signalwire/cli/types.py
@@ -10,7 +10,7 @@ See LICENSE file in the project root for full license information.
 Type definitions for the CLI tools
 """
 
-from typing import TypedDict, Dict, Any, Optional
+from typing import TypedDict, Any
 
 
 class CallData(TypedDict, total=False):
@@ -28,7 +28,7 @@ class CallData(TypedDict, total=False):
     from_: str
     to: str
     from_name: str
-    headers: Dict[str, str]
+    headers: dict[str, str]
     timeout: int
     tag: str
 
@@ -36,9 +36,9 @@ class CallData(TypedDict, total=False):
 class VarsData(TypedDict, total=False):
     """Variables data structure for SWML post_data"""
 
-    userVariables: Dict[str, Any]
+    userVariables: dict[str, Any]
     environment: str
-    call_data: Dict[str, Any]
+    call_data: dict[str, Any]
 
 
 class PostData(TypedDict, total=False):
@@ -47,23 +47,23 @@ class PostData(TypedDict, total=False):
     call_id: str
     call: CallData
     vars: VarsData
-    params: Dict[str, Any]
+    params: dict[str, Any]
     project_id: str
     space_id: str
-    meta_data: Dict[str, Any]
-    post_prompt_data: Dict[str, Any]
-    error: Optional[str]
-    protocol_error: Optional[bool]
-    parse_error: Optional[bool]
+    meta_data: dict[str, Any]
+    post_prompt_data: dict[str, Any]
+    error: str | None
+    protocol_error: bool | None
+    parse_error: bool | None
 
 
 class DataMapConfig(TypedDict, total=False):
     """DataMap function configuration"""
 
     function: str
-    data_map: Dict[str, Any]
+    data_map: dict[str, Any]
     description: str
-    parameters: Dict[str, Any]
+    parameters: dict[str, Any]
 
 
 class AgentInfo(TypedDict):
@@ -72,7 +72,7 @@ class AgentInfo(TypedDict):
     class_name: str
     file_path: str
     is_instance: bool
-    instance_name: Optional[str]
+    instance_name: str | None
 
 
 class FunctionInfo(TypedDict):
@@ -80,6 +80,6 @@ class FunctionInfo(TypedDict):
 
     name: str
     description: str
-    parameters: Dict[str, Any]
+    parameters: dict[str, Any]
     type: str  # 'local', 'external', 'datamap'
-    webhook_url: Optional[str]
+    webhook_url: str | None

--- a/signalwire/signalwire/core/agent/prompt/manager.py
+++ b/signalwire/signalwire/core/agent/prompt/manager.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 Prompt management functionality for AgentBase.
 """
 
-from typing import Dict, Any, Optional, List, Union
+from typing import Any
 import inspect
 
 from signalwire.core.logging_config import get_logger
@@ -49,7 +49,7 @@ class PromptManager:
                     "Please use either set_prompt_text() OR the prompt_add_* methods, not both."
                 )
 
-    def _process_prompt_sections(self) -> Optional[Union[str, List[Dict[str, Any]]]]:
+    def _process_prompt_sections(self) -> str | list[dict[str, Any]] | None:
         """
         Process prompt sections from POM or raw prompt text.
 
@@ -72,7 +72,7 @@ class PromptManager:
 
         return None
 
-    def define_contexts(self, contexts: Union[Dict[str, Any], Any]) -> None:
+    def define_contexts(self, contexts: dict[str, Any] | Any) -> None:
         """
         Define contexts for the agent.
 
@@ -111,7 +111,7 @@ class PromptManager:
         self._post_prompt_text = text
         logger.debug(f"Set post-prompt text: {text[:100]}...")
 
-    def set_prompt_pom(self, pom: List[Dict[str, Any]]) -> None:
+    def set_prompt_pom(self, pom: list[dict[str, Any]]) -> None:
         """
         Set the prompt as a POM dictionary.
 
@@ -130,10 +130,10 @@ class PromptManager:
         self,
         title: str,
         body: str = "",
-        bullets: Optional[List[str]] = None,
+        bullets: list[str] | None = None,
         numbered: bool = False,
         numbered_bullets: bool = False,
-        subsections: Optional[List[Dict[str, Any]]] = None,
+        subsections: list[dict[str, Any]] | None = None,
     ) -> None:
         """
         Add a section to the prompt.
@@ -149,7 +149,7 @@ class PromptManager:
         self._validate_prompt_mode_exclusivity()
         if self.agent._use_pom and self.agent.pom:
             # Create parameters for add_section based on what's supported
-            kwargs: Dict[str, Any] = {}
+            kwargs: dict[str, Any] = {}
 
             # Start with basic parameters
             kwargs["title"] = title
@@ -181,9 +181,9 @@ class PromptManager:
     def prompt_add_to_section(
         self,
         title: str,
-        body: Optional[str] = None,
-        bullet: Optional[str] = None,
-        bullets: Optional[List[str]] = None,
+        body: str | None = None,
+        bullet: str | None = None,
+        bullets: list[str] | None = None,
     ) -> None:
         """
         Add content to an existing section (creating it if needed).
@@ -224,7 +224,7 @@ class PromptManager:
         parent_title: str,
         title: str,
         body: str = "",
-        bullets: Optional[List[str]] = None,
+        bullets: list[str] | None = None,
     ) -> None:
         """
         Add a subsection to an existing section (creating parent if needed).
@@ -268,7 +268,7 @@ class PromptManager:
             return self.agent.pom.find_section(title) is not None
         return False
 
-    def get_prompt(self) -> Optional[Union[str, List[Dict[str, Any]]]]:
+    def get_prompt(self) -> str | list[dict[str, Any]] | None:
         """
         Get the prompt configuration.
 
@@ -277,7 +277,7 @@ class PromptManager:
         """
         return self._process_prompt_sections()
 
-    def get_raw_prompt(self) -> Optional[str]:
+    def get_raw_prompt(self) -> str | None:
         """
         Get the raw prompt text if set.
 
@@ -286,7 +286,7 @@ class PromptManager:
         """
         return self._prompt_text
 
-    def get_post_prompt(self) -> Optional[str]:
+    def get_post_prompt(self) -> str | None:
         """
         Get the post-prompt text.
 
@@ -295,7 +295,7 @@ class PromptManager:
         """
         return self._post_prompt_text
 
-    def get_contexts(self) -> Optional[Dict[str, Any]]:
+    def get_contexts(self) -> dict[str, Any] | None:
         """
         Get the contexts configuration.
 

--- a/signalwire/signalwire/core/agent/tools/registry.py
+++ b/signalwire/signalwire/core/agent/tools/registry.py
@@ -9,7 +9,8 @@ See LICENSE file in the project root for full license information.
 Tool registration and management.
 """
 
-from typing import Dict, Any, Optional, List, Callable, Union
+from typing import Any
+from collections.abc import Callable
 import inspect
 
 from signalwire.core.swaig_function import SWAIGFunction
@@ -36,14 +37,14 @@ class ToolRegistry:
         self,
         name: str,
         description: str,
-        parameters: Dict[str, Any],
+        parameters: dict[str, Any],
         handler: Callable,
         secure: bool = True,
-        fillers: Optional[Dict[str, List[str]]] = None,
-        wait_file: Optional[str] = None,
-        wait_file_loops: Optional[int] = None,
-        webhook_url: Optional[str] = None,
-        required: Optional[List[str]] = None,
+        fillers: dict[str, list[str]] | None = None,
+        wait_file: str | None = None,
+        wait_file_loops: int | None = None,
+        webhook_url: str | None = None,
+        required: list[str] | None = None,
         is_typed_handler: bool = False,
         **swaig_fields,
     ) -> None:
@@ -87,7 +88,7 @@ class ToolRegistry:
 
         logger.debug(f"Defined tool: {name}")
 
-    def register_swaig_function(self, function_dict: Dict[str, Any]) -> None:
+    def register_swaig_function(self, function_dict: dict[str, Any]) -> None:
         """
         Register a raw SWAIG function dictionary (e.g., from DataMap.to_swaig_function()).
 
@@ -203,7 +204,7 @@ class ToolRegistry:
 
                 logger.debug(f"Registered class-decorated tool: {tool_name}")
 
-    def get_function(self, name: str) -> Optional[Union[SWAIGFunction, Dict[str, Any]]]:
+    def get_function(self, name: str) -> SWAIGFunction | dict[str, Any] | None:
         """
         Get a registered function by name.
 
@@ -215,7 +216,7 @@ class ToolRegistry:
         """
         return self._swaig_functions.get(name)
 
-    def get_all_functions(self) -> Dict[str, Union[SWAIGFunction, Dict[str, Any]]]:
+    def get_all_functions(self) -> dict[str, SWAIGFunction | dict[str, Any]]:
         """
         Get all registered functions.
 

--- a/signalwire/signalwire/core/agent/tools/type_inference.py
+++ b/signalwire/signalwire/core/agent/tools/type_inference.py
@@ -12,7 +12,7 @@ Type-hint-based schema inference for SWAIG tool functions.
 import inspect
 import re
 import typing
-from typing import Any, Dict, List, Optional, Tuple, get_type_hints
+from typing import Any, get_type_hints
 
 
 # Map Python types to JSON Schema types
@@ -26,7 +26,7 @@ _TYPE_MAP = {
 }
 
 
-def _resolve_type(annotation) -> Tuple[Dict[str, Any], bool]:
+def _resolve_type(annotation) -> tuple[dict[str, Any], bool]:
     """
     Resolve a Python type annotation to a JSON Schema property dict.
 
@@ -77,7 +77,7 @@ def _resolve_type(annotation) -> Tuple[Dict[str, Any], bool]:
     return {"type": "string"}, False
 
 
-def _parse_docstring_args(docstring: str) -> Tuple[str, Dict[str, str]]:
+def _parse_docstring_args(docstring: str) -> tuple[str, dict[str, str]]:
     """
     Parse a Google-style docstring to extract the summary line
     and per-parameter descriptions from the Args: block.
@@ -154,7 +154,7 @@ def _parse_docstring_args(docstring: str) -> Tuple[str, Dict[str, str]]:
     return summary, param_descriptions
 
 
-def infer_schema(func) -> Tuple[Dict[str, Dict], List[str], Optional[str], bool, bool]:
+def infer_schema(func) -> tuple[dict[str, dict], list[str], str | None, bool, bool]:
     """
     Inspect a function's signature and type hints to infer a JSON Schema
     for SWAIG tool parameters.
@@ -190,9 +190,9 @@ def infer_schema(func) -> Tuple[Dict[str, Dict], List[str], Optional[str], bool,
         for p in params:
             if p.annotation is not inspect.Parameter.empty and p.annotation not in (
                 dict,
-                Dict,
+                dict,
                 Any,
-                Dict[str, Any],
+                dict[str, Any],
             ):
                 has_meaningful_hints = True
                 break

--- a/signalwire/signalwire/core/agent_base.py
+++ b/signalwire/signalwire/core/agent_base.py
@@ -16,16 +16,11 @@ import json
 import uuid
 import re
 from typing import (
-    Optional,
-    List,
-    Dict,
     Any,
-    Tuple,
-    Callable,
     ClassVar,
-    Set,
     TYPE_CHECKING,
 )
+from collections.abc import Callable
 
 if TYPE_CHECKING:
     from signalwire.core.contexts import ContextBuilder
@@ -61,6 +56,7 @@ except ImportError:
 
 from signalwire.core.security.session_manager import SessionManager
 from signalwire.core.swml_service import SWMLService
+from signalwire.pom.pom import PromptObjectModel
 from signalwire.core.skill_manager import SkillManager
 from signalwire.core.logging_config import get_logger, get_execution_mode
 
@@ -115,7 +111,7 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
     # Attributes set dynamically (on ephemeral copies / when native functions are
     # configured) rather than unconditionally in __init__. Declared here so the
     # type checker knows their types at the guarded access sites.
-    _native_functions: List[Any]
+    _native_functions: list[Any]
     _is_ephemeral: bool
 
     def __init__(
@@ -123,24 +119,24 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         name: str,
         route: str = "/",
         host: str = "0.0.0.0",  # noqa: S104  # intended server default: listen on all interfaces (overridable)
-        port: Optional[int] = None,
-        basic_auth: Optional[Tuple[str, str]] = None,
+        port: int | None = None,
+        basic_auth: tuple[str, str] | None = None,
         use_pom: bool = True,
         token_expiry_secs: int = 3600,
         auto_answer: bool = True,
         record_call: bool = False,
         record_format: str = "mp4",
         record_stereo: bool = True,
-        default_webhook_url: Optional[str] = None,
-        agent_id: Optional[str] = None,
-        native_functions: Optional[List[str]] = None,
-        schema_path: Optional[str] = None,
+        default_webhook_url: str | None = None,
+        agent_id: str | None = None,
+        native_functions: list[str] | None = None,
+        schema_path: str | None = None,
         suppress_logs: bool = False,
         enable_post_prompt_override: bool = False,
         check_for_input_override: bool = False,
-        config_file: Optional[str] = None,
+        config_file: str | None = None,
         schema_validation: bool = True,
-        signing_key: Optional[str] = None,
+        signing_key: str | None = None,
         trust_proxy_for_signature: bool = False,
     ):
         """
@@ -235,10 +231,8 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         self._use_pom = use_pom
 
         # Initialize POM if needed
-        self.pom: Optional["PromptObjectModel"]
+        self.pom: PromptObjectModel | None
         if self._use_pom:
-            from signalwire.pom.pom import PromptObjectModel
-
             self.pom = PromptObjectModel()
         else:
             self.pom = None
@@ -266,8 +260,8 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
             )
 
         # URL override variables
-        self._web_hook_url_override: Optional[str] = None
-        self._post_prompt_url_override: Optional[str] = None
+        self._web_hook_url_override: str | None = None
+        self._post_prompt_url_override: str | None = None
 
         # Register the tool decorator on this instance
         self.tool = self._tool_decorator  # type: ignore[method-assign]  # intentional per-instance decorator binding
@@ -290,17 +284,17 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         self.native_functions = native_functions or []
 
         # Initialize new configuration containers
-        self._hints: List[Any] = []
+        self._hints: list[Any] = []
         self._languages = []
         self._pronounce = []
-        self._params: Dict[str, Any] = {}
-        self._global_data: Dict[str, Any] = {}
+        self._params: dict[str, Any] = {}
+        self._global_data: dict[str, Any] = {}
         self._function_includes = []
-        self._mcp_servers: List[Any] = []
+        self._mcp_servers: list[Any] = []
         self._mcp_server_enabled = False
         # Initialize LLM params as empty - only send if explicitly set
-        self._prompt_llm_params: Dict[str, Any] = {}
-        self._post_prompt_llm_params: Dict[str, Any] = {}
+        self._prompt_llm_params: dict[str, Any] = {}
+        self._post_prompt_llm_params: dict[str, Any] = {}
 
         # Dynamic configuration callback
         self._dynamic_config_callback = None
@@ -309,32 +303,32 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         self.skill_manager = SkillManager(self)
 
         # Initialize contexts system
-        self._contexts_builder: Optional["ContextBuilder"] = None
+        self._contexts_builder: ContextBuilder | None = None
         self._contexts_defined = False
 
         # Initialize SWAIG query params for dynamic config
-        self._swaig_query_params: Dict[str, Any] = {}
+        self._swaig_query_params: dict[str, Any] = {}
 
         # Debug events
         self._debug_events_enabled = False
         self._debug_events_level = 1
-        self._debug_event_handler: Optional[Callable[..., Any]] = None
+        self._debug_event_handler: Callable[..., Any] | None = None
 
         # Initialize verb insertion points for call flow customization.
         # The verb lists hold (verb_name, config) tuples; _answer_config is a dict.
-        self._pre_answer_verbs: List[
-            Tuple[str, Dict[str, Any]]
+        self._pre_answer_verbs: list[
+            tuple[str, dict[str, Any]]
         ] = []  # Verbs to run before answer (e.g., ringback, screening)
-        self._answer_config: Dict[str, Any] = {}  # Configuration for the answer verb
-        self._post_answer_verbs: List[
-            Tuple[str, Dict[str, Any]]
+        self._answer_config: dict[str, Any] = {}  # Configuration for the answer verb
+        self._post_answer_verbs: list[
+            tuple[str, dict[str, Any]]
         ] = []  # Verbs to run after answer, before AI (e.g., announcements)
-        self._post_ai_verbs: List[
-            Tuple[str, Dict[str, Any]]
+        self._post_ai_verbs: list[
+            tuple[str, dict[str, Any]]
         ] = []  # Verbs to run after AI ends (e.g., cleanup, transfers)
 
     # Verb categories for pre-answer validation
-    _PRE_ANSWER_SAFE_VERBS: ClassVar[Set[str]] = {
+    _PRE_ANSWER_SAFE_VERBS: ClassVar[set[str]] = {
         "transfer",
         "execute",
         "return",
@@ -354,10 +348,10 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         "stop_denoise",
         "stop_tap",
     }
-    _AUTO_ANSWER_VERBS: ClassVar[Set[str]] = {"play", "connect"}
+    _AUTO_ANSWER_VERBS: ClassVar[set[str]] = {"play", "connect"}
 
     @staticmethod
-    def _load_service_config(config_file: Optional[str], service_name: str) -> dict:
+    def _load_service_config(config_file: str | None, service_name: str) -> dict:
         """Load service configuration from config file if available"""
         from signalwire.core.config_loader import ConfigLoader
 
@@ -506,8 +500,8 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
 
     def on_summary(
         self,
-        summary: Optional[Dict[str, Any]],
-        raw_data: Optional[Dict[str, Any]] = None,
+        summary: dict[str, Any] | None,
+        raw_data: dict[str, Any] | None = None,
     ) -> None:
         """
         Called when a post-prompt summary is received
@@ -550,7 +544,7 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
     # ==================== Call Flow Verb Insertion Methods ====================
 
     def add_pre_answer_verb(
-        self, verb_name: str, config: Dict[str, Any]
+        self, verb_name: str, config: dict[str, Any]
     ) -> "AgentBase":
         """
         Add a verb to run before the call is answered.
@@ -599,7 +593,7 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         self._pre_answer_verbs.append((verb_name, config))
         return self
 
-    def add_answer_verb(self, config: Optional[Dict[str, Any]] = None) -> "AgentBase":
+    def add_answer_verb(self, config: dict[str, Any] | None = None) -> "AgentBase":
         """
         Configure the answer verb.
 
@@ -620,7 +614,7 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         return self
 
     def add_post_answer_verb(
-        self, verb_name: str, config: Dict[str, Any]
+        self, verb_name: str, config: dict[str, Any]
     ) -> "AgentBase":
         """
         Add a verb to run after the call is answered but before the AI starts.
@@ -646,7 +640,7 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         self._post_answer_verbs.append((verb_name, config))
         return self
 
-    def add_post_ai_verb(self, verb_name: str, config: Dict[str, Any]) -> "AgentBase":
+    def add_post_ai_verb(self, verb_name: str, config: dict[str, Any]) -> "AgentBase":
         """
         Add a verb to run after the AI conversation ends.
 
@@ -723,9 +717,7 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         """
 
         # Create a routing callback that handles SIP usernames
-        def sip_routing_callback(
-            request: Request, body: Dict[str, Any]
-        ) -> Optional[str]:
+        def sip_routing_callback(request: Request, body: dict[str, Any]) -> str | None:
             # Extract SIP username from the request body
             sip_username = self.extract_sip_username(body)
 
@@ -825,7 +817,7 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         self._post_prompt_url_override = url
         return self
 
-    def add_swaig_query_params(self, params: Dict[str, str]) -> "AgentBase":
+    def add_swaig_query_params(self, params: dict[str, str]) -> "AgentBase":
         """
         Add query parameters that will be included in all SWAIG webhook URLs
 
@@ -862,7 +854,7 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         return self
 
     def _render_swml(
-        self, call_id: Optional[str] = None, modifications: Optional[dict] = None
+        self, call_id: str | None = None, modifications: dict | None = None
     ) -> str:
         """
         Render the complete SWML document using SWMLService methods
@@ -976,7 +968,7 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
             default_webhook_url = agent_to_use._web_hook_url_override
 
         # Prepare SWAIG object (correct format)
-        swaig_obj: Dict[str, Any] = {}
+        swaig_obj: dict[str, Any] = {}
 
         # Add native_functions if any are defined
         if agent_to_use.native_functions:
@@ -1385,7 +1377,7 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
     # token-validation + ephemeral dynamic config on POST dispatch.
 
     async def _swaig_render_get_response(
-        self, request: Request, call_id: Optional[str]
+        self, request: Request, call_id: str | None
     ) -> Response:
         swml = self._render_swml(call_id)
         self.log.debug("swml_rendered", swml_size=len(swml))
@@ -1394,10 +1386,10 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
     def _swaig_pre_dispatch(
         self,
         request: Request,
-        body: Dict[str, Any],
-        call_id: Optional[str],
+        body: dict[str, Any],
+        call_id: str | None,
         function_name: str,
-    ) -> Tuple[Any, Optional[Dict[str, Any]]]:
+    ) -> tuple[Any, dict[str, Any] | None]:
         req_log = self.log.bind(endpoint="swaig", function=function_name)
 
         # Validate security token if present.
@@ -1448,7 +1440,7 @@ class AgentBase(  # type: ignore[misc]  # intentional diamond: WebMixin's serve/
         return target, None
 
     def _build_webhook_url(
-        self, endpoint: str, query_params: Optional[Dict[str, str]] = None
+        self, endpoint: str, query_params: dict[str, str] | None = None
     ) -> str:
         """
         Helper method to build webhook URLs consistently

--- a/signalwire/signalwire/core/auth_handler.py
+++ b/signalwire/signalwire/core/auth_handler.py
@@ -8,7 +8,8 @@ See LICENSE file in the project root for full license information.
 """
 
 import secrets
-from typing import Optional, Dict, Any, Callable, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
+from collections.abc import Callable
 from functools import wraps
 
 if TYPE_CHECKING:
@@ -70,7 +71,7 @@ class AuthHandler:
 
     def _setup_auth_methods(self):
         """Setup enabled authentication methods from config"""
-        self.auth_methods: Dict[str, Dict[str, Any]] = {}
+        self.auth_methods: dict[str, dict[str, Any]] = {}
 
         # Basic auth (always available for backward compatibility)
         username, password = self.security_config.get_basic_auth()
@@ -139,15 +140,15 @@ class AuthHandler:
             return None
 
         async def auth_dependency(
-            basic_credentials: Optional[HTTPBasicCredentials] = Depends(self.basic_auth)  # noqa: B008  # FastAPI DI: Depends() in default is the intended idiom (Depends is lazy-imported so the config-level extend-immutable-calls can't resolve it)
+            basic_credentials: HTTPBasicCredentials | None = Depends(self.basic_auth)  # noqa: B008  # FastAPI DI: Depends() in default is the intended idiom (Depends is lazy-imported so the config-level extend-immutable-calls can't resolve it)
             if self.basic_auth
             else None,
-            bearer_credentials: Optional[HTTPAuthorizationCredentials] = Depends(  # noqa: B008  # FastAPI DI: Depends() in default is the intended idiom
+            bearer_credentials: HTTPAuthorizationCredentials | None = Depends(  # noqa: B008  # FastAPI DI: Depends() in default is the intended idiom
                 self.bearer_auth
             )
             if self.bearer_auth
             else None,
-            api_key: Optional[str] = None,  # Get from header in request
+            api_key: str | None = None,  # Get from header in request
         ):
             # Try each auth method
             authenticated = False
@@ -230,7 +231,7 @@ class AuthHandler:
 
         return decorated
 
-    def get_auth_info(self) -> Dict[str, Any]:
+    def get_auth_info(self) -> dict[str, Any]:
         """Get information about configured auth methods"""
         info = {}
 

--- a/signalwire/signalwire/core/config_loader.py
+++ b/signalwire/signalwire/core/config_loader.py
@@ -11,7 +11,7 @@ import os
 import re
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 from signalwire.core.logging_config import get_logger
 
 logger = get_logger("config_loader")
@@ -26,7 +26,7 @@ class ConfigLoader:
     configuration across all SignalWire services.
     """
 
-    def __init__(self, config_paths: Optional[List[str]] = None):
+    def __init__(self, config_paths: list[str] | None = None):
         """
         Initialize config loader.
 
@@ -36,10 +36,10 @@ class ConfigLoader:
         """
         self.config_paths = config_paths or self._get_default_paths()
         self._config = None
-        self._config_file: Optional[str] = None
+        self._config_file: str | None = None
         self._load_config()
 
-    def _get_default_paths(self) -> List[str]:
+    def _get_default_paths(self) -> list[str]:
         """Get default configuration file search paths."""
         return [
             "config.json",
@@ -67,11 +67,11 @@ class ConfigLoader:
         """Check if a configuration was loaded."""
         return self._config is not None
 
-    def get_config_file(self) -> Optional[str]:
+    def get_config_file(self) -> str | None:
         """Get the path of the loaded config file."""
         return self._config_file
 
-    def get_config(self) -> Dict[str, Any]:
+    def get_config(self) -> dict[str, Any]:
         """Get the raw configuration (before substitution)."""
         return self._config or {}
 
@@ -152,7 +152,7 @@ class ConfigLoader:
         # Substitute variables before returning
         return self.substitute_vars(value)
 
-    def get_section(self, section: str) -> Dict[str, Any]:
+    def get_section(self, section: str) -> dict[str, Any]:
         """
         Get an entire configuration section.
 
@@ -167,7 +167,7 @@ class ConfigLoader:
 
         return self.substitute_vars(self._config[section])
 
-    def merge_with_env(self, env_prefix: str = "SWML_") -> Dict[str, Any]:
+    def merge_with_env(self, env_prefix: str = "SWML_") -> dict[str, Any]:
         """
         Merge configuration with environment variables.
 
@@ -181,7 +181,7 @@ class ConfigLoader:
             Merged configuration dictionary
         """
         # Start with substituted config
-        result: Dict[str, Any] = (
+        result: dict[str, Any] = (
             self.substitute_vars(self._config) if self._config else {}
         )
 
@@ -198,7 +198,7 @@ class ConfigLoader:
 
         return result
 
-    def _has_nested_key(self, data: Dict, key_path: str) -> bool:
+    def _has_nested_key(self, data: dict, key_path: str) -> bool:
         """Check if a nested key exists in dictionary."""
         keys = key_path.split("_")
         current = data
@@ -210,7 +210,7 @@ class ConfigLoader:
                 return False
         return True
 
-    def _set_nested_key(self, data: Dict, key_path: str, value: Any) -> None:
+    def _set_nested_key(self, data: dict, key_path: str, value: Any) -> None:
         """Set a value in dictionary using underscore-separated path."""
         keys = key_path.split("_")
         current = data
@@ -224,8 +224,8 @@ class ConfigLoader:
 
     @staticmethod
     def find_config_file(
-        service_name: Optional[str] = None, additional_paths: Optional[List[str]] = None
-    ) -> Optional[str]:
+        service_name: str | None = None, additional_paths: list[str] | None = None
+    ) -> str | None:
         """
         Static method to find a config file for a service.
 

--- a/signalwire/signalwire/core/contexts.py
+++ b/signalwire/signalwire/core/contexts.py
@@ -13,7 +13,7 @@ agents to be defined as structured contexts with sequential steps. Each step
 contains its own prompt, completion criteria, and function restrictions.
 """
 
-from typing import Dict, List, Optional, Union, Any
+from typing import Optional, Any
 
 MAX_CONTEXTS = 50
 MAX_STEPS_PER_CONTEXT = 100
@@ -28,8 +28,8 @@ class GatherQuestion:
         question: str,
         type: str = "string",
         confirm: bool = False,
-        prompt: Optional[str] = None,
-        functions: Optional[List[str]] = None,
+        prompt: str | None = None,
+        functions: list[str] | None = None,
     ):
         self.key = key
         self.question = question
@@ -38,9 +38,9 @@ class GatherQuestion:
         self.prompt = prompt
         self.functions = functions
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert question to dictionary for SWML generation"""
-        d: Dict[str, Any] = {"key": self.key, "question": self.question}
+        d: dict[str, Any] = {"key": self.key, "question": self.question}
         if self.type != "string":
             d["type"] = self.type
         if self.confirm:
@@ -62,11 +62,11 @@ class GatherInfo:
 
     def __init__(
         self,
-        output_key: Optional[str] = None,
-        completion_action: Optional[str] = None,
-        prompt: Optional[str] = None,
+        output_key: str | None = None,
+        completion_action: str | None = None,
+        prompt: str | None = None,
     ):
-        self._questions: List[GatherQuestion] = []
+        self._questions: list[GatherQuestion] = []
         self._output_key = output_key
         self._completion_action = completion_action
         self._prompt = prompt
@@ -94,11 +94,11 @@ class GatherInfo:
         self._questions.append(q)
         return self
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for SWML generation"""
         if not self._questions:
             raise ValueError("gather_info must have at least one question")
-        d: Dict[str, Any] = {"questions": [q.to_dict() for q in self._questions]}
+        d: dict[str, Any] = {"questions": [q.to_dict() for q in self._questions]}
         if self._prompt:
             d["prompt"] = self._prompt
         if self._output_key:
@@ -113,17 +113,17 @@ class Step:
 
     def __init__(self, name: str):
         self.name = name
-        self._text: Optional[str] = None
-        self._step_criteria: Optional[str] = None
-        self._functions: Optional[Union[str, List[str]]] = None
-        self._valid_steps: Optional[List[str]] = None
-        self._valid_contexts: Optional[List[str]] = None
+        self._text: str | None = None
+        self._step_criteria: str | None = None
+        self._functions: str | list[str] | None = None
+        self._valid_steps: list[str] | None = None
+        self._valid_contexts: list[str] | None = None
 
         # POM-style sections for rich prompts
-        self._sections: List[Dict[str, Any]] = []
+        self._sections: list[dict[str, Any]] = []
 
         # Gather info configuration
-        self._gather_info: Optional[GatherInfo] = None
+        self._gather_info: GatherInfo | None = None
 
         # Step behavior flags
         self._end: bool = False
@@ -131,8 +131,8 @@ class Step:
         self._skip_to_next_step: bool = False
 
         # Reset object for context switching from steps
-        self._reset_system_prompt: Optional[str] = None
-        self._reset_user_prompt: Optional[str] = None
+        self._reset_system_prompt: str | None = None
+        self._reset_user_prompt: str | None = None
         self._reset_consolidate: bool = False
         self._reset_full_reset: bool = False
 
@@ -171,7 +171,7 @@ class Step:
         self._sections.append({"title": title, "body": body})
         return self
 
-    def add_bullets(self, title: str, bullets: List[str]) -> "Step":
+    def add_bullets(self, title: str, bullets: list[str]) -> "Step":
         """
         Add a POM section with bullet points
 
@@ -202,7 +202,7 @@ class Step:
         self._step_criteria = criteria
         return self
 
-    def set_functions(self, functions: Union[str, List[str]]) -> "Step":
+    def set_functions(self, functions: str | list[str]) -> "Step":
         """
         Set which non-internal functions are callable while this step is active.
 
@@ -262,7 +262,7 @@ class Step:
         self._functions = functions
         return self
 
-    def set_valid_steps(self, steps: List[str]) -> "Step":
+    def set_valid_steps(self, steps: list[str]) -> "Step":
         """
         Set which steps can be navigated to from this step
 
@@ -275,7 +275,7 @@ class Step:
         self._valid_steps = steps
         return self
 
-    def set_valid_contexts(self, contexts: List[str]) -> "Step":
+    def set_valid_contexts(self, contexts: list[str]) -> "Step":
         """
         Set which contexts can be navigated to from this step
 
@@ -341,9 +341,9 @@ class Step:
 
     def set_gather_info(
         self,
-        output_key: Optional[str] = None,
-        completion_action: Optional[str] = None,
-        prompt: Optional[str] = None,
+        output_key: str | None = None,
+        completion_action: str | None = None,
+        prompt: str | None = None,
     ) -> "Step":
         """
         Enable info gathering for this step. Questions are presented one at a time
@@ -377,8 +377,8 @@ class Step:
         question: str,
         type: str = "string",
         confirm: bool = False,
-        prompt: Optional[str] = None,
-        functions: Optional[List[str]] = None,
+        prompt: str | None = None,
+        functions: list[str] | None = None,
     ) -> "Step":
         """
         Add a question to this step's gather_info configuration.
@@ -513,9 +513,9 @@ class Step:
 
         return "\n".join(markdown_parts).strip()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert step to dictionary for SWML generation"""
-        step_dict: Dict[str, Any] = {"name": self.name, "text": self._render_text()}
+        step_dict: dict[str, Any] = {"name": self.name, "text": self._render_text()}
 
         if self._step_criteria:
             step_dict["step_criteria"] = self._step_criteria
@@ -539,7 +539,7 @@ class Step:
             step_dict["skip_to_next_step"] = True
 
         # Add reset object if any reset parameters are set
-        reset_obj: Dict[str, Any] = {}
+        reset_obj: dict[str, Any] = {}
         if self._reset_system_prompt is not None:
             reset_obj["system_prompt"] = self._reset_system_prompt
         if self._reset_user_prompt is not None:
@@ -593,40 +593,40 @@ class Context:
 
     def __init__(self, name: str):
         self.name = name
-        self._steps: Dict[str, Step] = {}
-        self._step_order: List[str] = []
-        self._valid_contexts: Optional[List[str]] = None
-        self._valid_steps: Optional[List[str]] = None
-        self._initial_step: Optional[str] = None
+        self._steps: dict[str, Step] = {}
+        self._step_order: list[str] = []
+        self._valid_contexts: list[str] | None = None
+        self._valid_steps: list[str] | None = None
+        self._initial_step: str | None = None
 
         # Context entry parameters
-        self._post_prompt: Optional[str] = None
-        self._system_prompt: Optional[str] = None
-        self._system_prompt_sections: List[
-            Dict[str, Any]
+        self._post_prompt: str | None = None
+        self._system_prompt: str | None = None
+        self._system_prompt_sections: list[
+            dict[str, Any]
         ] = []  # For POM-style system prompts
         self._consolidate: bool = False
         self._full_reset: bool = False
-        self._user_prompt: Optional[str] = None
+        self._user_prompt: str | None = None
         self._isolated: bool = False
 
         # Context prompt (separate from system_prompt)
-        self._prompt_text: Optional[str] = None
-        self._prompt_sections: List[Dict[str, Any]] = []
+        self._prompt_text: str | None = None
+        self._prompt_sections: list[dict[str, Any]] = []
 
         # Context fillers
-        self._enter_fillers: Optional[Dict[str, List[str]]] = None
-        self._exit_fillers: Optional[Dict[str, List[str]]] = None
+        self._enter_fillers: dict[str, list[str]] | None = None
+        self._exit_fillers: dict[str, list[str]] | None = None
 
     def add_step(
         self,
         name: str,
         *,
-        task: Optional[str] = None,
-        bullets: Optional[List[str]] = None,
-        criteria: Optional[str] = None,
-        functions: Optional[Union[str, List[str]]] = None,
-        valid_steps: Optional[List[str]] = None,
+        task: str | None = None,
+        bullets: list[str] | None = None,
+        criteria: str | None = None,
+        functions: str | list[str] | None = None,
+        valid_steps: list[str] | None = None,
     ) -> Step:
         """
         Add a new step to this context.
@@ -721,7 +721,7 @@ class Context:
         self._step_order.insert(position, name)
         return self
 
-    def set_valid_contexts(self, contexts: List[str]) -> "Context":
+    def set_valid_contexts(self, contexts: list[str]) -> "Context":
         """
         Set which contexts can be navigated to from this context
 
@@ -734,7 +734,7 @@ class Context:
         self._valid_contexts = contexts
         return self
 
-    def set_valid_steps(self, steps: List[str]) -> "Context":
+    def set_valid_steps(self, steps: list[str]) -> "Context":
         """
         Set which steps can be navigated to from any step in this context
 
@@ -897,7 +897,7 @@ class Context:
         self._system_prompt_sections.append({"title": title, "body": body})
         return self
 
-    def add_system_bullets(self, title: str, bullets: List[str]) -> "Context":
+    def add_system_bullets(self, title: str, bullets: list[str]) -> "Context":
         """
         Add a POM section with bullet points to the system prompt
 
@@ -950,7 +950,7 @@ class Context:
         self._prompt_sections.append({"title": title, "body": body})
         return self
 
-    def add_bullets(self, title: str, bullets: List[str]) -> "Context":
+    def add_bullets(self, title: str, bullets: list[str]) -> "Context":
         """
         Add a POM section with bullet points to the context prompt
 
@@ -968,7 +968,7 @@ class Context:
         self._prompt_sections.append({"title": title, "bullets": bullets})
         return self
 
-    def set_enter_fillers(self, enter_fillers: Dict[str, List[str]]) -> "Context":
+    def set_enter_fillers(self, enter_fillers: dict[str, list[str]]) -> "Context":
         """
         Set fillers that the AI says when entering this context
 
@@ -983,7 +983,7 @@ class Context:
             self._enter_fillers = enter_fillers
         return self
 
-    def set_exit_fillers(self, exit_fillers: Dict[str, List[str]]) -> "Context":
+    def set_exit_fillers(self, exit_fillers: dict[str, list[str]]) -> "Context":
         """
         Set fillers that the AI says when exiting this context
 
@@ -998,7 +998,7 @@ class Context:
             self._exit_fillers = exit_fillers
         return self
 
-    def add_enter_filler(self, language_code: str, fillers: List[str]) -> "Context":
+    def add_enter_filler(self, language_code: str, fillers: list[str]) -> "Context":
         """
         Add enter fillers for a specific language
 
@@ -1015,7 +1015,7 @@ class Context:
             self._enter_fillers[language_code] = fillers
         return self
 
-    def add_exit_filler(self, language_code: str, fillers: List[str]) -> "Context":
+    def add_exit_filler(self, language_code: str, fillers: list[str]) -> "Context":
         """
         Add exit fillers for a specific language
 
@@ -1032,7 +1032,7 @@ class Context:
             self._exit_fillers[language_code] = fillers
         return self
 
-    def _render_prompt(self) -> Optional[str]:
+    def _render_prompt(self) -> str | None:
         """Render the context's prompt text"""
         if self._prompt_text is not None:
             return self._prompt_text
@@ -1053,7 +1053,7 @@ class Context:
 
         return "\n".join(markdown_parts).strip()
 
-    def _render_system_prompt(self) -> Optional[str]:
+    def _render_system_prompt(self) -> str | None:
         """Render the system prompt text"""
         if self._system_prompt is not None:
             return self._system_prompt
@@ -1074,12 +1074,12 @@ class Context:
 
         return "\n".join(markdown_parts).strip()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert context to dictionary for SWML generation"""
         if not self._steps:
             raise ValueError(f"Context '{self.name}' has no steps defined")
 
-        context_dict: Dict[str, Any] = {
+        context_dict: dict[str, Any] = {
             "steps": [self._steps[name].to_dict() for name in self._step_order]
         }
 
@@ -1192,8 +1192,8 @@ class ContextBuilder:
 
     def __init__(self, agent):
         self._agent = agent
-        self._contexts: Dict[str, Context] = {}
-        self._context_order: List[str] = []
+        self._contexts: dict[str, Context] = {}
+        self._context_order: list[str] = []
 
     def reset(self) -> "ContextBuilder":
         """
@@ -1239,7 +1239,7 @@ class ContextBuilder:
         self._context_order.append(name)
         return context
 
-    def get_context(self, name: str) -> Optional[Context]:
+    def get_context(self, name: str) -> Context | None:
         """
         Get an existing context by name for inspection or modification.
 
@@ -1385,7 +1385,7 @@ class ContextBuilder:
                         f"avoid the collision."
                     )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert all contexts to dictionary for SWML generation"""
         self.validate()
 

--- a/signalwire/signalwire/core/data_map.py
+++ b/signalwire/signalwire/core/data_map.py
@@ -9,7 +9,8 @@ See LICENSE file in the project root for full license information.
 DataMap class for building SWAIG data_map configurations
 """
 
-from typing import Dict, List, Any, Optional, Union, Pattern, Tuple
+from typing import Any
+from re import Pattern
 from .function_result import FunctionResult
 
 
@@ -70,11 +71,11 @@ class DataMap:
         """
         self.function_name = function_name
         self._purpose = ""
-        self._parameters: Dict[str, Any] = {}
-        self._expressions: List[Dict[str, Any]] = []
-        self._webhooks: List[Dict[str, Any]] = []
-        self._output: Optional[Dict[str, Any]] = None
-        self._error_keys: List[str] = []
+        self._parameters: dict[str, Any] = {}
+        self._expressions: list[dict[str, Any]] = []
+        self._webhooks: list[dict[str, Any]] = []
+        self._output: dict[str, Any] | None = None
+        self._error_keys: list[str] = []
 
     def purpose(self, description: str) -> "DataMap":
         """
@@ -126,7 +127,7 @@ class DataMap:
         param_type: str,
         description: str,
         required: bool = False,
-        enum: Optional[List[str]] = None,
+        enum: list[str] | None = None,
     ) -> "DataMap":
         """
         Add a function parameter.
@@ -155,7 +156,7 @@ class DataMap:
         Returns:
             Self for method chaining.
         """
-        param_def: Dict[str, Any] = {"type": param_type, "description": description}
+        param_def: dict[str, Any] = {"type": param_type, "description": description}
 
         if enum:
             param_def["enum"] = enum
@@ -173,9 +174,9 @@ class DataMap:
     def expression(
         self,
         test_value: str,
-        pattern: Union[str, Pattern],
+        pattern: str | Pattern,
         output: FunctionResult,
-        nomatch_output: Optional[FunctionResult] = None,
+        nomatch_output: FunctionResult | None = None,
     ) -> "DataMap":
         """
         Add an expression pattern for pattern-based responses
@@ -207,10 +208,10 @@ class DataMap:
         self,
         method: str,
         url: str,
-        headers: Optional[Dict[str, str]] = None,
-        form_param: Optional[str] = None,
+        headers: dict[str, str] | None = None,
+        form_param: str | None = None,
         input_args_as_params: bool = False,
-        require_args: Optional[List[str]] = None,
+        require_args: list[str] | None = None,
     ) -> "DataMap":
         """
         Add a webhook API call
@@ -226,7 +227,7 @@ class DataMap:
         Returns:
             Self for method chaining
         """
-        webhook_def: Dict[str, Any] = {"url": url, "method": method.upper()}
+        webhook_def: dict[str, Any] = {"url": url, "method": method.upper()}
 
         if headers:
             webhook_def["headers"] = headers
@@ -240,7 +241,7 @@ class DataMap:
         self._webhooks.append(webhook_def)
         return self
 
-    def webhook_expressions(self, expressions: List[Dict[str, Any]]) -> "DataMap":
+    def webhook_expressions(self, expressions: list[dict[str, Any]]) -> "DataMap":
         """
         Add expressions that run after the most recent webhook completes
 
@@ -256,7 +257,7 @@ class DataMap:
         self._webhooks[-1]["expressions"] = expressions
         return self
 
-    def body(self, data: Dict[str, Any]) -> "DataMap":
+    def body(self, data: dict[str, Any]) -> "DataMap":
         """
         Set request body for the last added webhook (POST/PUT requests)
 
@@ -272,7 +273,7 @@ class DataMap:
         self._webhooks[-1]["body"] = data
         return self
 
-    def params(self, data: Dict[str, Any]) -> "DataMap":
+    def params(self, data: dict[str, Any]) -> "DataMap":
         """
         Set request params for the last added webhook (alias for body)
 
@@ -288,7 +289,7 @@ class DataMap:
         self._webhooks[-1]["params"] = data
         return self
 
-    def foreach(self, foreach_config: Dict[str, Any]) -> "DataMap":
+    def foreach(self, foreach_config: dict[str, Any]) -> "DataMap":
         """
         Process an array from the webhook response using foreach mechanism
 
@@ -359,7 +360,7 @@ class DataMap:
         self._output = result.to_dict()
         return self
 
-    def error_keys(self, keys: List[str]) -> "DataMap":
+    def error_keys(self, keys: list[str]) -> "DataMap":
         """
         Set error keys for the most recent webhook (if webhooks exist) or top-level
 
@@ -377,7 +378,7 @@ class DataMap:
             self._error_keys = keys
         return self
 
-    def global_error_keys(self, keys: List[str]) -> "DataMap":
+    def global_error_keys(self, keys: list[str]) -> "DataMap":
         """
         Set top-level error keys (applies to all webhooks)
 
@@ -390,7 +391,7 @@ class DataMap:
         self._error_keys = keys
         return self
 
-    def to_swaig_function(self) -> Dict[str, Any]:
+    def to_swaig_function(self) -> dict[str, Any]:
         """
         Convert this DataMap to a SWAIG function definition
 
@@ -412,7 +413,7 @@ class DataMap:
             param_schema = {"type": "object", "properties": {}}
 
         # Build data_map structure
-        data_map: Dict[str, Any] = {}
+        data_map: dict[str, Any] = {}
 
         # Add expressions if present
         if self._expressions:
@@ -443,11 +444,11 @@ def create_simple_api_tool(
     name: str,
     url: str,
     response_template: str,
-    parameters: Optional[Dict[str, Dict]] = None,
+    parameters: dict[str, dict] | None = None,
     method: str = "GET",
-    headers: Optional[Dict[str, str]] = None,
-    body: Optional[Dict[str, Any]] = None,
-    error_keys: Optional[List[str]] = None,
+    headers: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
+    error_keys: list[str] | None = None,
 ) -> DataMap:
     """
     Create a simple API tool with minimal configuration
@@ -497,8 +498,8 @@ def create_simple_api_tool(
 
 def create_expression_tool(
     name: str,
-    patterns: Dict[str, Tuple[str, FunctionResult]],
-    parameters: Optional[Dict[str, Dict]] = None,
+    patterns: dict[str, tuple[str, FunctionResult]],
+    parameters: dict[str, dict] | None = None,
 ) -> DataMap:
     """
     Create an expression-based tool for pattern matching responses

--- a/signalwire/signalwire/core/function_result.py
+++ b/signalwire/signalwire/core/function_result.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 FunctionResult class for handling the response format of SWAIG function calls
 """
 
-from typing import Dict, List, Any, Literal, Optional, Union
+from typing import Any, Literal
 
 
 class FunctionResult:
@@ -67,7 +67,7 @@ class FunctionResult:
         )
     """
 
-    def __init__(self, response: Optional[str] = None, post_process: bool = False):
+    def __init__(self, response: str | None = None, post_process: bool = False):
         """
         Initialize a new SWAIG function result
 
@@ -77,7 +77,7 @@ class FunctionResult:
                          Defaults to False (execute actions immediately after response).
         """
         self.response = response if response is not None else ""
-        self.action: List[Dict[str, Any]] = []
+        self.action: list[dict[str, Any]] = []
         self.post_process = post_process
 
     def set_response(self, response: str) -> "FunctionResult":
@@ -124,7 +124,7 @@ class FunctionResult:
         self.action.append({name: data})
         return self
 
-    def add_actions(self, actions: List[Dict[str, Any]]) -> "FunctionResult":
+    def add_actions(self, actions: list[dict[str, Any]]) -> "FunctionResult":
         """
         Add multiple structured actions to the response
 
@@ -138,7 +138,7 @@ class FunctionResult:
         return self
 
     def connect(
-        self, destination: str, final: bool = True, from_addr: Optional[str] = None
+        self, destination: str, final: bool = True, from_addr: str | None = None
     ) -> "FunctionResult":
         """
         Add a connect action to transfer/connect the call to another destination.
@@ -245,7 +245,7 @@ class FunctionResult:
 
         return self
 
-    def update_global_data(self, data: Dict[str, Any]) -> "FunctionResult":
+    def update_global_data(self, data: dict[str, Any]) -> "FunctionResult":
         """
         Update global agent data variables.
 
@@ -261,7 +261,7 @@ class FunctionResult:
         """
         return self.add_action("set_global_data", data)
 
-    def swml_user_event(self, event_data: Dict[str, Any]) -> "FunctionResult":
+    def swml_user_event(self, event_data: dict[str, Any]) -> "FunctionResult":
         """
         Send a user event through SWML to update the client UI.
 
@@ -408,7 +408,7 @@ class FunctionResult:
             try:
                 import json
 
-                swml_data: Dict[str, Any] = json.loads(swml_content)
+                swml_data: dict[str, Any] = json.loads(swml_content)
             except (json.JSONDecodeError, ValueError):
                 swml_data = {"raw_swml": swml_content}
         elif hasattr(swml_content, "to_dict"):
@@ -451,8 +451,8 @@ class FunctionResult:
 
     def wait_for_user(
         self,
-        enabled: Optional[bool] = None,
-        timeout: Optional[int] = None,
+        enabled: bool | None = None,
+        timeout: int | None = None,
         answer_first: bool = False,
     ) -> "FunctionResult":
         """
@@ -466,7 +466,7 @@ class FunctionResult:
         Returns:
             self for method chaining
         """
-        wait_value: Union[str, int, bool]
+        wait_value: str | int | bool
         if answer_first:
             wait_value = "answer_first"
         elif timeout is not None:
@@ -525,9 +525,7 @@ class FunctionResult:
         """
         return self.add_action("stop_playback_bg", True)
 
-    def add_dynamic_hints(
-        self, hints: List[Union[str, Dict[str, Any]]]
-    ) -> "FunctionResult":
+    def add_dynamic_hints(self, hints: list[str | dict[str, Any]]) -> "FunctionResult":
         """
         Add dynamic speech recognition hints during a call.
 
@@ -594,7 +592,7 @@ class FunctionResult:
         """
         return self.add_action("speech_event_timeout", milliseconds)
 
-    def remove_global_data(self, keys: Union[str, List[str]]) -> "FunctionResult":
+    def remove_global_data(self, keys: str | list[str]) -> "FunctionResult":
         """
         Remove global agent data variables.
 
@@ -606,7 +604,7 @@ class FunctionResult:
         """
         return self.add_action("unset_global_data", keys)
 
-    def set_metadata(self, data: Dict[str, Any]) -> "FunctionResult":
+    def set_metadata(self, data: dict[str, Any]) -> "FunctionResult":
         """
         Set metadata scoped to current function's meta_data_token.
 
@@ -618,7 +616,7 @@ class FunctionResult:
         """
         return self.add_action("set_meta_data", data)
 
-    def remove_metadata(self, keys: Union[str, List[str]]) -> "FunctionResult":
+    def remove_metadata(self, keys: str | list[str]) -> "FunctionResult":
         """
         Remove metadata from current function's meta_data_token scope.
 
@@ -631,7 +629,7 @@ class FunctionResult:
         return self.add_action("unset_meta_data", keys)
 
     def toggle_functions(
-        self, function_toggles: List[Dict[str, Any]]
+        self, function_toggles: list[dict[str, Any]]
     ) -> "FunctionResult":
         """
         Enable/disable specific SWAIG functions.
@@ -669,7 +667,7 @@ class FunctionResult:
         """
         return self.add_action("extensive_data", enabled)
 
-    def replace_in_history(self, text: Union[str, bool] = True) -> "FunctionResult":
+    def replace_in_history(self, text: str | bool = True) -> "FunctionResult":
         """
         After first send, replace tool_call+result pair in conversation history.
 
@@ -682,7 +680,7 @@ class FunctionResult:
         """
         return self.add_action("replace_in_history", text)
 
-    def update_settings(self, settings: Dict[str, Any]) -> "FunctionResult":
+    def update_settings(self, settings: dict[str, Any]) -> "FunctionResult":
         """
         Update agent runtime settings.
 
@@ -705,8 +703,8 @@ class FunctionResult:
 
     def switch_context(
         self,
-        system_prompt: Optional[str] = None,
-        user_prompt: Optional[str] = None,
+        system_prompt: str | None = None,
+        user_prompt: str | None = None,
         consolidate: bool = False,
         full_reset: bool = False,
     ) -> "FunctionResult":
@@ -726,7 +724,7 @@ class FunctionResult:
             # Simple string context switch
             return self.add_action("context_switch", system_prompt)
         # Advanced object context switch
-        context_data: Dict[str, Any] = {}
+        context_data: dict[str, Any] = {}
         if system_prompt:
             context_data["system_prompt"] = system_prompt
         if user_prompt:
@@ -753,10 +751,10 @@ class FunctionResult:
         self,
         to_number: str,
         from_number: str,
-        body: Optional[str] = None,
-        media: Optional[List[str]] = None,
-        tags: Optional[List[str]] = None,
-        region: Optional[str] = None,
+        body: str | None = None,
+        media: list[str] | None = None,
+        tags: list[str] | None = None,
+        region: str | None = None,
     ) -> "FunctionResult":
         """
         Send a text message to a PSTN phone number using SWML.
@@ -783,7 +781,7 @@ class FunctionResult:
             raise ValueError("Either body or media must be provided")
 
         # Build the send_sms parameters
-        sms_params: Dict[str, Any] = {
+        sms_params: dict[str, Any] = {
             "to_number": to_number,
             "from_number": from_number,
         }
@@ -811,25 +809,24 @@ class FunctionResult:
         self,
         payment_connector_url: str,
         input_method: str = "dtmf",
-        status_url: Optional[str] = None,
+        status_url: str | None = None,
         payment_method: str = "credit-card",
         timeout: int = 5,
         max_attempts: int = 1,
         security_code: bool = True,
-        postal_code: Union[bool, str] = True,
+        postal_code: bool | str = True,
         min_postal_code_length: int = 0,
         token_type: str = "reusable",  # noqa: S107  # false positive: SWML pay-verb field name, the value "reusable" is a mode, not a secret
-        charge_amount: Optional[str] = None,
+        charge_amount: str | None = None,
         currency: str = "usd",
         language: str = "en-US",
         voice: str = "woman",
-        description: Optional[str] = None,
+        description: str | None = None,
         valid_card_types: str = "visa mastercard amex",
-        parameters: Optional[List[Dict[str, str]]] = None,
-        prompts: Optional[List[Dict[str, Any]]] = None,
-        ai_response: Optional[
-            str
-        ] = "The payment status is ${pay_result}, do not mention anything else about collecting payment if successful.",
+        parameters: list[dict[str, str]] | None = None,
+        prompts: list[dict[str, Any]] | None = None,
+        ai_response: str
+        | None = "The payment status is ${pay_result}, do not mention anything else about collecting payment if successful.",
     ) -> "FunctionResult":
         """
         Process payment using SWML pay action.
@@ -862,7 +859,7 @@ class FunctionResult:
             self for method chaining
         """
         # Build the pay parameters
-        pay_params: Dict[str, Any] = {
+        pay_params: dict[str, Any] = {
             "payment_connector_url": payment_connector_url,
             "input": input_method,
             "payment_method": payment_method,
@@ -908,17 +905,17 @@ class FunctionResult:
 
     def record_call(
         self,
-        control_id: Optional[str] = None,
+        control_id: str | None = None,
         stereo: bool = False,
         format: Literal["wav", "mp3", "mp4"] = "wav",
         direction: Literal["speak", "listen", "both"] = "both",
-        terminators: Optional[str] = None,
+        terminators: str | None = None,
         beep: bool = False,
         input_sensitivity: float = 44.0,
-        initial_timeout: Optional[float] = None,
-        end_silence_timeout: Optional[float] = None,
-        max_length: Optional[float] = None,
-        status_url: Optional[str] = None,
+        initial_timeout: float | None = None,
+        end_silence_timeout: float | None = None,
+        max_length: float | None = None,
+        status_url: str | None = None,
     ) -> "FunctionResult":
         """
         Start background call recording using SWML.
@@ -953,7 +950,7 @@ class FunctionResult:
             raise ValueError("direction must be 'speak', 'listen', or 'both'")
 
         # Build the record_call parameters
-        record_params: Dict[str, Any] = {
+        record_params: dict[str, Any] = {
             "stereo": stereo,
             "format": format,
             "direction": direction,
@@ -984,7 +981,7 @@ class FunctionResult:
         # Use execute_swml to add the action
         return self.execute_swml(swml_doc)
 
-    def stop_record_call(self, control_id: Optional[str] = None) -> "FunctionResult":
+    def stop_record_call(self, control_id: str | None = None) -> "FunctionResult":
         """
         Stop an active background call recording using SWML.
 
@@ -1069,19 +1066,19 @@ class FunctionResult:
         beep: str = "true",
         start_on_enter: bool = True,
         end_on_exit: bool = False,
-        wait_url: Optional[str] = None,
+        wait_url: str | None = None,
         max_participants: int = 250,
         record: str = "do-not-record",
-        region: Optional[str] = None,
+        region: str | None = None,
         trim: str = "trim-silence",
-        coach: Optional[str] = None,
-        status_callback_event: Optional[str] = None,
-        status_callback: Optional[str] = None,
+        coach: str | None = None,
+        status_callback_event: str | None = None,
+        status_callback: str | None = None,
         status_callback_method: str = "POST",
-        recording_status_callback: Optional[str] = None,
+        recording_status_callback: str | None = None,
         recording_status_callback_method: str = "POST",
         recording_status_callback_event: str = "completed",
-        result: Optional[Any] = None,
+        result: Any | None = None,
     ) -> "FunctionResult":
         """
         Join an ad-hoc audio conference with RELAY and CXML calls using SWML.
@@ -1168,7 +1165,7 @@ class FunctionResult:
             and result is None
         ):
             # Simple form - just the conference name
-            join_params: Union[str, Dict[str, Any]] = name
+            join_params: str | dict[str, Any] = name
         else:
             # Full object form with parameters
             join_params = {"name": name}
@@ -1225,11 +1222,11 @@ class FunctionResult:
     def tap(
         self,
         uri: str,
-        control_id: Optional[str] = None,
+        control_id: str | None = None,
         direction: Literal["speak", "hear", "both"] = "both",
         codec: Literal["PCMU", "PCMA"] = "PCMU",
         rtp_ptime: int = 20,
-        status_url: Optional[str] = None,
+        status_url: str | None = None,
     ) -> "FunctionResult":
         """
         Start background call tap using SWML.
@@ -1271,7 +1268,7 @@ class FunctionResult:
             raise ValueError("rtp_ptime must be a positive integer")
 
         # Build the tap parameters
-        tap_params: Dict[str, Any] = {"uri": uri}
+        tap_params: dict[str, Any] = {"uri": uri}
 
         # Add optional parameters if they differ from defaults
         if control_id:
@@ -1291,7 +1288,7 @@ class FunctionResult:
         # Use execute_swml to add the action
         return self.execute_swml(swml_doc)
 
-    def stop_tap(self, control_id: Optional[str] = None) -> "FunctionResult":
+    def stop_tap(self, control_id: str | None = None) -> "FunctionResult":
         """
         Stop an active tap stream using SWML.
 
@@ -1320,9 +1317,9 @@ class FunctionResult:
     def execute_rpc(
         self,
         method: str,
-        params: Optional[Dict[str, Any]] = None,
-        call_id: Optional[str] = None,
-        node_id: Optional[str] = None,
+        params: dict[str, Any] | None = None,
+        call_id: str | None = None,
+        node_id: str | None = None,
     ) -> "FunctionResult":
         """
         Execute an RPC method on a call using SWML.
@@ -1350,7 +1347,7 @@ class FunctionResult:
             )
         """
         # Build the execute_rpc parameters
-        rpc_params: Dict[str, Any] = {"method": method}
+        rpc_params: dict[str, Any] = {"method": method}
 
         if call_id:
             rpc_params["call_id"] = call_id
@@ -1471,10 +1468,10 @@ class FunctionResult:
     @staticmethod
     def create_payment_prompt(
         for_situation: str,
-        actions: List[Dict[str, str]],
-        card_type: Optional[str] = None,
-        error_type: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        actions: list[dict[str, str]],
+        card_type: str | None = None,
+        error_type: str | None = None,
+    ) -> dict[str, Any]:
         """
         Create a payment prompt structure for use with pay() method.
 
@@ -1497,7 +1494,7 @@ class FunctionResult:
         return prompt
 
     @staticmethod
-    def create_payment_action(action_type: str, phrase: str) -> Dict[str, str]:
+    def create_payment_action(action_type: str, phrase: str) -> dict[str, str]:
         """
         Create a payment action for use in payment prompts.
 
@@ -1511,7 +1508,7 @@ class FunctionResult:
         return {"type": action_type, "phrase": phrase}
 
     @staticmethod
-    def create_payment_parameter(name: str, value: str) -> Dict[str, str]:
+    def create_payment_parameter(name: str, value: str) -> dict[str, str]:
         """
         Create a payment parameter for use with pay() method.
 
@@ -1524,7 +1521,7 @@ class FunctionResult:
         """
         return {"name": name, "value": value}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Convert to the JSON structure expected by SWAIG
 
@@ -1539,7 +1536,7 @@ class FunctionResult:
             Dictionary in SWAIG function response format
         """
         # Create the result object
-        result: Dict[str, Any] = {}
+        result: dict[str, Any] = {}
 
         # Add response if present
         if self.response:

--- a/signalwire/signalwire/core/mixins/ai_config_mixin.py
+++ b/signalwire/signalwire/core/mixins/ai_config_mixin.py
@@ -8,7 +8,7 @@ See LICENSE file in the project root for full license information.
 """
 
 import threading
-from typing import TYPE_CHECKING, List, Dict, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from signalwire.core.agent_base import AgentBase  # type: ignore[attr-defined]  # cycle: agent_base imports the mixins; the name resolves at type-check time but mypy flags the back-reference
@@ -36,7 +36,7 @@ class AIConfigMixin(_HostTyped):
             self._hints.append(hint)
         return self
 
-    def add_hints(self, hints: List[str]) -> "AgentBase":
+    def add_hints(self, hints: list[str]) -> "AgentBase":
         """
         Add multiple string hints
 
@@ -83,11 +83,11 @@ class AIConfigMixin(_HostTyped):
         name: str,
         code: str,
         voice: str,
-        speech_fillers: Optional[List[str]] = None,
-        function_fillers: Optional[List[str]] = None,
-        engine: Optional[str] = None,
-        model: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
+        speech_fillers: list[str] | None = None,
+        function_fillers: list[str] | None = None,
+        engine: str | None = None,
+        model: str | None = None,
+        params: dict[str, Any] | None = None,
     ) -> "AgentBase":
         """
         Add a language configuration to support multilingual conversations
@@ -123,7 +123,7 @@ class AIConfigMixin(_HostTyped):
                                engine="elevenlabs",
                                params={"stability": 0.5, "similarity_boost": 0.75})
         """
-        language: Dict[str, Any] = {"name": name, "code": code}
+        language: dict[str, Any] = {"name": name, "code": code}
 
         # Handle voice formatting (either explicit params or combined string)
         if engine or model:
@@ -167,7 +167,7 @@ class AIConfigMixin(_HostTyped):
         self._languages.append(language)
         return self
 
-    def set_language_params(self, code: str, params: Dict[str, Any]) -> "AgentBase":
+    def set_language_params(self, code: str, params: dict[str, Any]) -> "AgentBase":
         """
         Set (or replace) the per-language ``params`` dict on an already-added
         language. Useful when language entries are built up via add_language()
@@ -190,7 +190,7 @@ class AIConfigMixin(_HostTyped):
                 break
         return self
 
-    def get_language_params(self, code: str) -> Optional[Dict[str, Any]]:
+    def get_language_params(self, code: str) -> dict[str, Any] | None:
         """
         Read the per-language ``params`` dict for a previously-added language.
 
@@ -205,7 +205,7 @@ class AIConfigMixin(_HostTyped):
                 return language.get("params")
         return None
 
-    def set_languages(self, languages: List[Dict[str, Any]]) -> "AgentBase":
+    def set_languages(self, languages: list[dict[str, Any]]) -> "AgentBase":
         """
         Set all language configurations at once
 
@@ -234,14 +234,14 @@ class AIConfigMixin(_HostTyped):
             Self for method chaining
         """
         if replace and with_text:
-            rule: Dict[str, Any] = {"replace": replace, "with": with_text}
+            rule: dict[str, Any] = {"replace": replace, "with": with_text}
             if ignore_case:
                 rule["ignore_case"] = True
 
             self._pronounce.append(rule)
         return self
 
-    def set_pronunciations(self, pronunciations: List[Dict[str, Any]]) -> "AgentBase":
+    def set_pronunciations(self, pronunciations: list[dict[str, Any]]) -> "AgentBase":
         """
         Set all pronunciation rules at once
 
@@ -270,7 +270,7 @@ class AIConfigMixin(_HostTyped):
             self._params[key] = value
         return self
 
-    def set_params(self, params: Dict[str, Any]) -> "AgentBase":
+    def set_params(self, params: dict[str, Any]) -> "AgentBase":
         """
         Set multiple AI parameters at once
 
@@ -284,7 +284,7 @@ class AIConfigMixin(_HostTyped):
             self._params.update(params)
         return self
 
-    def set_global_data(self, data: Dict[str, Any]) -> "AgentBase":
+    def set_global_data(self, data: dict[str, Any]) -> "AgentBase":
         """
         Merge data into the global data available to the AI throughout the conversation.
 
@@ -304,7 +304,7 @@ class AIConfigMixin(_HostTyped):
                 self._global_data.update(data)
         return self
 
-    def update_global_data(self, data: Dict[str, Any]) -> "AgentBase":
+    def update_global_data(self, data: dict[str, Any]) -> "AgentBase":
         """
         Update the global data with new values
 
@@ -321,7 +321,7 @@ class AIConfigMixin(_HostTyped):
                 self._global_data.update(data)
         return self
 
-    def set_native_functions(self, function_names: List[str]) -> "AgentBase":
+    def set_native_functions(self, function_names: list[str]) -> "AgentBase":
         """
         Set the list of native functions to enable
 
@@ -356,7 +356,7 @@ class AIConfigMixin(_HostTyped):
     )
 
     def set_internal_fillers(
-        self, internal_fillers: Dict[str, Dict[str, List[str]]]
+        self, internal_fillers: dict[str, dict[str, list[str]]]
     ) -> "AgentBase":
         """
         Set internal fillers for native SWAIG functions.
@@ -433,7 +433,7 @@ class AIConfigMixin(_HostTyped):
         return self
 
     def add_internal_filler(
-        self, function_name: str, language_code: str, fillers: List[str]
+        self, function_name: str, language_code: str, fillers: list[str]
     ) -> "AgentBase":
         """
         Add internal fillers for a single internal function and language.
@@ -513,7 +513,7 @@ class AIConfigMixin(_HostTyped):
         return self
 
     def add_function_include(
-        self, url: str, functions: List[str], meta_data: Optional[Dict[str, Any]] = None
+        self, url: str, functions: list[str], meta_data: dict[str, Any] | None = None
     ) -> "AgentBase":
         """
         Add a remote function include to the SWAIG configuration
@@ -527,14 +527,14 @@ class AIConfigMixin(_HostTyped):
             Self for method chaining
         """
         if url and functions and isinstance(functions, list):
-            include: Dict[str, Any] = {"url": url, "functions": functions}
+            include: dict[str, Any] = {"url": url, "functions": functions}
             if meta_data and isinstance(meta_data, dict):
                 include["meta_data"] = meta_data
 
             self._function_includes.append(include)
         return self
 
-    def set_function_includes(self, includes: List[Dict[str, Any]]) -> "AgentBase":
+    def set_function_includes(self, includes: list[dict[str, Any]]) -> "AgentBase":
         """
         Set the complete list of function includes
 
@@ -563,9 +563,9 @@ class AIConfigMixin(_HostTyped):
     def add_mcp_server(
         self,
         url: str,
-        headers: Optional[Dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
         resources: bool = False,
-        resource_vars: Optional[Dict[str, str]] = None,
+        resource_vars: dict[str, str] | None = None,
     ) -> "AgentBase":
         """
         Add an external MCP server for tool discovery and invocation.
@@ -583,7 +583,7 @@ class AIConfigMixin(_HostTyped):
         Returns:
             Self for method chaining
         """
-        server: Dict[str, Any] = {"url": url}
+        server: dict[str, Any] = {"url": url}
         if headers:
             server["headers"] = headers
         if resources:

--- a/signalwire/signalwire/core/mixins/auth_mixin.py
+++ b/signalwire/signalwire/core/mixins/auth_mixin.py
@@ -11,7 +11,6 @@ import os
 import hmac
 import json
 import base64
-from typing import Union, Tuple
 
 from fastapi import Request
 
@@ -46,7 +45,7 @@ class AuthMixin(_HostTyped):
 
     def get_basic_auth_credentials(
         self, include_source: bool = False
-    ) -> Union[Tuple[str, str], Tuple[str, str, str]]:
+    ) -> tuple[str, str] | tuple[str, str, str]:
         """
         Get the basic auth credentials
 

--- a/signalwire/signalwire/core/mixins/mcp_server_mixin.py
+++ b/signalwire/signalwire/core/mixins/mcp_server_mixin.py
@@ -9,7 +9,7 @@ Handles the MCP JSON-RPC 2.0 protocol: initialize, tools/list, tools/call.
 """
 
 import logging
-from typing import Dict, Any, List
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ class MCPServerMixin:
 
     def _build_mcp_tool_list(self) -> list:
         """Convert registered @tool functions to MCP tool format"""
-        tools: List[Dict[str, Any]] = []
+        tools: list[dict[str, Any]] = []
 
         if not hasattr(self, "_swaig_functions"):
             return tools
@@ -42,7 +42,7 @@ class MCPServerMixin:
 
         return tools
 
-    def _handle_mcp_request(self, body: Dict[str, Any]) -> Dict[str, Any]:
+    def _handle_mcp_request(self, body: dict[str, Any]) -> dict[str, Any]:
         """Handle a single MCP JSON-RPC 2.0 request"""
         jsonrpc = body.get("jsonrpc", "")
         method = body.get("method", "")
@@ -136,7 +136,7 @@ class MCPServerMixin:
         return self._mcp_error(req_id, -32601, f"Method not found: {method}")
 
     @staticmethod
-    def _mcp_error(req_id, code: int, message: str) -> Dict[str, Any]:
+    def _mcp_error(req_id, code: int, message: str) -> dict[str, Any]:
         """Build a JSON-RPC error response"""
         return {
             "jsonrpc": "2.0",

--- a/signalwire/signalwire/core/mixins/prompt_mixin.py
+++ b/signalwire/signalwire/core/mixins/prompt_mixin.py
@@ -7,7 +7,7 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-from typing import Optional, Union, List, Dict, Any, TYPE_CHECKING
+from typing import Union, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from signalwire.core.agent_base import AgentBase  # type: ignore[attr-defined]  # cycle: agent_base imports the mixins; the name resolves at type-check time but mypy flags the back-reference
@@ -26,7 +26,7 @@ class PromptMixin(_HostTyped):
 
     # Host attribute PromptMixin reads/writes; owned by AgentBase. Declared here
     # (Optional) so the checker resolves it without a cross-class has-type gap.
-    _contexts_builder: Optional[Any]
+    _contexts_builder: Any | None
 
     def _process_prompt_sections(self):
         """
@@ -221,7 +221,7 @@ class PromptMixin(_HostTyped):
         self._prompt_manager.set_post_prompt(text)
         return self
 
-    def set_prompt_pom(self, pom: List[Dict[str, Any]]) -> "AgentBase":
+    def set_prompt_pom(self, pom: list[dict[str, Any]]) -> "AgentBase":
         """
         Set the prompt as a POM dictionary
 
@@ -238,10 +238,10 @@ class PromptMixin(_HostTyped):
         self,
         title: str,
         body: str = "",
-        bullets: Optional[List[str]] = None,
+        bullets: list[str] | None = None,
         numbered: bool = False,
         numbered_bullets: bool = False,
-        subsections: Optional[List[Dict[str, Any]]] = None,
+        subsections: list[dict[str, Any]] | None = None,
     ) -> "AgentBase":
         """
         Add a section to the prompt
@@ -270,9 +270,9 @@ class PromptMixin(_HostTyped):
     def prompt_add_to_section(
         self,
         title: str,
-        body: Optional[str] = None,
-        bullet: Optional[str] = None,
-        bullets: Optional[List[str]] = None,
+        body: str | None = None,
+        bullet: str | None = None,
+        bullets: list[str] | None = None,
     ) -> "AgentBase":
         """
         Add content to an existing section (creating it if needed)
@@ -296,7 +296,7 @@ class PromptMixin(_HostTyped):
         parent_title: str,
         title: str,
         body: str = "",
-        bullets: Optional[List[str]] = None,
+        bullets: list[str] | None = None,
     ) -> "AgentBase":
         """
         Add a subsection to an existing section (creating parent if needed)
@@ -327,7 +327,7 @@ class PromptMixin(_HostTyped):
         """
         return self._prompt_manager.prompt_has_section(title)
 
-    def get_prompt(self) -> Union[str, List[Dict[str, Any]]]:
+    def get_prompt(self) -> str | list[dict[str, Any]]:
         """
         Get the prompt for the agent
 
@@ -374,7 +374,7 @@ class PromptMixin(_HostTyped):
         # Return default text
         return f"You are {self.name}, a helpful AI assistant."
 
-    def get_post_prompt(self) -> Optional[str]:
+    def get_post_prompt(self) -> str | None:
         """
         Get the post-prompt for the agent
 

--- a/signalwire/signalwire/core/mixins/serverless_mixin.py
+++ b/signalwire/signalwire/core/mixins/serverless_mixin.py
@@ -11,7 +11,7 @@ import contextlib
 import os
 import json
 import re
-from typing import Optional, Dict, Any
+from typing import Any
 
 from signalwire.core.logging_config import get_execution_mode
 from signalwire.core.function_result import FunctionResult
@@ -219,9 +219,9 @@ class ServerlessMixin(_HostTyped):
     def _execute_swaig_function(
         self,
         function_name: str,
-        args: Optional[Dict[str, Any]] = None,
-        call_id: Optional[str] = None,
-        raw_data: Optional[Dict[str, Any]] = None,
+        args: dict[str, Any] | None = None,
+        call_id: str | None = None,
+        raw_data: dict[str, Any] | None = None,
     ):
         """
         Execute a SWAIG function in serverless context

--- a/signalwire/signalwire/core/mixins/skill_mixin.py
+++ b/signalwire/signalwire/core/mixins/skill_mixin.py
@@ -7,7 +7,7 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-from typing import TYPE_CHECKING, List, Dict, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from signalwire.core.agent_base import AgentBase  # type: ignore[attr-defined]  # cycle: agent_base imports the mixins; the name resolves at type-check time but mypy flags the back-reference
@@ -22,7 +22,7 @@ class SkillMixin(_HostTyped):
     """
 
     def add_skill(
-        self, skill_name: str, params: Optional[Dict[str, Any]] = None
+        self, skill_name: str, params: dict[str, Any] | None = None
     ) -> "AgentBase":
         """
         Add a skill to this agent
@@ -60,7 +60,7 @@ class SkillMixin(_HostTyped):
         self.skill_manager.unload_skill(skill_name)
         return self
 
-    def list_skills(self) -> List[str]:
+    def list_skills(self) -> list[str]:
         """List currently loaded skills"""
         return self.skill_manager.list_loaded_skills()
 

--- a/signalwire/signalwire/core/mixins/tool_mixin.py
+++ b/signalwire/signalwire/core/mixins/tool_mixin.py
@@ -7,7 +7,8 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-from typing import TYPE_CHECKING, Dict, Any, List, Optional, Callable, Union
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
 import json
 import logging
 
@@ -31,12 +32,12 @@ class ToolMixin(_HostTyped):
         self,
         name: str,
         description: str,
-        parameters: Dict[str, Any],
+        parameters: dict[str, Any],
         handler: Callable,
         secure: bool = True,
-        fillers: Optional[Dict[str, List[str]]] = None,
-        webhook_url: Optional[str] = None,
-        required: Optional[List[str]] = None,
+        fillers: dict[str, list[str]] | None = None,
+        webhook_url: str | None = None,
+        required: list[str] | None = None,
         is_typed_handler: bool = False,
         **swaig_fields,
     ) -> "AgentBase":
@@ -163,7 +164,7 @@ class ToolMixin(_HostTyped):
         )
         return self
 
-    def register_swaig_function(self, function_dict: Dict[str, Any]) -> "AgentBase":
+    def register_swaig_function(self, function_dict: dict[str, Any]) -> "AgentBase":
         """
         Register a raw SWAIG function dictionary (e.g., from DataMap.to_swaig_function())
 
@@ -203,7 +204,7 @@ class ToolMixin(_HostTyped):
         """
         return ToolDecorator.create_class_decorator()(name, **kwargs)
 
-    def define_tools(self) -> List[Union[SWAIGFunction, Dict[str, Any]]]:
+    def define_tools(self) -> list[SWAIGFunction | dict[str, Any]]:
         """
         Define the tools this agent can use
 
@@ -212,7 +213,7 @@ class ToolMixin(_HostTyped):
 
         This method can be overridden by subclasses.
         """
-        tools: List[Union[SWAIGFunction, Dict[str, Any]]] = []
+        tools: list[SWAIGFunction | dict[str, Any]] = []
         for func in self._tool_registry._swaig_functions.values():
             if isinstance(func, dict):
                 # Raw dictionary from register_swaig_function (e.g., DataMap)
@@ -223,7 +224,7 @@ class ToolMixin(_HostTyped):
         return tools
 
     def on_function_call(
-        self, name: str, args: Dict[str, Any], raw_data: Optional[Dict[str, Any]] = None
+        self, name: str, args: dict[str, Any], raw_data: dict[str, Any] | None = None
     ) -> Any:
         """
         Called when a SWAIG function is invoked
@@ -286,9 +287,9 @@ class ToolMixin(_HostTyped):
     def _execute_swaig_function(
         self,
         function_name: str,
-        args: Optional[Dict[str, Any]] = None,
-        call_id: Optional[str] = None,
-        raw_data: Optional[Dict[str, Any]] = None,
+        args: dict[str, Any] | None = None,
+        call_id: str | None = None,
+        raw_data: dict[str, Any] | None = None,
     ):
         """
         Execute a SWAIG function in serverless context

--- a/signalwire/signalwire/core/mixins/web_mixin.py
+++ b/signalwire/signalwire/core/mixins/web_mixin.py
@@ -13,7 +13,8 @@ import json
 import signal
 import sys
 import contextvars
-from typing import TYPE_CHECKING, Optional, Dict, Any, Callable
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
 
 from fastapi import Depends, FastAPI, APIRouter, Request, Response
 
@@ -31,7 +32,7 @@ if TYPE_CHECKING:
     from signalwire.core.agent_base import AgentBase  # type: ignore[attr-defined]  # cycle: agent_base imports the mixins; the name resolves at type-check time but mypy flags the back-reference
 
 # Per-request proxy URL to avoid race conditions in concurrent async contexts
-_request_proxy_url: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+_request_proxy_url: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_request_proxy_url", default=None
 )
 
@@ -48,9 +49,9 @@ class WebMixin(_HostTyped):
     # SWMLService/AgentBase; declared here (with their true Optional types) so the
     # checker resolves them at WebMixin's read/write sites without a cross-class
     # has-type ordering gap. Runtime is unaffected (no assignment here).
-    _app: Optional[Any]
-    _proxy_url_base: Optional[str]
-    _dynamic_config_callback: Optional[Callable[[dict, dict, dict, Any], None]]
+    _app: Any | None
+    _proxy_url_base: str | None
+    _dynamic_config_callback: Callable[[dict, dict, dict, Any], None] | None
 
     def get_app(self):
         """
@@ -171,7 +172,7 @@ class WebMixin(_HostTyped):
 
         return router
 
-    def serve(self, host: Optional[str] = None, port: Optional[int] = None) -> None:
+    def serve(self, host: str | None = None, port: int | None = None) -> None:
         """
         Start a web server for this agent
 
@@ -342,8 +343,8 @@ class WebMixin(_HostTyped):
         event=None,
         context=None,
         force_mode=None,
-        host: Optional[str] = None,
-        port: Optional[int] = None,
+        host: str | None = None,
+        port: int | None = None,
     ):
         """
         Smart run method that automatically detects environment and handles accordingly
@@ -1157,8 +1158,8 @@ class WebMixin(_HostTyped):
             )
 
     def on_request(
-        self, request_data: Optional[dict] = None, callback_path: Optional[str] = None
-    ) -> Optional[dict]:
+        self, request_data: dict | None = None, callback_path: str | None = None
+    ) -> dict | None:
         """
         Called when SWML is requested, with request data when available
 
@@ -1181,10 +1182,10 @@ class WebMixin(_HostTyped):
 
     def on_swml_request(
         self,
-        request_data: Optional[dict] = None,
-        callback_path: Optional[str] = None,
-        request: Optional[Request] = None,
-    ) -> Optional[dict]:
+        request_data: dict | None = None,
+        callback_path: str | None = None,
+        request: Request | None = None,
+    ) -> dict | None:
         """
         Customization point for subclasses to modify SWML based on request data
 
@@ -1225,7 +1226,7 @@ class WebMixin(_HostTyped):
 
     def register_routing_callback(
         self,
-        callback_fn: Callable[[Request, Dict[str, Any]], Optional[str]],
+        callback_fn: Callable[[Request, dict[str, Any]], str | None],
         path: str = "/sip",
     ) -> None:
         """

--- a/signalwire/signalwire/core/pom_builder.py
+++ b/signalwire/signalwire/core/pom_builder.py
@@ -11,7 +11,7 @@ PomBuilder for creating structured POM prompts for SignalWire AI Agents
 
 from signalwire.pom.pom import PromptObjectModel, Section
 
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 
 class PomBuilder:
@@ -31,16 +31,16 @@ class PomBuilder:
     def __init__(self):
         """Initialize a new POM builder with an empty POM"""
         self.pom = PromptObjectModel()
-        self._sections: Dict[str, Section] = {}
+        self._sections: dict[str, Section] = {}
 
     def add_section(
         self,
         title: str,
         body: str = "",
-        bullets: Optional[List[str]] = None,
+        bullets: list[str] | None = None,
         numbered: bool = False,
         numbered_bullets: bool = False,
-        subsections: Optional[List[Dict[str, Any]]] = None,
+        subsections: list[dict[str, Any]] | None = None,
     ) -> "PomBuilder":
         """
         Add a new section to the POM
@@ -84,9 +84,9 @@ class PomBuilder:
     def add_to_section(
         self,
         title: str,
-        body: Optional[str] = None,
-        bullet: Optional[str] = None,
-        bullets: Optional[List[str]] = None,
+        body: str | None = None,
+        bullet: str | None = None,
+        bullets: list[str] | None = None,
     ) -> "PomBuilder":
         """
         Add content to an existing section
@@ -127,7 +127,7 @@ class PomBuilder:
         parent_title: str,
         title: str,
         body: str = "",
-        bullets: Optional[List[str]] = None,
+        bullets: list[str] | None = None,
     ) -> "PomBuilder":
         """
         Add a subsection to an existing section, creating the parent if needed
@@ -161,7 +161,7 @@ class PomBuilder:
         """
         return title in self._sections
 
-    def get_section(self, title: str) -> Optional[Section]:
+    def get_section(self, title: str) -> Section | None:
         """
         Get a section by title
 
@@ -181,7 +181,7 @@ class PomBuilder:
         """Render the POM as XML"""
         return self.pom.render_xml()
 
-    def to_dict(self) -> List[Dict[str, Any]]:
+    def to_dict(self) -> list[dict[str, Any]]:
         """Convert the POM to a list of section dictionaries"""
         return self.pom.to_dict()
 
@@ -190,7 +190,7 @@ class PomBuilder:
         return self.pom.to_json()
 
     @classmethod
-    def from_sections(cls, sections: List[Dict[str, Any]]) -> "PomBuilder":
+    def from_sections(cls, sections: list[dict[str, Any]]) -> "PomBuilder":
         """
         Create a PomBuilder from a list of section dictionaries
 

--- a/signalwire/signalwire/core/security/session_manager.py
+++ b/signalwire/signalwire/core/security/session_manager.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 Session manager for handling call sessions and security tokens
 """
 
-from typing import Dict, Any, Optional
+from typing import Any
 import secrets
 import time
 import hmac
@@ -27,7 +27,7 @@ class SessionManager:
     signatures with the tokens containing all necessary information.
     """
 
-    def __init__(self, token_expiry_secs: int = 900, secret_key: Optional[str] = None):
+    def __init__(self, token_expiry_secs: int = 900, secret_key: str | None = None):
         """
         Initialize the session manager
 
@@ -40,7 +40,7 @@ class SessionManager:
         self.secret_key = secret_key or secrets.token_hex(32)
         self._debug_mode = False
 
-    def create_session(self, call_id: Optional[str] = None) -> str:
+    def create_session(self, call_id: str | None = None) -> str:
         """
         Create a new session ID if one isn't provided
 
@@ -194,7 +194,7 @@ class SessionManager:
         """
         return True
 
-    def get_session_metadata(self, call_id: str) -> Optional[Dict[str, Any]]:
+    def get_session_metadata(self, call_id: str) -> dict[str, Any] | None:
         """
         Legacy method, always returns empty metadata
         """
@@ -206,7 +206,7 @@ class SessionManager:
         """
         return True
 
-    def debug_token(self, token: str) -> Dict[str, Any]:
+    def debug_token(self, token: str) -> dict[str, Any]:
         """
         Debug a token without validating it
 

--- a/signalwire/signalwire/core/security/webhook_middleware.py
+++ b/signalwire/signalwire/core/security/webhook_middleware.py
@@ -39,7 +39,8 @@ Usage::
 from __future__ import annotations
 
 import os
-from typing import Awaitable, Callable, NoReturn, Optional
+from typing import NoReturn
+from collections.abc import Awaitable, Callable
 
 from fastapi import HTTPException, Request, Response, status
 
@@ -77,7 +78,7 @@ def _reconstruct_url(request: Request, *, trust_proxy: bool) -> str:
     return str(request.url)
 
 
-def _extract_signature_header(request: Request) -> Optional[str]:
+def _extract_signature_header(request: Request) -> str | None:
     """Return the SignalWire signature header (or ``X-Twilio-Signature`` alias)."""
     sig = request.headers.get(SIGNALWIRE_SIGNATURE_HEADER)
     if sig is None:
@@ -89,7 +90,7 @@ def make_webhook_validation_dependency(
     signing_key: str,
     *,
     trust_proxy: bool = False,
-) -> Callable[[Request, Response], Awaitable[Optional[Response]]]:
+) -> Callable[[Request, Response], Awaitable[Response | None]]:
     """Build a FastAPI dependency that enforces signature validation.
 
     The returned coroutine:

--- a/signalwire/signalwire/core/security/webhook_validator.py
+++ b/signalwire/signalwire/core/security/webhook_validator.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
-from typing import Any, Dict, List, Mapping, Tuple, Union
+from typing import Any
+from collections.abc import Mapping
 from urllib.parse import parse_qsl, urlparse, urlunparse
 
 
@@ -66,7 +67,7 @@ def _safe_eq(a: str, b: str) -> bool:
 
 
 def _sorted_concat_params(
-    params: Union[Mapping[str, Any], List[Tuple[str, Any]], None],
+    params: Mapping[str, Any] | list[tuple[str, Any]] | None,
 ) -> str:
     """Concatenate form params per Scheme B rules.
 
@@ -81,7 +82,7 @@ def _sorted_concat_params(
 
     # Normalize to a list of (key, value) tuples preserving original order.
     if isinstance(params, Mapping):
-        items: List[Tuple[str, Any]] = []
+        items: list[tuple[str, Any]] = []
         for k, v in params.items():
             if isinstance(v, (list, tuple)):
                 items.extend((k, vi) for vi in v)
@@ -96,7 +97,7 @@ def _sorted_concat_params(
     return "".join(f"{k}{'' if v is None else v}" for k, v in items)
 
 
-def _parse_form_body(raw_body: str) -> List[Tuple[str, str]]:
+def _parse_form_body(raw_body: str) -> list[tuple[str, str]]:
     """Best-effort parse of an x-www-form-urlencoded body.
 
     Returns an empty list if the body doesn't decode as form data; the
@@ -110,7 +111,7 @@ def _parse_form_body(raw_body: str) -> List[Tuple[str, str]]:
         return []
 
 
-def _split_url(url: str) -> Tuple[str, str, str, str, str, str, Dict[str, str]]:
+def _split_url(url: str) -> tuple[str, str, str, str, str, str, dict[str, str]]:
     """Split URL into scheme, host (no port), port (or ''), path, query, fragment, query_params.
 
     Empty strings if the field is absent.
@@ -147,7 +148,7 @@ def _build_url(
     return urlunparse((scheme, netloc, path, "", query, fragment))
 
 
-def _candidate_urls(url: str) -> List[str]:
+def _candidate_urls(url: str) -> list[str]:
     """Return the URL variants to try for Scheme B port normalization.
 
     - If the URL already has a non-standard port: just the input URL.
@@ -161,7 +162,7 @@ def _candidate_urls(url: str) -> List[str]:
         return [url]
 
     standard = {"http": "80", "https": "443"}.get(scheme.lower())
-    candidates: List[str] = [url]
+    candidates: list[str] = [url]
 
     if not port and standard is not None:
         # Input has no port; also try with-standard-port.
@@ -269,7 +270,7 @@ def validate_request(
     signing_key: str,
     signature: str,
     url: str,
-    params_or_raw_body: Union[str, Mapping[str, Any], List[Tuple[str, Any]], None],
+    params_or_raw_body: str | Mapping[str, Any] | list[tuple[str, Any]] | None,
 ) -> bool:
     """Legacy ``@signalwire/compatibility-api`` drop-in entry point.
 

--- a/signalwire/signalwire/core/security_config.py
+++ b/signalwire/signalwire/core/security_config.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 
 import os
 import secrets
-from typing import Dict, Any, ClassVar, Optional, Tuple, Union
+from typing import Any, ClassVar
 from signalwire.core.logging_config import get_logger
 from signalwire.core.config_loader import ConfigLoader
 
@@ -45,7 +45,7 @@ class SecurityConfig:
     BASIC_AUTH_PASSWORD = "SWML_BASIC_AUTH_PASSWORD"  # noqa: S105  # false positive: this is the env-var NAME constant, not a password value
 
     # Defaults (secure by default)
-    DEFAULTS: ClassVar[Dict[str, Any]] = {
+    DEFAULTS: ClassVar[dict[str, Any]] = {
         SSL_ENABLED: False,  # Off by default, but secure when enabled
         SSL_VERIFY_MODE: "CERT_REQUIRED",
         ALLOWED_HOSTS: "*",  # Accept all hosts by default for backward compatibility
@@ -57,9 +57,7 @@ class SecurityConfig:
         HSTS_MAX_AGE: 31536000,  # 1 year
     }
 
-    def __init__(
-        self, config_file: Optional[str] = None, service_name: Optional[str] = None
-    ):
+    def __init__(self, config_file: str | None = None, service_name: str | None = None):
         """
         Initialize security configuration.
 
@@ -98,9 +96,7 @@ class SecurityConfig:
         self.basic_auth_user = None
         self.basic_auth_password = None
 
-    def _load_config_file(
-        self, config_file: Optional[str], service_name: Optional[str]
-    ):
+    def _load_config_file(self, config_file: str | None, service_name: str | None):
         """Load configuration from config file if available"""
         # Find config file
         if not config_file:
@@ -211,7 +207,7 @@ class SecurityConfig:
         self.basic_auth_user = os.environ.get(self.BASIC_AUTH_USER)
         self.basic_auth_password = os.environ.get(self.BASIC_AUTH_PASSWORD)
 
-    def _parse_list(self, value: Union[str, list]) -> list:
+    def _parse_list(self, value: str | list) -> list:
         """Parse comma-separated list from environment variable or list from config"""
         if isinstance(value, list):
             return value
@@ -219,7 +215,7 @@ class SecurityConfig:
             return ["*"]
         return [item.strip() for item in value.split(",") if item.strip()]
 
-    def validate_ssl_config(self) -> Tuple[bool, Optional[str]]:
+    def validate_ssl_config(self) -> tuple[bool, str | None]:
         """
         Validate SSL configuration.
 
@@ -247,7 +243,7 @@ class SecurityConfig:
 
         return True, None
 
-    def get_ssl_context_kwargs(self) -> Dict[str, Any]:
+    def get_ssl_context_kwargs(self) -> dict[str, Any]:
         """
         Get SSL context kwargs for uvicorn.
 
@@ -268,7 +264,7 @@ class SecurityConfig:
             # Additional SSL options can be added here
         }
 
-    def get_basic_auth(self) -> Tuple[str, str]:
+    def get_basic_auth(self) -> tuple[str, str]:
         """
         Get basic auth credentials, generating if not set.
 
@@ -311,7 +307,7 @@ class SecurityConfig:
 
         return username, password
 
-    def get_security_headers(self, is_https: bool = False) -> Dict[str, str]:
+    def get_security_headers(self, is_https: bool = False) -> dict[str, str]:
         """
         Get security headers to add to responses.
 
@@ -351,7 +347,7 @@ class SecurityConfig:
 
         return host in self.allowed_hosts
 
-    def get_cors_config(self) -> Dict[str, Any]:
+    def get_cors_config(self) -> dict[str, Any]:
         """
         Get CORS configuration for FastAPI.
 

--- a/signalwire/signalwire/core/skill_base.py
+++ b/signalwire/signalwire/core/skill_base.py
@@ -8,7 +8,7 @@ See LICENSE file in the project root for full license information.
 """
 
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any, ClassVar, TYPE_CHECKING, Optional
+from typing import Any, ClassVar, TYPE_CHECKING
 
 from signalwire.core.logging_config import get_logger
 
@@ -21,16 +21,16 @@ class SkillBase(ABC):
     """Abstract base class for all agent skills"""
 
     # Subclasses must define these
-    SKILL_NAME: Optional[str] = None  # Required: unique identifier
-    SKILL_DESCRIPTION: Optional[str] = None  # Required: human-readable description
+    SKILL_NAME: str | None = None  # Required: unique identifier
+    SKILL_DESCRIPTION: str | None = None  # Required: human-readable description
     SKILL_VERSION: str = "1.0.0"  # Semantic version
-    REQUIRED_PACKAGES: ClassVar[List[str]] = []  # Python packages needed
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []  # Environment variables needed
+    REQUIRED_PACKAGES: ClassVar[list[str]] = []  # Python packages needed
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []  # Environment variables needed
 
     # Multiple instance support
     SUPPORTS_MULTIPLE_INSTANCES: bool = False  # Set to True to allow multiple instances
 
-    def __init__(self, agent: "AgentBase", params: Optional[Dict[str, Any]] = None):
+    def __init__(self, agent: "AgentBase", params: dict[str, Any] | None = None):
         if self.SKILL_NAME is None:
             raise ValueError(f"{self.__class__.__name__} must define SKILL_NAME")
         if self.SKILL_DESCRIPTION is None:
@@ -76,22 +76,22 @@ class SkillBase(ABC):
         # Call the agent's define_tool with merged arguments
         return self.agent.define_tool(**merged_kwargs)
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints for this skill"""
         return []
 
-    def get_global_data(self) -> Dict[str, Any]:
+    def get_global_data(self) -> dict[str, Any]:
         """Return data to add to agent's global context"""
         return {}
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent.
         Returns empty list if skip_prompt is set to True in params."""
         if self.params.get("skip_prompt", False):
             return []
         return self._get_prompt_sections()
 
-    def _get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def _get_prompt_sections(self) -> list[dict[str, Any]]:
         """Override this in subclasses to provide prompt sections."""
         return []
 
@@ -162,7 +162,7 @@ class SkillBase(ABC):
             return f"skill:{prefix}"
         return f"skill:{self.get_instance_key()}"
 
-    def get_skill_data(self, raw_data: Dict[str, Any]) -> Dict[str, Any]:
+    def get_skill_data(self, raw_data: dict[str, Any]) -> dict[str, Any]:
         """
         Read this skill instance's namespaced data from raw_data global_data.
 
@@ -178,7 +178,7 @@ class SkillBase(ABC):
         return global_data.get(namespace, {})
 
     def update_skill_data(
-        self, result: "FunctionResult", data: Dict[str, Any]
+        self, result: "FunctionResult", data: dict[str, Any]
     ) -> "FunctionResult":
         """
         Write this skill instance's namespaced data into a FunctionResult.
@@ -198,7 +198,7 @@ class SkillBase(ABC):
         return result
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """
         Get the parameter schema for this skill
 

--- a/signalwire/signalwire/core/skill_manager.py
+++ b/signalwire/signalwire/core/skill_manager.py
@@ -7,7 +7,7 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-from typing import Dict, List, Type, Any, Optional
+from typing import Any
 from signalwire.core.logging_config import get_logger
 from signalwire.core.skill_base import SkillBase
 
@@ -17,14 +17,14 @@ class SkillManager:
 
     def __init__(self, agent):
         self.agent = agent
-        self.loaded_skills: Dict[str, SkillBase] = {}
+        self.loaded_skills: dict[str, SkillBase] = {}
         self.logger = get_logger("skill_manager")
 
     def load_skill(
         self,
         skill_name: str,
-        skill_class: Optional[Type[SkillBase]] = None,
-        params: Optional[Dict[str, Any]] = None,
+        skill_class: type[SkillBase] | None = None,
+        params: dict[str, Any] | None = None,
     ) -> tuple[bool, str]:
         """
         Load and setup a skill by name
@@ -235,7 +235,7 @@ class SkillManager:
             self.logger.error(f"Error unloading skill '{skill_identifier}': {e}")
             return False
 
-    def list_loaded_skills(self) -> List[str]:
+    def list_loaded_skills(self) -> list[str]:
         """List instance keys of currently loaded skills"""
         return list(self.loaded_skills.keys())
 
@@ -252,7 +252,7 @@ class SkillManager:
         # First try as direct instance key
         return skill_identifier in self.loaded_skills
 
-    def get_skill(self, skill_identifier: str) -> Optional[SkillBase]:
+    def get_skill(self, skill_identifier: str) -> SkillBase | None:
         """
         Get a loaded skill instance by identifier
 

--- a/signalwire/signalwire/core/swaig_function.py
+++ b/signalwire/signalwire/core/swaig_function.py
@@ -9,7 +9,8 @@ See LICENSE file in the project root for full license information.
 SwaigFunction class for defining and managing SWAIG function interfaces
 """
 
-from typing import Dict, Any, Optional, Callable, List
+from typing import Any
+from collections.abc import Callable
 import logging
 
 # Import here to avoid circular imports
@@ -45,13 +46,13 @@ class SWAIGFunction:
         name: str,
         handler: Callable,
         description: str,
-        parameters: Optional[Dict[str, Dict]] = None,
+        parameters: dict[str, dict] | None = None,
         secure: bool = False,
-        fillers: Optional[Dict[str, List[str]]] = None,
-        wait_file: Optional[str] = None,
-        wait_file_loops: Optional[int] = None,
-        webhook_url: Optional[str] = None,
-        required: Optional[List[str]] = None,
+        fillers: dict[str, list[str]] | None = None,
+        wait_file: str | None = None,
+        wait_file_loops: int | None = None,
+        webhook_url: str | None = None,
+        required: list[str] | None = None,
         is_typed_handler: bool = False,
         **extra_swaig_fields,
     ):
@@ -103,7 +104,7 @@ class SWAIGFunction:
         # Mark as external if webhook_url is provided
         self.is_external = webhook_url is not None
 
-    def _ensure_parameter_structure(self) -> Dict:
+    def _ensure_parameter_structure(self) -> dict:
         """
         Ensure the parameters are correctly structured for SWML
 
@@ -133,8 +134,8 @@ class SWAIGFunction:
         return self.handler(*args, **kwargs)
 
     def execute(
-        self, args: Dict[str, Any], raw_data: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
+        self, args: dict[str, Any], raw_data: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """
         Execute the function with the given arguments
 
@@ -174,7 +175,7 @@ class SWAIGFunction:
                 "Sorry, I couldn't complete that action. Please try again or contact support if the issue persists."
             ).to_dict()
 
-    def validate_args(self, args: Dict[str, Any]) -> tuple:
+    def validate_args(self, args: dict[str, Any]) -> tuple:
         """
         Validate the arguments against the parameter schema.
 
@@ -229,10 +230,10 @@ class SWAIGFunction:
     def to_swaig(
         self,
         base_url: str,
-        token: Optional[str] = None,
-        call_id: Optional[str] = None,
+        token: str | None = None,
+        call_id: str | None = None,
         include_auth: bool = True,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Convert this function to a SWAIG-compatible JSON object for SWML
 

--- a/signalwire/signalwire/core/swml_builder.py
+++ b/signalwire/signalwire/core/swml_builder.py
@@ -13,7 +13,7 @@ It allows for chaining method calls to build up a document step by step.
 """
 
 import types
-from typing import Dict, List, Any, Optional, TypeVar
+from typing import Any, TypeVar
 
 try:
     from typing import Self  # type: ignore[attr-defined]  # 3.11+; typing_extensions fallback below
@@ -45,13 +45,13 @@ class SWMLBuilder:
         self.service = service
 
         # Dictionary to cache dynamically created methods
-        self._verb_methods_cache: Dict[str, Any] = {}
+        self._verb_methods_cache: dict[str, Any] = {}
 
         # Create auto-vivified methods for all verbs
         self._create_verb_methods()
 
     def answer(
-        self, max_duration: Optional[int] = None, codecs: Optional[str] = None
+        self, max_duration: int | None = None, codecs: str | None = None
     ) -> Self:
         """
         Add an 'answer' verb to the main section
@@ -63,7 +63,7 @@ class SWMLBuilder:
         Returns:
             Self for method chaining
         """
-        config: Dict[str, Any] = {}
+        config: dict[str, Any] = {}
         if max_duration is not None:
             config["max_duration"] = max_duration
         if codecs is not None:
@@ -71,7 +71,7 @@ class SWMLBuilder:
         self.service.add_verb("answer", config)
         return self
 
-    def hangup(self, reason: Optional[str] = None) -> Self:
+    def hangup(self, reason: str | None = None) -> Self:
         """
         Add a 'hangup' verb to the main section
 
@@ -81,7 +81,7 @@ class SWMLBuilder:
         Returns:
             Self for method chaining
         """
-        config: Dict[str, Any] = {}
+        config: dict[str, Any] = {}
         if reason is not None:
             config["reason"] = reason
         self.service.add_verb("hangup", config)
@@ -89,11 +89,11 @@ class SWMLBuilder:
 
     def ai(
         self,
-        prompt_text: Optional[str] = None,
-        prompt_pom: Optional[List[Dict[str, Any]]] = None,
-        post_prompt: Optional[str] = None,
-        post_prompt_url: Optional[str] = None,
-        swaig: Optional[Dict[str, Any]] = None,
+        prompt_text: str | None = None,
+        prompt_pom: list[dict[str, Any]] | None = None,
+        post_prompt: str | None = None,
+        post_prompt_url: str | None = None,
+        swaig: dict[str, Any] | None = None,
         **kwargs,
     ) -> Self:
         """
@@ -110,7 +110,7 @@ class SWMLBuilder:
         Returns:
             Self for method chaining
         """
-        config: Dict[str, Any] = {}
+        config: dict[str, Any] = {}
 
         # Handle prompt (either text or POM, but not both)
         if prompt_text is not None:
@@ -134,13 +134,13 @@ class SWMLBuilder:
 
     def play(
         self,
-        url: Optional[str] = None,
-        urls: Optional[List[str]] = None,
-        volume: Optional[float] = None,
-        say_voice: Optional[str] = None,
-        say_language: Optional[str] = None,
-        say_gender: Optional[str] = None,
-        auto_answer: Optional[bool] = None,
+        url: str | None = None,
+        urls: list[str] | None = None,
+        volume: float | None = None,
+        say_voice: str | None = None,
+        say_language: str | None = None,
+        say_gender: str | None = None,
+        auto_answer: bool | None = None,
     ) -> Self:
         """
         Add a 'play' verb to the main section
@@ -158,7 +158,7 @@ class SWMLBuilder:
             Self for method chaining
         """
         # Create base config
-        config: Dict[str, Any] = {}
+        config: dict[str, Any] = {}
 
         # Add play config (either single URL or list)
         if url is not None:
@@ -187,10 +187,10 @@ class SWMLBuilder:
     def say(
         self,
         text: str,
-        voice: Optional[str] = None,
-        language: Optional[str] = None,
-        gender: Optional[str] = None,
-        volume: Optional[float] = None,
+        voice: str | None = None,
+        language: str | None = None,
+        gender: str | None = None,
+        volume: float | None = None,
     ) -> Self:
         """
         Add a 'play' verb with say: prefix for text-to-speech
@@ -230,7 +230,7 @@ class SWMLBuilder:
         self.service.add_section(section_name)
         return self
 
-    def build(self) -> Dict[str, Any]:
+    def build(self) -> dict[str, Any]:
         """
         Build and return the SWML document
 
@@ -312,7 +312,7 @@ class SWMLBuilder:
                     """
                     Dynamically generated method for SWML verb - returns self for chaining
                     """
-                    config: Dict[str, Any] = {
+                    config: dict[str, Any] = {
                         key: value for key, value in kwargs.items() if value is not None
                     }
                     self_instance.service.add_verb(name, config)
@@ -407,7 +407,7 @@ class SWMLBuilder:
                 """
                 Dynamically generated method for SWML verb - returns self for chaining
                 """
-                config: Dict[str, Any] = {
+                config: dict[str, Any] = {
                     key: value for key, value in kwargs.items() if value is not None
                 }
                 self_instance.service.add_verb(name, config)

--- a/signalwire/signalwire/core/swml_handler.py
+++ b/signalwire/signalwire/core/swml_handler.py
@@ -13,7 +13,7 @@ implementations for specific verbs that require special handling.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, List, Any, Optional, Tuple
+from typing import Any
 
 
 class SWMLVerbHandler(ABC):
@@ -36,7 +36,7 @@ class SWMLVerbHandler(ABC):
         pass
 
     @abstractmethod
-    def validate_config(self, config: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    def validate_config(self, config: dict[str, Any]) -> tuple[bool, list[str]]:
         """
         Validate the configuration for this verb
 
@@ -49,7 +49,7 @@ class SWMLVerbHandler(ABC):
         pass
 
     @abstractmethod
-    def build_config(self, **kwargs) -> Dict[str, Any]:
+    def build_config(self, **kwargs) -> dict[str, Any]:
         """
         Build a configuration for this verb from the provided arguments
 
@@ -79,7 +79,7 @@ class AIVerbHandler(SWMLVerbHandler):
         """
         return "ai"
 
-    def validate_config(self, config: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    def validate_config(self, config: dict[str, Any]) -> tuple[bool, list[str]]:
         """
         Validate the configuration for the AI verb
 
@@ -131,14 +131,14 @@ class AIVerbHandler(SWMLVerbHandler):
 
     def build_config(
         self,
-        prompt_text: Optional[str] = None,
-        prompt_pom: Optional[List[Dict[str, Any]]] = None,
-        contexts: Optional[Dict[str, Any]] = None,
-        post_prompt: Optional[str] = None,
-        post_prompt_url: Optional[str] = None,
-        swaig: Optional[Dict[str, Any]] = None,
+        prompt_text: str | None = None,
+        prompt_pom: list[dict[str, Any]] | None = None,
+        contexts: dict[str, Any] | None = None,
+        post_prompt: str | None = None,
+        post_prompt_url: str | None = None,
+        swaig: dict[str, Any] | None = None,
         **kwargs,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Build a configuration for the AI verb
 
@@ -154,7 +154,7 @@ class AIVerbHandler(SWMLVerbHandler):
         Returns:
             AI verb configuration dictionary
         """
-        config: Dict[str, Any] = {}
+        config: dict[str, Any] = {}
 
         # Require either text or pom as base prompt (mutually exclusive)
         base_prompt_count = sum(x is not None for x in [prompt_text, prompt_pom])
@@ -166,7 +166,7 @@ class AIVerbHandler(SWMLVerbHandler):
             raise ValueError("prompt_text and prompt_pom are mutually exclusive")
 
         # Build prompt object with base prompt
-        prompt_config: Dict[str, Any] = {}
+        prompt_config: dict[str, Any] = {}
         if prompt_text is not None:
             prompt_config["text"] = prompt_text
         elif prompt_pom is not None:
@@ -236,7 +236,7 @@ class VerbHandlerRegistry:
         verb_name = handler.get_verb_name()
         self._handlers[verb_name] = handler
 
-    def get_handler(self, verb_name: str) -> Optional[SWMLVerbHandler]:
+    def get_handler(self, verb_name: str) -> SWMLVerbHandler | None:
         """
         Get the handler for a specific verb
 

--- a/signalwire/signalwire/core/swml_renderer.py
+++ b/signalwire/signalwire/core/swml_renderer.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 SWML document rendering utilities for SignalWire AI Agents.
 """
 
-from typing import Dict, List, Any, Optional, Union, cast
+from typing import Any, cast
 
 from signalwire.core.swml_service import SWMLService
 from signalwire.core.swml_builder import SWMLBuilder
@@ -24,21 +24,21 @@ class SwmlRenderer:
 
     @staticmethod
     def render_swml(
-        prompt: Union[str, List[Dict[str, Any]]],
+        prompt: str | list[dict[str, Any]],
         service: SWMLService,
-        post_prompt: Optional[str] = None,
-        post_prompt_url: Optional[str] = None,
-        swaig_functions: Optional[List[Dict[str, Any]]] = None,
-        startup_hook_url: Optional[str] = None,
-        hangup_hook_url: Optional[str] = None,
+        post_prompt: str | None = None,
+        post_prompt_url: str | None = None,
+        swaig_functions: list[dict[str, Any]] | None = None,
+        startup_hook_url: str | None = None,
+        hangup_hook_url: str | None = None,
         prompt_is_pom: bool = False,
-        params: Optional[Dict[str, Any]] = None,
+        params: dict[str, Any] | None = None,
         add_answer: bool = False,
         record_call: bool = False,
         record_format: str = "mp4",
         record_stereo: bool = True,
         format: str = "json",
-        default_webhook_url: Optional[str] = None,
+        default_webhook_url: str | None = None,
     ) -> str:
         """
         Generate a complete SWML document with AI configuration
@@ -80,7 +80,7 @@ class SwmlRenderer:
             )
 
         # Configure SWAIG object for AI verb
-        swaig_config: Dict[str, Any] = {}
+        swaig_config: dict[str, Any] = {}
         functions = []
 
         # Add startup hook if provided
@@ -130,7 +130,7 @@ class SwmlRenderer:
         # so cast each branch to the type it is guaranteed to be.
         builder.ai(
             prompt_text=None if prompt_is_pom else cast(str, prompt),
-            prompt_pom=cast(List[Dict[str, Any]], prompt) if prompt_is_pom else None,
+            prompt_pom=cast(list[dict[str, Any]], prompt) if prompt_is_pom else None,
             post_prompt=post_prompt,
             post_prompt_url=post_prompt_url,
             swaig=swaig_config if swaig_config else None,
@@ -148,7 +148,7 @@ class SwmlRenderer:
     def render_function_response_swml(
         response_text: str,
         service: SWMLService,
-        actions: Optional[List[Dict[str, Any]]] = None,
+        actions: list[dict[str, Any]] | None = None,
         format: str = "json",
     ) -> str:
         """

--- a/signalwire/signalwire/core/swml_service.py
+++ b/signalwire/signalwire/core/swml_service.py
@@ -19,7 +19,8 @@ import re
 import base64
 import sys
 import types
-from typing import Dict, Any, Optional, Union, Callable, Tuple
+from typing import Any
+from collections.abc import Callable
 from urllib.parse import urlparse
 
 # Import centralized logging system
@@ -88,10 +89,10 @@ class SWMLService(ToolMixin):
         name: str,
         route: str = "/",
         host: str = "0.0.0.0",  # noqa: S104  # intended server default: listen on all interfaces (overridable)
-        port: Optional[int] = None,
-        basic_auth: Optional[Tuple[str, str]] = None,
-        schema_path: Optional[str] = None,
-        config_file: Optional[str] = None,
+        port: int | None = None,
+        basic_auth: tuple[str, str] | None = None,
+        schema_path: str | None = None,
+        config_file: str | None = None,
         schema_validation: bool = True,
     ):
         """
@@ -129,7 +130,7 @@ class SWMLService(ToolMixin):
         self.ssl_key_path = self.security.ssl_key_path
 
         # Initialize proxy detection attributes
-        self._proxy_url_base: Optional[str] = os.environ.get("SWML_PROXY_URL_BASE")
+        self._proxy_url_base: str | None = os.environ.get("SWML_PROXY_URL_BASE")
         self._proxy_url_base_from_env = bool(
             self._proxy_url_base
         )  # Track if it came from environment
@@ -175,21 +176,21 @@ class SWMLService(ToolMixin):
         self.verb_registry = VerbHandlerRegistry()
 
         # Server state
-        self._app: Optional[Any] = None
-        self._router: Optional[Any] = None
+        self._app: Any | None = None
+        self._router: Any | None = None
         self._running = False
 
         # Initialize SWML document state
         self._current_document = self._create_empty_document()
 
         # Dictionary to cache dynamically created methods (instance level cache)
-        self._verb_methods_cache: Dict[str, Any] = {}
+        self._verb_methods_cache: dict[str, Any] = {}
 
         # Create auto-vivified methods for all verbs
         self._create_verb_methods()
 
         # Initialize routing callbacks dictionary (path -> callback)
-        self._routing_callbacks: Dict[str, Any] = {}
+        self._routing_callbacks: dict[str, Any] = {}
 
         # SWAIG tool registry — lifted from AgentBase so that any SWMLService
         # (sidecar, custom verb host, etc.) can register and dispatch SWAIG
@@ -396,7 +397,7 @@ class SWMLService(ToolMixin):
             self.schema_utils.full_validation_available if self.schema_utils else False
         )
 
-    def _find_schema_path(self) -> Optional[str]:
+    def _find_schema_path(self) -> str | None:
         """
         Find the schema.json file location
 
@@ -459,7 +460,7 @@ class SWMLService(ToolMixin):
 
         return None
 
-    def _create_empty_document(self) -> Dict[str, Any]:
+    def _create_empty_document(self) -> dict[str, Any]:
         """
         Create an empty SWML document
 
@@ -474,7 +475,7 @@ class SWMLService(ToolMixin):
         """
         self._current_document = self._create_empty_document()
 
-    def add_verb(self, verb_name: str, config: Union[Dict[str, Any], int]) -> bool:
+    def add_verb(self, verb_name: str, config: dict[str, Any] | int) -> bool:
         """
         Add a verb to the main section of the current document
 
@@ -488,7 +489,7 @@ class SWMLService(ToolMixin):
         # Special case for verbs that take direct values (like sleep)
         if verb_name == "sleep" and isinstance(config, int):
             # Sleep verb takes a direct integer value
-            verb_obj: Dict[str, Any] = {verb_name: config}
+            verb_obj: dict[str, Any] = {verb_name: config}
             self._current_document["sections"]["main"].append(verb_obj)
             return True
 
@@ -536,7 +537,7 @@ class SWMLService(ToolMixin):
         return True
 
     def add_verb_to_section(
-        self, section_name: str, verb_name: str, config: Union[Dict[str, Any], int]
+        self, section_name: str, verb_name: str, config: dict[str, Any] | int
     ) -> bool:
         """
         Add a verb to a specific section
@@ -556,7 +557,7 @@ class SWMLService(ToolMixin):
         # Special case for verbs that take direct values (like sleep)
         if verb_name == "sleep" and isinstance(config, int):
             # Sleep verb takes a direct integer value
-            verb_obj: Dict[str, Any] = {verb_name: config}
+            verb_obj: dict[str, Any] = {verb_name: config}
             self._current_document["sections"][section_name].append(verb_obj)
             return True
 
@@ -588,7 +589,7 @@ class SWMLService(ToolMixin):
         self._current_document["sections"][section_name].append(verb_obj)
         return True
 
-    def get_document(self) -> Dict[str, Any]:
+    def get_document(self) -> dict[str, Any]:
         """
         Get the current SWML document
 
@@ -695,7 +696,7 @@ class SWMLService(ToolMixin):
         return "application/json" in content_type
 
     async def _swaig_render_get_response(
-        self, request: Request, call_id: Optional[str]
+        self, request: Request, call_id: str | None
     ) -> Response:
         """Extension point: render the SWML document for a GET on /swaig.
 
@@ -708,10 +709,10 @@ class SWMLService(ToolMixin):
     def _swaig_pre_dispatch(
         self,
         request: Request,
-        body: Dict[str, Any],
-        call_id: Optional[str],
+        body: dict[str, Any],
+        call_id: str | None,
         function_name: str,
-    ) -> Tuple[Any, Optional[Dict[str, Any]]]:
+    ) -> tuple[Any, dict[str, Any] | None]:
         """Extension point: invoked between argument parsing and function dispatch.
 
         Returns a tuple (target, short_circuit):
@@ -800,7 +801,7 @@ class SWMLService(ToolMixin):
             # Argument extraction. Handle both AgentBase's nested
             # {"argument": {"parsed": [...], "raw": "..."}} shape AND a flat
             # {"arguments": {...}} shape used by some external integrations.
-            args: Dict[str, Any] = {}
+            args: dict[str, Any] = {}
             if "argument" in body and isinstance(body["argument"], dict):
                 if (
                     "parsed" in body["argument"]
@@ -861,7 +862,7 @@ class SWMLService(ToolMixin):
 
     def register_routing_callback(
         self,
-        callback_fn: Callable[[Request, Dict[str, Any]], Optional[str]],
+        callback_fn: Callable[[Request, dict[str, Any]], str | None],
         path: str = "/sip",
     ) -> None:
         """
@@ -889,7 +890,7 @@ class SWMLService(ToolMixin):
         self._routing_callbacks[normalized_path] = callback_fn
 
     @staticmethod
-    def extract_sip_username(request_body: Dict[str, Any]) -> Optional[str]:
+    def extract_sip_username(request_body: dict[str, Any]) -> str | None:
         """
         Extract SIP username from request body
 
@@ -1016,8 +1017,8 @@ class SWMLService(ToolMixin):
         return Response(content=swml, media_type="application/json")
 
     def on_request(
-        self, request_data: Optional[dict] = None, callback_path: Optional[str] = None
-    ) -> Optional[dict]:
+        self, request_data: dict | None = None, callback_path: str | None = None
+    ) -> dict | None:
         """
         Called when SWML is requested, with request data when available
 
@@ -1035,12 +1036,12 @@ class SWMLService(ToolMixin):
 
     def serve(
         self,
-        host: Optional[str] = None,
-        port: Optional[int] = None,
-        ssl_cert: Optional[str] = None,
-        ssl_key: Optional[str] = None,
-        ssl_enabled: Optional[bool] = None,
-        domain: Optional[str] = None,
+        host: str | None = None,
+        port: int | None = None,
+        ssl_cert: str | None = None,
+        ssl_key: str | None = None,
+        ssl_enabled: bool | None = None,
+        domain: str | None = None,
     ) -> None:
         """
         Start a web server for this service
@@ -1229,7 +1230,7 @@ class SWMLService(ToolMixin):
 
     def get_basic_auth_credentials(
         self, include_source: bool = False
-    ) -> Union[Tuple[str, str], Tuple[str, str, str]]:
+    ) -> tuple[str, str] | tuple[str, str, str]:
         """
         Get the basic auth credentials
 
@@ -1372,7 +1373,7 @@ class SWMLService(ToolMixin):
         self,
         endpoint: str = "",
         include_auth: bool = True,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: dict[str, str] | None = None,
     ) -> str:
         """
         Build the full URL for this service or a specific endpoint
@@ -1417,7 +1418,7 @@ class SWMLService(ToolMixin):
         return url
 
     def _build_webhook_url(
-        self, endpoint: str, query_params: Optional[Dict[str, str]] = None
+        self, endpoint: str, query_params: dict[str, str] | None = None
     ) -> str:
         """
         Helper method to build webhook URLs consistently

--- a/signalwire/signalwire/livewire/__init__.py
+++ b/signalwire/signalwire/livewire/__init__.py
@@ -20,7 +20,8 @@ import inspect
 import logging
 import threading
 import asyncio
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Optional
+from collections.abc import Callable
 
 # ---------------------------------------------------------------------------
 # Sentinel for "not given" keyword arguments (distinct from None)
@@ -98,7 +99,7 @@ class _NoopTracker:
 
     def __init__(self):
         self._lock = threading.Lock()
-        self._logged: Dict[str, bool] = {}
+        self._logged: dict[str, bool] = {}
 
     def once(self, key: str, message: str) -> bool:
         """Log *message* once for *key*.  Returns True if it was logged."""
@@ -155,7 +156,7 @@ class ChatContext:
     """Minimal stub mirroring livekit ChatContext."""
 
     def __init__(self):
-        self.messages: List[Dict[str, str]] = []
+        self.messages: list[dict[str, str]] = []
 
     def append(self, *, role: str = "user", text: str = ""):
         self.messages.append({"role": role, "content": text})
@@ -168,7 +169,7 @@ class ChatContext:
 
 
 def function_tool(
-    func=None, *, name: Optional[str] = None, description: Optional[str] = None
+    func=None, *, name: str | None = None, description: str | None = None
 ):
     """Mirrors the livekit ``@function_tool`` decorator.
 
@@ -183,8 +184,8 @@ def function_tool(
 
         # Build a JSON-schema-style parameter dict from type hints
         sig = inspect.signature(fn)
-        properties: Dict[str, Any] = {}
-        required: List[str] = []
+        properties: dict[str, Any] = {}
+        required: list[str] = []
 
         for pname, param in sig.parameters.items():
             # Skip 'self' and RunContext parameters
@@ -273,7 +274,7 @@ class Agent:
         self,
         *,
         instructions: str = "",
-        tools: Optional[List[Any]] = None,
+        tools: list[Any] | None = None,
         chat_ctx: Any = NOT_GIVEN,
         stt: Any = NOT_GIVEN,
         tts: Any = NOT_GIVEN,
@@ -286,9 +287,9 @@ class Agent:
         max_endpointing_delay: Any = NOT_GIVEN,
     ):
         self.instructions = instructions
-        self._tools: List[Any] = list(tools or [])
+        self._tools: list[Any] = list(tools or [])
         self._chat_ctx = chat_ctx
-        self._session: Optional["AgentSession"] = None
+        self._session: AgentSession | None = None
         self._userdata: Any = {}
 
         # Pipeline config (noop when not NOT_GIVEN)
@@ -389,7 +390,7 @@ class Agent:
         """Update the agent's instructions mid-session."""
         self.instructions = instructions
 
-    async def update_tools(self, tools: List[Any]):
+    async def update_tools(self, tools: list[Any]):
         """Update the agent's tool list mid-session."""
         self._tools = list(tools)
 
@@ -411,7 +412,7 @@ class AgentSession:
         llm: Any = None,
         vad: Any = None,
         turn_detection: Any = None,
-        tools: Optional[List[Any]] = None,
+        tools: list[Any] | None = None,
         mcp_servers: Any = None,
         userdata: Any = None,
         allow_interruptions: bool = True,
@@ -473,10 +474,10 @@ class AgentSession:
             )
 
         # Internal state
-        self._agent: Optional[Agent] = None
+        self._agent: Agent | None = None
         self._sw_agent: Any = None  # Will hold the real AgentBase
-        self._say_queue: List[str] = []
-        self._history: List[Dict[str, str]] = []
+        self._say_queue: list[str] = []
+        self._history: list[dict[str, str]] = []
         self._noop = _NoopTracker()
         self._started = False
 
@@ -493,7 +494,7 @@ class AgentSession:
         self._userdata = val
 
     @property
-    def history(self) -> List[Dict[str, str]]:
+    def history(self) -> list[dict[str, str]]:
         return self._history
 
     # ------------------------------------------------------------------
@@ -510,7 +511,7 @@ class AgentSession:
         """Queue text to be spoken by the agent."""
         self._say_queue.append(text)
 
-    def generate_reply(self, *, instructions: Optional[str] = None):
+    def generate_reply(self, *, instructions: str | None = None):
         """Trigger the agent to generate a reply.  On SignalWire the prompt
         handles this; if *instructions* is provided they are noted."""
         if instructions:
@@ -649,7 +650,7 @@ class JobProcess:
     """Mirrors a livekit JobProcess -- used for prewarm/setup."""
 
     def __init__(self):
-        self.userdata: Dict[str, Any] = {}
+        self.userdata: dict[str, Any] = {}
 
 
 class JobContext:
@@ -687,8 +688,8 @@ class AgentServer:
     """Mirrors a livekit AgentServer -- registers entrypoints and starts."""
 
     def __init__(self, **kwargs):
-        self.setup_fnc: Optional[Callable] = None
-        self._entrypoint: Optional[Callable] = None
+        self.setup_fnc: Callable | None = None
+        self._entrypoint: Callable | None = None
         self._agent_name: str = ""
 
     def rtc_session(

--- a/signalwire/signalwire/livewire/plugins.py
+++ b/signalwire/signalwire/livewire/plugins.py
@@ -15,13 +15,13 @@ STT/TTS/LLM/VAD infrastructure -- these are no-ops that log once.
 
 import logging
 import threading
-from typing import Any, Dict
+from typing import Any
 
 _logger = logging.getLogger("LiveWire")
 
 # Reuse a simple once-tracker scoped to this module
 _lock = threading.Lock()
-_logged: Dict[str, bool] = {}
+_logged: dict[str, bool] = {}
 
 
 def _log_once(key: str, message: str):

--- a/signalwire/signalwire/mcp_gateway/gateway_service.py
+++ b/signalwire/signalwire/mcp_gateway/gateway_service.py
@@ -21,7 +21,7 @@ import argparse
 from pathlib import Path
 import signal
 import re
-from typing import Dict, Any, Optional
+from typing import Any
 from datetime import datetime
 import ssl
 import concurrent.futures
@@ -70,7 +70,7 @@ class MCPGateway:
         self.app = Flask(__name__)
         self.mcp_manager = MCPManager(self.config)
         self.session_manager = SessionManager(self.config)
-        self.server: Optional[BaseWSGIServer] = None
+        self.server: BaseWSGIServer | None = None
         self._shutdown_requested = False
         self._shutdown_cleanup_done = False
 
@@ -154,7 +154,7 @@ class MCPGateway:
             raise ValueError("Tool name contains invalid characters")
         return name
 
-    def _log_security_event(self, event_type: str, details: Dict[str, Any]):
+    def _log_security_event(self, event_type: str, details: dict[str, Any]):
         """Log security-relevant events with proper sanitization"""
         # Sanitize any user input in details
         sanitized = {}
@@ -193,7 +193,7 @@ class MCPGateway:
             return [self._substitute_env_vars(item) for item in value]
         return value
 
-    def _load_config(self, config_path: str) -> Dict[str, Any]:
+    def _load_config(self, config_path: str) -> dict[str, Any]:
         """Load configuration from JSON file with environment variable substitution"""
         if not Path(config_path).exists():
             # Check if sample_config.json exists

--- a/signalwire/signalwire/mcp_gateway/mcp_manager.py
+++ b/signalwire/signalwire/mcp_gateway/mcp_manager.py
@@ -25,7 +25,7 @@ import pwd
 import shutil
 import resource
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Any
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -36,10 +36,10 @@ class MCPService:
     """Configuration for an MCP service"""
 
     name: str
-    command: List[str]
+    command: list[str]
     description: str
     enabled: bool = True
-    sandbox_config: Optional[Dict[str, Any]] = None
+    sandbox_config: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         # Default sandbox config if not provided
@@ -59,18 +59,18 @@ class MCPClient:
 
     def __init__(self, service: MCPService, sandbox_base_dir: str = "./sandbox"):
         self.service = service
-        self.process: Optional["subprocess.Popen[str]"] = None
+        self.process: subprocess.Popen[str] | None = None
         self.request_id = 0
-        self.pending_requests: Dict[Any, Any] = {}
-        self.response_queue: "queue.Queue[Any]" = queue.Queue()
-        self.reader_thread: Optional[threading.Thread] = None
+        self.pending_requests: dict[Any, Any] = {}
+        self.response_queue: queue.Queue[Any] = queue.Queue()
+        self.reader_thread: threading.Thread | None = None
         self.lock = threading.Lock()
-        self.tools: List[Any] = []
+        self.tools: list[Any] = []
         self.sandbox_base_dir = sandbox_base_dir
-        self.sandbox_dir: Optional[str] = None
+        self.sandbox_dir: str | None = None
         self._shutdown = threading.Event()
 
-    def _setup_sandbox_env(self) -> Tuple[Dict[str, str], Optional[str]]:
+    def _setup_sandbox_env(self) -> tuple[dict[str, str], str | None]:
         """Create environment for the MCP process based on sandbox config
 
         Returns:
@@ -293,13 +293,13 @@ class MCPClient:
             except Exception as e:
                 logger.warning(f"Failed to clean up sandbox directory: {e}")
 
-    def call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         """Call a tool on the MCP server"""
         return self.call_method(
             "tools/call", {"name": tool_name, "arguments": arguments}
         )
 
-    def call_method(self, method: str, params: Dict[str, Any]) -> Any:
+    def call_method(self, method: str, params: dict[str, Any]) -> Any:
         """Call an RPC method and wait for response"""
         if self._shutdown.is_set():
             raise RuntimeError("Client is shutting down")
@@ -338,11 +338,11 @@ class MCPClient:
 
         return response.get("result")
 
-    def get_tools(self) -> List[Dict[str, Any]]:
+    def get_tools(self) -> list[dict[str, Any]]:
         """Get the list of available tools"""
         return self.tools.copy()
 
-    def _send_message(self, message: Dict[str, Any]):
+    def _send_message(self, message: dict[str, Any]):
         """Send a JSON-RPC message to the server"""
         if not self.process or self.process.poll() is not None:
             raise RuntimeError("MCP server process is not running")
@@ -435,7 +435,7 @@ class MCPClient:
             logger.error(f"Failed to initialize '{self.service.name}': {e}")
             return False
 
-    def _list_tools(self) -> List[Dict[str, Any]]:
+    def _list_tools(self) -> list[dict[str, Any]]:
         """Get the list of available tools from the server"""
         try:
             result = self.call_method("tools/list", {})
@@ -449,10 +449,10 @@ class MCPClient:
 class MCPManager:
     """Manages multiple MCP services and their lifecycles"""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         self.config = config
-        self.services: Dict[str, MCPService] = {}
-        self.clients: Dict[str, MCPClient] = {}
+        self.services: dict[str, MCPService] = {}
+        self.clients: dict[str, MCPClient] = {}
         self._clients_lock = threading.RLock()
 
         # Get sandbox directory from config or use default
@@ -490,11 +490,11 @@ class MCPManager:
                 extra={"service": name, "description": service.description},
             )
 
-    def get_service(self, service_name: str) -> Optional[MCPService]:
+    def get_service(self, service_name: str) -> MCPService | None:
         """Get a service definition by name"""
         return self.services.get(service_name)
 
-    def list_services(self) -> Dict[str, Dict[str, Any]]:
+    def list_services(self) -> dict[str, dict[str, Any]]:
         """List all available services"""
         result = {}
 
@@ -526,7 +526,7 @@ class MCPManager:
 
             return client
 
-    def get_service_tools(self, service_name: str) -> List[Dict[str, Any]]:
+    def get_service_tools(self, service_name: str) -> list[dict[str, Any]]:
         """Get tools for a service by starting a temporary instance"""
         with self._clients_lock:
             client = None
@@ -541,7 +541,7 @@ class MCPManager:
                     if client_key and client_key in self.clients:
                         del self.clients[client_key]
 
-    def validate_services(self) -> Dict[str, bool]:
+    def validate_services(self) -> dict[str, bool]:
         """Validate that all services can be started"""
         with self._clients_lock:
             results = {}

--- a/signalwire/signalwire/mcp_gateway/session_manager.py
+++ b/signalwire/signalwire/mcp_gateway/session_manager.py
@@ -15,7 +15,7 @@ Handles timeouts, cleanup, and resource limits.
 
 import threading
 import logging
-from typing import Dict, Optional, Any, Union
+from typing import Any
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field
 
@@ -31,8 +31,8 @@ class Session:
     process: Any  # MCPClient instance
     created_at: datetime = field(default_factory=datetime.now)
     last_accessed: datetime = field(default_factory=datetime.now)
-    timeout: Union[int, float] = 300  # seconds (wire-supplied; may be float)
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    timeout: int | float = 300  # seconds (wire-supplied; may be float)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     @property
     def is_expired(self) -> bool:
@@ -56,9 +56,9 @@ class Session:
 class SessionManager:
     """Manages MCP server sessions with automatic cleanup"""
 
-    def __init__(self, config: Dict[str, Any], max_total_sessions: int = 500):
+    def __init__(self, config: dict[str, Any], max_total_sessions: int = 500):
         self.config = config
-        self.sessions: Dict[str, Session] = {}
+        self.sessions: dict[str, Session] = {}
         self.lock = threading.RLock()
         self.cleanup_interval = config.get("session", {}).get("cleanup_interval", 60)
         self.max_sessions_per_service = config.get("session", {}).get(
@@ -83,8 +83,8 @@ class SessionManager:
         session_id: str,
         service_name: str,
         process: Any,
-        timeout: Optional[Union[int, float]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        timeout: int | float | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> Session:
         """Create and register a new session"""
         with self.lock:
@@ -124,7 +124,7 @@ class SessionManager:
 
             return session
 
-    def get_session(self, session_id: str) -> Optional[Session]:
+    def get_session(self, session_id: str) -> Session | None:
         """Get an active session by ID"""
         with self.lock:
             session = self.sessions.get(session_id)
@@ -167,7 +167,7 @@ class SessionManager:
             logger.info(f"Closed session {session_id}")
             return True
 
-    def list_sessions(self) -> Dict[str, Dict[str, Any]]:
+    def list_sessions(self) -> dict[str, dict[str, Any]]:
         """List all active sessions with their info"""
         with self.lock:
             result = {}

--- a/signalwire/signalwire/pom/pom.py
+++ b/signalwire/signalwire/pom/pom.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 import json
 import yaml
 
@@ -21,11 +21,11 @@ class Section:
 
     def __init__(
         self,
-        title: Optional[str] = None,
+        title: str | None = None,
         *,
         body: str = "",
-        bullets: Optional[List[str]] = None,
-        numbered: Optional[bool] = None,
+        bullets: list[str] | None = None,
+        numbered: bool | None = None,
         numberedBullets: bool = False,
     ):
         self.title = title
@@ -45,7 +45,7 @@ class Section:
             )
         self.bullets = bullets or []
 
-        self.subsections: List["Section"] = []
+        self.subsections: list[Section] = []
         self.numbered = numbered
         self.numberedBullets = numberedBullets
 
@@ -55,7 +55,7 @@ class Section:
             raise TypeError(f"body must be a string, not {type(body).__name__}")
         self.body = body
 
-    def add_bullets(self, bullets: List[str]):
+    def add_bullets(self, bullets: list[str]):
         """Add bullet points to this section."""
         if not isinstance(bullets, list):
             raise TypeError(f"bullets must be a list, not {type(bullets).__name__}")
@@ -66,7 +66,7 @@ class Section:
         title: str,
         *,
         body: str = "",
-        bullets: Optional[List[str]] = None,
+        bullets: list[str] | None = None,
         numbered: bool = False,
         numberedBullets: bool = False,
     ) -> "Section":
@@ -101,9 +101,9 @@ class Section:
         self.subsections.append(subsection)
         return subsection
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert the section to a dictionary representation."""
-        data: Dict[str, Any] = {}
+        data: dict[str, Any] = {}
 
         # Add keys in specific order: title, body, bullets, subsections
         if self.title is not None:
@@ -126,7 +126,7 @@ class Section:
         return data
 
     def render_markdown(
-        self, level: int = 2, section_number: Optional[List[int]] = None
+        self, level: int = 2, section_number: list[int] | None = None
     ) -> str:
         """
         Render this section and all its subsections as markdown.
@@ -189,7 +189,7 @@ class Section:
         return "\n".join(md)
 
     def render_xml(
-        self, indent: int = 0, section_number: Optional[List[int]] = None
+        self, indent: int = 0, section_number: list[int] | None = None
     ) -> str:
         """
         Render this section and all its subsections as XML.
@@ -277,7 +277,7 @@ class PromptObjectModel:
     """
 
     @staticmethod
-    def from_json(json_data: Union[str, dict, list]) -> "PromptObjectModel":
+    def from_json(json_data: str | dict | list) -> "PromptObjectModel":
         """
         Create a PromptObjectModel instance from JSON data.
 
@@ -296,7 +296,7 @@ class PromptObjectModel:
         return PromptObjectModel._from_dict(data)
 
     @staticmethod
-    def from_yaml(yaml_data: Union[str, dict]) -> "PromptObjectModel":
+    def from_yaml(yaml_data: str | dict) -> "PromptObjectModel":
         """
         Create a PromptObjectModel instance from YAML data.
 
@@ -314,7 +314,7 @@ class PromptObjectModel:
         return PromptObjectModel._from_dict(data)
 
     @staticmethod
-    def _from_dict(data: Union[str, dict, list]) -> "PromptObjectModel":
+    def _from_dict(data: str | dict | list) -> "PromptObjectModel":
         """
         Internal method to create a PromptObjectModel from a dictionary.
         Used by both from_json and from_yaml.
@@ -387,16 +387,16 @@ class PromptObjectModel:
         return pom
 
     def __init__(self, debug: bool = False):
-        self.sections: List[Section] = []
+        self.sections: list[Section] = []
         self.debug = debug
 
     def add_section(
         self,
-        title: Optional[str] = None,
+        title: str | None = None,
         *,
         body: str = "",
-        bullets: Optional[Union[List[str], str]] = None,
-        numbered: Optional[bool] = None,
+        bullets: list[str] | str | None = None,
+        numbered: bool | None = None,
         numberedBullets: bool = False,
     ) -> Section:
         """
@@ -433,7 +433,7 @@ class PromptObjectModel:
         self.sections.append(section)
         return section
 
-    def find_section(self, title: str) -> Optional[Section]:
+    def find_section(self, title: str) -> Section | None:
         """
         Find a section by its title.
 
@@ -446,7 +446,7 @@ class PromptObjectModel:
             The Section object if found, None otherwise
         """
 
-        def recurse(sections: List[Section]) -> Optional[Section]:
+        def recurse(sections: list[Section]) -> Section | None:
             for section in sections:
                 if section.title == title:
                     return section
@@ -479,7 +479,7 @@ class PromptObjectModel:
             sort_keys=False,
         )
 
-    def to_dict(self) -> List[dict]:
+    def to_dict(self) -> list[dict]:
         """
         Convert the entire model to a list of dictionaries.
 
@@ -562,7 +562,7 @@ class PromptObjectModel:
         return "\n".join(xml)
 
     def add_pom_as_subsection(
-        self, target: Union[str, Section], pom_to_add: "PromptObjectModel"
+        self, target: str | Section, pom_to_add: "PromptObjectModel"
     ):
         """
         Add another PromptObjectModel as a subsection to a section with the given title or section object.

--- a/signalwire/signalwire/prefabs/concierge.py
+++ b/signalwire/signalwire/prefabs/concierge.py
@@ -9,7 +9,6 @@ See LICENSE file in the project root for full license information.
 ConciergeAgent - Prefab agent for providing virtual concierge services
 """
 
-from typing import List, Dict, Optional
 import json
 
 from signalwire.core.agent_base import AgentBase
@@ -41,11 +40,11 @@ class ConciergeAgent(AgentBase):
     def __init__(
         self,
         venue_name: str,
-        services: List[str],
-        amenities: Dict[str, Dict[str, str]],
-        hours_of_operation: Optional[Dict[str, str]] = None,
-        special_instructions: Optional[List[str]] = None,
-        welcome_message: Optional[str] = None,
+        services: list[str],
+        amenities: dict[str, dict[str, str]],
+        hours_of_operation: dict[str, str] | None = None,
+        special_instructions: list[str] | None = None,
+        welcome_message: str | None = None,
         name: str = "concierge",
         route: str = "/concierge",
         **kwargs,
@@ -77,7 +76,7 @@ class ConciergeAgent(AgentBase):
         # Set up the agent's configuration
         self._setup_concierge_agent(welcome_message)
 
-    def _setup_concierge_agent(self, welcome_message: Optional[str] = None):
+    def _setup_concierge_agent(self, welcome_message: str | None = None):
         """Configure the concierge agent with appropriate settings"""
         # Basic personality and instructions
         self.prompt_add_section(

--- a/signalwire/signalwire/prefabs/faq_bot.py
+++ b/signalwire/signalwire/prefabs/faq_bot.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 FAQBotAgent - Prefab agent for answering frequently asked questions
 """
 
-from typing import Any, List, Dict, Optional
+from typing import Any
 import json
 
 from signalwire.core.agent_base import AgentBase
@@ -43,9 +43,9 @@ class FAQBotAgent(AgentBase):
 
     def __init__(
         self,
-        faqs: List[Dict[str, Any]],
+        faqs: list[dict[str, Any]],
         suggest_related: bool = True,
-        persona: Optional[str] = None,
+        persona: str | None = None,
         name: str = "faq_bot",
         route: str = "/faq",
         **kwargs,
@@ -228,7 +228,7 @@ class FAQBotAgent(AgentBase):
 
         # Simple search logic (in a real implementation, you would use more
         # sophisticated search algorithms such as vector embeddings)
-        results: List[Dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
 
         for faq in self.faqs:
             question = faq.get("question", "").lower()

--- a/signalwire/signalwire/prefabs/info_gatherer.py
+++ b/signalwire/signalwire/prefabs/info_gatherer.py
@@ -12,7 +12,7 @@ Supports both static (questions provided at init) and dynamic (questions determi
 by a callback function) configuration modes.
 """
 
-from typing import List, Dict, Optional, Callable
+from collections.abc import Callable
 
 from signalwire.core.agent_base import AgentBase
 from signalwire.core.function_result import FunctionResult
@@ -39,7 +39,7 @@ class InfoGathererAgent(AgentBase):
 
     def __init__(
         self,
-        questions: Optional[List[Dict[str, str]]] = None,
+        questions: list[dict[str, str]] | None = None,
         name: str = "info_gatherer",
         route: str = "/info_gatherer",
         **kwargs,
@@ -62,9 +62,9 @@ class InfoGathererAgent(AgentBase):
 
         # Store whether we're in static or dynamic mode
         self._static_questions = questions
-        self._question_callback: Optional[
-            Callable[[dict, dict, dict], List[Dict[str, str]]]
-        ] = None
+        self._question_callback: (
+            Callable[[dict, dict, dict], list[dict[str, str]]] | None
+        ) = None
 
         if questions is not None:
             # Static mode: validate questions and set up immediately
@@ -83,7 +83,7 @@ class InfoGathererAgent(AgentBase):
         self._configure_agent_settings()
 
     def set_question_callback(
-        self, callback: Callable[[dict, dict, dict], List[Dict[str, str]]]
+        self, callback: Callable[[dict, dict, dict], list[dict[str, str]]]
     ):
         """
         Set a callback function for dynamic question configuration

--- a/signalwire/signalwire/prefabs/receptionist.py
+++ b/signalwire/signalwire/prefabs/receptionist.py
@@ -9,8 +9,6 @@ See LICENSE file in the project root for full license information.
 ReceptionistAgent - Prefab agent for greeting callers and transferring them to appropriate departments
 """
 
-from typing import List, Dict
-
 from signalwire.core.agent_base import AgentBase
 from signalwire.core.function_result import FunctionResult
 
@@ -33,7 +31,7 @@ class ReceptionistAgent(AgentBase):
 
     def __init__(
         self,
-        departments: List[Dict[str, str]],
+        departments: list[dict[str, str]],
         name: str = "receptionist",
         route: str = "/receptionist",
         greeting: str = "Thank you for calling. How can I help you today?",

--- a/signalwire/signalwire/prefabs/survey.py
+++ b/signalwire/signalwire/prefabs/survey.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 SurveyAgent - Prefab agent for conducting automated surveys
 """
 
-from typing import List, Dict, Any, Optional
+from typing import Any
 import json
 
 from signalwire.core.agent_base import AgentBase
@@ -51,10 +51,10 @@ class SurveyAgent(AgentBase):
     def __init__(
         self,
         survey_name: str,
-        questions: List[Dict[str, Any]],
-        introduction: Optional[str] = None,
-        conclusion: Optional[str] = None,
-        brand_name: Optional[str] = None,
+        questions: list[dict[str, Any]],
+        introduction: str | None = None,
+        conclusion: str | None = None,
+        brand_name: str | None = None,
         max_retries: int = 2,
         name: str = "survey",
         route: str = "/survey",

--- a/signalwire/signalwire/relay/call.py
+++ b/signalwire/signalwire/relay/call.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from typing import Any, Callable, Coroutine, Optional, TypeVar, TYPE_CHECKING
+from typing import Any, TypeVar, TYPE_CHECKING
+from collections.abc import Callable, Coroutine
 
 from signalwire.core.logging_config import get_logger
 
@@ -42,10 +43,10 @@ logger = get_logger("relay_call")
 # returned by a user callback could be garbage-collected mid-flight. These
 # callbacks run on short-lived Action/Call instances, so the set is module-
 # level (outliving any single instance); tasks are discarded on completion.
-_bg_tasks: set["asyncio.Task[Any]"] = set()
+_bg_tasks: set[asyncio.Task[Any]] = set()
 
 
-def _spawn_bg(coro: "Coroutine[Any, Any, Any]") -> None:
+def _spawn_bg(coro: Coroutine[Any, Any, Any]) -> None:
     """Schedule a fire-and-forget coroutine while holding a strong reference."""
     task = asyncio.ensure_future(coro)
     _bg_tasks.add(task)
@@ -73,7 +74,7 @@ class Action:
 
     def __init__(
         self,
-        call: "Call",
+        call: Call,
         control_id: str,
         terminal_event: str,
         terminal_states: tuple[str, ...],
@@ -85,9 +86,9 @@ class Action:
         self._done: asyncio.Future[RelayEvent] = (
             asyncio.get_running_loop().create_future()
         )
-        self.result: Optional[RelayEvent] = None
+        self.result: RelayEvent | None = None
         self.completed = False
-        self._on_completed: Optional[Callable[[RelayEvent], Any]] = None
+        self._on_completed: Callable[[RelayEvent], Any] | None = None
 
     def _check_event(self, event: RelayEvent) -> None:
         """Called by Call when an event matches our control_id."""
@@ -110,7 +111,7 @@ class Action:
                     f"Error in on_completed callback for {self.control_id}"
                 )
 
-    async def wait(self, timeout: Optional[float] = None) -> RelayEvent:
+    async def wait(self, timeout: float | None = None) -> RelayEvent:
         """Wait for the action to complete. Returns the terminal event."""
         if timeout is not None:
             return await asyncio.wait_for(self._done, timeout=timeout)
@@ -124,7 +125,7 @@ class Action:
 class PlayAction(Action):
     """Handle for an active play operation."""
 
-    def __init__(self, call: "Call", control_id: str):
+    def __init__(self, call: Call, control_id: str):
         super().__init__(
             call, control_id, EVENT_CALL_PLAY, (PLAY_STATE_FINISHED, PLAY_STATE_ERROR)
         )
@@ -151,7 +152,7 @@ class PlayAction(Action):
 class RecordAction(Action):
     """Handle for an active record operation."""
 
-    def __init__(self, call: "Call", control_id: str):
+    def __init__(self, call: Call, control_id: str):
         super().__init__(
             call,
             control_id,
@@ -162,7 +163,7 @@ class RecordAction(Action):
     async def stop(self) -> dict:
         return await self.call._execute("record.stop", {"control_id": self.control_id})
 
-    async def pause(self, behavior: Optional[str] = None) -> dict:
+    async def pause(self, behavior: str | None = None) -> dict:
         params: dict[str, Any] = {"control_id": self.control_id}
         if behavior:
             params["behavior"] = behavior
@@ -177,7 +178,7 @@ class RecordAction(Action):
 class DetectAction(Action):
     """Handle for an active detect operation."""
 
-    def __init__(self, call: "Call", control_id: str):
+    def __init__(self, call: Call, control_id: str):
         super().__init__(call, control_id, EVENT_CALL_DETECT, ("finished", "error"))
 
     def _check_event(self, event: RelayEvent) -> None:
@@ -195,7 +196,7 @@ class DetectAction(Action):
 class CollectAction(Action):
     """Handle for play_and_collect or standalone collect."""
 
-    def __init__(self, call: "Call", control_id: str):
+    def __init__(self, call: Call, control_id: str):
         super().__init__(
             call,
             control_id,
@@ -238,7 +239,7 @@ class CollectAction(Action):
 class StandaloneCollectAction(Action):
     """Handle for standalone calling.collect (without play)."""
 
-    def __init__(self, call: "Call", control_id: str):
+    def __init__(self, call: Call, control_id: str):
         super().__init__(
             call,
             control_id,
@@ -267,7 +268,7 @@ class StandaloneCollectAction(Action):
 class FaxAction(Action):
     """Handle for an active send_fax or receive_fax operation."""
 
-    def __init__(self, call: "Call", control_id: str, method_prefix: str):
+    def __init__(self, call: Call, control_id: str, method_prefix: str):
         super().__init__(call, control_id, EVENT_CALL_FAX, ("finished", "error"))
         self._method_prefix = method_prefix
 
@@ -280,7 +281,7 @@ class FaxAction(Action):
 class TapAction(Action):
     """Handle for an active tap operation."""
 
-    def __init__(self, call: "Call", control_id: str):
+    def __init__(self, call: Call, control_id: str):
         super().__init__(call, control_id, EVENT_CALL_TAP, ("finished",))
 
     async def stop(self) -> dict:
@@ -290,7 +291,7 @@ class TapAction(Action):
 class StreamAction(Action):
     """Handle for an active stream operation."""
 
-    def __init__(self, call: "Call", control_id: str):
+    def __init__(self, call: Call, control_id: str):
         super().__init__(call, control_id, EVENT_CALL_STREAM, ("finished",))
 
     async def stop(self) -> dict:
@@ -300,7 +301,7 @@ class StreamAction(Action):
 class PayAction(Action):
     """Handle for an active pay operation."""
 
-    def __init__(self, call: "Call", control_id: str):
+    def __init__(self, call: Call, control_id: str):
         super().__init__(call, control_id, EVENT_CALL_PAY, ("finished", "error"))
 
     async def stop(self) -> dict:
@@ -310,7 +311,7 @@ class PayAction(Action):
 class TranscribeAction(Action):
     """Handle for an active transcribe operation."""
 
-    def __init__(self, call: "Call", control_id: str):
+    def __init__(self, call: Call, control_id: str):
         super().__init__(call, control_id, EVENT_CALL_TRANSCRIBE, ("finished",))
 
     async def stop(self) -> dict:
@@ -322,7 +323,7 @@ class TranscribeAction(Action):
 class AIAction(Action):
     """Handle for an active AI agent session."""
 
-    def __init__(self, call: "Call", control_id: str):
+    def __init__(self, call: Call, control_id: str):
         # AI sessions don't have a standard event type with state field —
         # they end when the call ends or when stopped. We treat "finished"
         # and "error" as terminal states from calling.call.ai events if any.
@@ -346,7 +347,7 @@ class Call:
 
     def __init__(
         self,
-        client: "RelayClient",
+        client: RelayClient,
         call_id: str,
         node_id: str,
         project_id: str,
@@ -354,7 +355,7 @@ class Call:
         *,
         tag: str = "",
         direction: str = "",
-        device: Optional[dict[str, Any]] = None,
+        device: dict[str, Any] | None = None,
         state: str = "",
         segment_id: str = "",
     ):
@@ -383,7 +384,7 @@ class Call:
     # ------------------------------------------------------------------
 
     async def _execute(
-        self, method: str, extra_params: Optional[dict[str, Any]] = None
+        self, method: str, extra_params: dict[str, Any] | None = None
     ) -> dict:
         """Send a ``calling.<method>`` JSON-RPC request for this call.
 
@@ -453,8 +454,8 @@ class Call:
     async def wait_for(
         self,
         event_type: str,
-        predicate: Optional[Callable[[RelayEvent], bool]] = None,
-        timeout: Optional[float] = None,
+        predicate: Callable[[RelayEvent], bool] | None = None,
+        timeout: float | None = None,
     ) -> RelayEvent:
         """Wait for a specific event, optionally filtered by predicate."""
         future: asyncio.Future[RelayEvent] = asyncio.get_running_loop().create_future()
@@ -476,7 +477,7 @@ class Call:
                 with contextlib.suppress(ValueError):
                     self._listeners[event_type].remove(_handler)
 
-    async def wait_for_ended(self, timeout: Optional[float] = None) -> RelayEvent:
+    async def wait_for_ended(self, timeout: float | None = None) -> RelayEvent:
         """Wait for the call to reach the ended state."""
         if timeout is not None:
             return await asyncio.wait_for(self._ended, timeout=timeout)
@@ -491,7 +492,7 @@ class Call:
         action: _ActionT,
         method: str,
         params: dict[str, Any],
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
     ) -> _ActionT:
         """Register an action, execute the RPC, and clean up on failure.
 
@@ -555,11 +556,11 @@ class Call:
         self,
         media: list[dict[str, Any]],
         *,
-        volume: Optional[float] = None,
-        direction: Optional[str] = None,
-        loop: Optional[int] = None,
-        control_id: Optional[str] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        volume: float | None = None,
+        direction: str | None = None,
+        loop: int | None = None,
+        control_id: str | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> PlayAction:
         """Play audio content. Returns a PlayAction for stop/pause/resume/wait."""
@@ -581,11 +582,11 @@ class Call:
         self,
         text: str,
         *,
-        language: Optional[str] = None,
-        gender: Optional[str] = None,
-        voice: Optional[str] = None,
-        volume: Optional[float] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        language: str | None = None,
+        gender: str | None = None,
+        voice: str | None = None,
+        volume: float | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
     ) -> PlayAction:
         """Play text-to-speech. Typed convenience over :meth:`play`.
 
@@ -607,8 +608,8 @@ class Call:
         self,
         url: str,
         *,
-        volume: Optional[float] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        volume: float | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
     ) -> PlayAction:
         """Play an audio file from a URL. Typed convenience over :meth:`play`."""
         return await self.play(
@@ -621,7 +622,7 @@ class Call:
         self,
         duration: float,
         *,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
     ) -> PlayAction:
         """Play silence for ``duration`` seconds. Typed convenience over :meth:`play`."""
         return await self.play(
@@ -633,9 +634,9 @@ class Call:
         self,
         name: str,
         *,
-        duration: Optional[float] = None,
-        volume: Optional[float] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        duration: float | None = None,
+        volume: float | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
     ) -> PlayAction:
         """Play a named ringtone by country code. Typed convenience over :meth:`play`."""
         rt: dict[str, Any] = {"name": name}
@@ -654,9 +655,9 @@ class Call:
     async def detect_digit(
         self,
         *,
-        digits: Optional[str] = None,
-        timeout: Optional[float] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        digits: str | None = None,
+        timeout: float | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
     ) -> DetectAction:
         """Detect DTMF digits. Typed convenience over :meth:`detect`."""
         params: dict[str, Any] = {}
@@ -671,14 +672,14 @@ class Call:
     async def detect_answering_machine(
         self,
         *,
-        initial_timeout: Optional[float] = None,
-        end_silence_timeout: Optional[float] = None,
-        machine_voice_threshold: Optional[float] = None,
-        machine_words_threshold: Optional[int] = None,
-        detect_interruptions: Optional[bool] = None,
-        detect_message_end: Optional[bool] = None,
-        timeout: Optional[float] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        initial_timeout: float | None = None,
+        end_silence_timeout: float | None = None,
+        machine_voice_threshold: float | None = None,
+        machine_words_threshold: int | None = None,
+        detect_interruptions: bool | None = None,
+        detect_message_end: bool | None = None,
+        timeout: float | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
     ) -> DetectAction:
         """Detect human vs answering machine (AMD). Typed convenience over :meth:`detect`."""
         params: dict[str, Any] = {
@@ -702,9 +703,9 @@ class Call:
     async def detect_fax(
         self,
         *,
-        tone: Optional[str] = None,
-        timeout: Optional[float] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        tone: str | None = None,
+        timeout: float | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
     ) -> DetectAction:
         """Detect a fax tone (CED/CNG). Typed convenience over :meth:`detect`."""
         params: dict[str, Any] = {}
@@ -725,11 +726,11 @@ class Call:
         text: str,
         collect: dict[str, Any],
         *,
-        language: Optional[str] = None,
-        gender: Optional[str] = None,
-        voice: Optional[str] = None,
-        volume: Optional[float] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        language: str | None = None,
+        gender: str | None = None,
+        voice: str | None = None,
+        volume: float | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
     ) -> CollectAction:
         """Play TTS then collect input. Typed media over :meth:`play_and_collect`."""
         tts: dict[str, Any] = {"text": text}
@@ -751,8 +752,8 @@ class Call:
         url: str,
         collect: dict[str, Any],
         *,
-        volume: Optional[float] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        volume: float | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
     ) -> CollectAction:
         """Play an audio file then collect input. Typed media over :meth:`play_and_collect`."""
         return await self.play_and_collect(
@@ -766,9 +767,7 @@ class Call:
     # State-wait convenience (typed waits over wait_for())
     # ------------------------------------------------------------------
 
-    async def _wait_for_state(
-        self, target: str, timeout: Optional[float]
-    ) -> RelayEvent:
+    async def _wait_for_state(self, target: str, timeout: float | None) -> RelayEvent:
         order = (
             CALL_STATE_CREATED,
             CALL_STATE_RINGING,
@@ -791,15 +790,15 @@ class Call:
             timeout=timeout,
         )
 
-    async def wait_for_answered(self, timeout: Optional[float] = None) -> RelayEvent:
+    async def wait_for_answered(self, timeout: float | None = None) -> RelayEvent:
         """Wait until the call is answered (immediate if already answered or past it)."""
         return await self._wait_for_state(CALL_STATE_ANSWERED, timeout)
 
-    async def wait_for_ringing(self, timeout: Optional[float] = None) -> RelayEvent:
+    async def wait_for_ringing(self, timeout: float | None = None) -> RelayEvent:
         """Wait until the call is ringing (immediate if already ringing or past it)."""
         return await self._wait_for_state(CALL_STATE_RINGING, timeout)
 
-    async def wait_for_ending(self, timeout: Optional[float] = None) -> RelayEvent:
+    async def wait_for_ending(self, timeout: float | None = None) -> RelayEvent:
         """Wait until the call is ending (immediate if already ending or past it)."""
         return await self._wait_for_state(CALL_STATE_ENDING, timeout)
 
@@ -809,10 +808,10 @@ class Call:
 
     async def record(
         self,
-        audio: Optional[dict[str, Any]] = None,
+        audio: dict[str, Any] | None = None,
         *,
-        control_id: Optional[str] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        control_id: str | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> RecordAction:
         """Record audio from the call. Returns a RecordAction."""
@@ -834,9 +833,9 @@ class Call:
         media: list[dict[str, Any]],
         collect: dict[str, Any],
         *,
-        volume: Optional[float] = None,
-        control_id: Optional[str] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        volume: float | None = None,
+        control_id: str | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> CollectAction:
         """Play audio and collect digit/speech input."""
@@ -857,15 +856,15 @@ class Call:
     async def collect(
         self,
         *,
-        digits: Optional[dict[str, Any]] = None,
-        speech: Optional[dict[str, Any]] = None,
-        initial_timeout: Optional[float] = None,
-        partial_results: Optional[bool] = None,
-        continuous: Optional[bool] = None,
-        send_start_of_input: Optional[bool] = None,
-        start_input_timers: Optional[bool] = None,
-        control_id: Optional[str] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        digits: dict[str, Any] | None = None,
+        speech: dict[str, Any] | None = None,
+        initial_timeout: float | None = None,
+        partial_results: bool | None = None,
+        continuous: bool | None = None,
+        send_start_of_input: bool | None = None,
+        start_input_timers: bool | None = None,
+        control_id: str | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> StandaloneCollectAction:
         """Collect digit/speech input without playing media."""
@@ -899,11 +898,11 @@ class Call:
         self,
         devices: list[list[dict[str, Any]]],
         *,
-        ringback: Optional[list[dict[str, Any]]] = None,
-        tag: Optional[str] = None,
-        max_duration: Optional[int] = None,
-        max_price_per_minute: Optional[float] = None,
-        status_url: Optional[str] = None,
+        ringback: list[dict[str, Any]] | None = None,
+        tag: str | None = None,
+        max_duration: int | None = None,
+        max_price_per_minute: float | None = None,
+        status_url: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Bridge the call to one or more destinations."""
@@ -933,7 +932,7 @@ class Call:
         self,
         digits: str,
         *,
-        control_id: Optional[str] = None,
+        control_id: str | None = None,
     ) -> dict:
         """Send DTMF digits on the call."""
         cid = control_id or str(uuid.uuid4())
@@ -953,9 +952,9 @@ class Call:
         self,
         detect: dict[str, Any],
         *,
-        timeout: Optional[float] = None,
-        control_id: Optional[str] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        timeout: float | None = None,
+        control_id: str | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> DetectAction:
         """Start audio detection (machine, fax, digit). Returns a DetectAction."""
@@ -977,7 +976,7 @@ class Call:
         self,
         device: dict[str, Any],
         *,
-        status_url: Optional[str] = None,
+        status_url: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Transfer a SIP call to an external SIP endpoint via REFER."""
@@ -995,25 +994,25 @@ class Call:
         self,
         payment_connector_url: str,
         *,
-        control_id: Optional[str] = None,
-        input_method: Optional[str] = None,
-        status_url: Optional[str] = None,
-        payment_method: Optional[str] = None,
-        timeout: Optional[str] = None,
-        max_attempts: Optional[str] = None,
-        security_code: Optional[str] = None,
-        postal_code: Optional[str] = None,
-        min_postal_code_length: Optional[str] = None,
-        token_type: Optional[str] = None,
-        charge_amount: Optional[str] = None,
-        currency: Optional[str] = None,
-        language: Optional[str] = None,
-        voice: Optional[str] = None,
-        description: Optional[str] = None,
-        valid_card_types: Optional[str] = None,
-        parameters: Optional[list[dict[str, Any]]] = None,
-        prompts: Optional[list[dict[str, Any]]] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        control_id: str | None = None,
+        input_method: str | None = None,
+        status_url: str | None = None,
+        payment_method: str | None = None,
+        timeout: str | None = None,
+        max_attempts: str | None = None,
+        security_code: str | None = None,
+        postal_code: str | None = None,
+        min_postal_code_length: str | None = None,
+        token_type: str | None = None,
+        charge_amount: str | None = None,
+        currency: str | None = None,
+        language: str | None = None,
+        voice: str | None = None,
+        description: str | None = None,
+        valid_card_types: str | None = None,
+        parameters: list[dict[str, Any]] | None = None,
+        prompts: list[dict[str, Any]] | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> PayAction:
         """Start a payment collection. Returns a PayAction."""
@@ -1070,10 +1069,10 @@ class Call:
         self,
         document: str,
         *,
-        identity: Optional[str] = None,
-        header_info: Optional[str] = None,
-        control_id: Optional[str] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        identity: str | None = None,
+        header_info: str | None = None,
+        control_id: str | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> FaxAction:
         """Send a fax document. Returns a FaxAction."""
@@ -1092,8 +1091,8 @@ class Call:
     async def receive_fax(
         self,
         *,
-        control_id: Optional[str] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        control_id: str | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> FaxAction:
         """Receive a fax. Returns a FaxAction."""
@@ -1114,8 +1113,8 @@ class Call:
         tap: dict[str, Any],
         device: dict[str, Any],
         *,
-        control_id: Optional[str] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        control_id: str | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> TapAction:
         """Intercept call media and stream it. Returns a TapAction."""
@@ -1139,15 +1138,15 @@ class Call:
         self,
         url: str,
         *,
-        name: Optional[str] = None,
-        codec: Optional[str] = None,
-        track: Optional[str] = None,
-        status_url: Optional[str] = None,
-        status_url_method: Optional[str] = None,
-        authorization_bearer_token: Optional[str] = None,
-        custom_parameters: Optional[dict[str, Any]] = None,
-        control_id: Optional[str] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        name: str | None = None,
+        codec: str | None = None,
+        track: str | None = None,
+        status_url: str | None = None,
+        status_url_method: str | None = None,
+        authorization_bearer_token: str | None = None,
+        custom_parameters: dict[str, Any] | None = None,
+        control_id: str | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> StreamAction:
         """Start streaming call audio to a WebSocket endpoint. Returns a StreamAction."""
@@ -1195,25 +1194,25 @@ class Call:
         self,
         name: str,
         *,
-        muted: Optional[bool] = None,
-        beep: Optional[str] = None,
-        start_on_enter: Optional[bool] = None,
-        end_on_exit: Optional[bool] = None,
-        wait_url: Optional[str] = None,
-        max_participants: Optional[int] = None,
-        record: Optional[str] = None,
-        region: Optional[str] = None,
-        trim: Optional[str] = None,
-        coach: Optional[str] = None,
-        status_callback: Optional[str] = None,
-        status_callback_event: Optional[str] = None,
-        status_callback_event_type: Optional[str] = None,
-        status_callback_method: Optional[str] = None,
-        recording_status_callback: Optional[str] = None,
-        recording_status_callback_event: Optional[str] = None,
-        recording_status_callback_event_type: Optional[str] = None,
-        recording_status_callback_method: Optional[str] = None,
-        stream_obj: Optional[dict[str, Any]] = None,
+        muted: bool | None = None,
+        beep: str | None = None,
+        start_on_enter: bool | None = None,
+        end_on_exit: bool | None = None,
+        wait_url: str | None = None,
+        max_participants: int | None = None,
+        record: str | None = None,
+        region: str | None = None,
+        trim: str | None = None,
+        coach: str | None = None,
+        status_callback: str | None = None,
+        status_callback_event: str | None = None,
+        status_callback_event_type: str | None = None,
+        status_callback_method: str | None = None,
+        recording_status_callback: str | None = None,
+        recording_status_callback_event: str | None = None,
+        recording_status_callback_event_type: str | None = None,
+        recording_status_callback_method: str | None = None,
+        stream_obj: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> dict:
         """Join an ad-hoc audio conference."""
@@ -1300,9 +1299,9 @@ class Call:
     async def transcribe(
         self,
         *,
-        control_id: Optional[str] = None,
-        status_url: Optional[str] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        control_id: str | None = None,
+        status_url: str | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> TranscribeAction:
         """Start transcribing the call. Returns a TranscribeAction."""
@@ -1323,8 +1322,8 @@ class Call:
     async def echo(
         self,
         *,
-        timeout: Optional[float] = None,
-        status_url: Optional[str] = None,
+        timeout: float | None = None,
+        status_url: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Echo audio back to the caller (useful for testing)."""
@@ -1345,9 +1344,9 @@ class Call:
         digits: str,
         bind_method: str,
         *,
-        bind_params: Optional[dict[str, Any]] = None,
-        realm: Optional[str] = None,
-        max_triggers: Optional[int] = None,
+        bind_params: dict[str, Any] | None = None,
+        realm: str | None = None,
+        max_triggers: int | None = None,
         **kwargs: Any,
     ) -> dict:
         """Bind a DTMF digit sequence to trigger a RELAY method."""
@@ -1367,7 +1366,7 @@ class Call:
     async def clear_digit_bindings(
         self,
         *,
-        realm: Optional[str] = None,
+        realm: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Clear all digit bindings, optionally filtered by realm."""
@@ -1395,7 +1394,7 @@ class Call:
         self,
         action: dict[str, Any],
         *,
-        status_url: Optional[str] = None,
+        status_url: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Start or stop live translation on the call."""
@@ -1413,7 +1412,7 @@ class Call:
         self,
         name: str,
         *,
-        status_url: Optional[str] = None,
+        status_url: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Join a video/audio room."""
@@ -1434,20 +1433,20 @@ class Call:
     async def ai(
         self,
         *,
-        control_id: Optional[str] = None,
-        agent: Optional[str] = None,
-        prompt: Optional[dict[str, Any]] = None,
-        post_prompt: Optional[dict[str, Any]] = None,
-        post_prompt_url: Optional[str] = None,
-        post_prompt_auth_user: Optional[str] = None,
-        post_prompt_auth_password: Optional[str] = None,
-        global_data: Optional[dict[str, Any]] = None,
-        pronounce: Optional[list[dict[str, Any]]] = None,
-        hints: Optional[list[str]] = None,
-        languages: Optional[list[dict[str, Any]]] = None,
-        SWAIG: Optional[dict[str, Any]] = None,
-        ai_params: Optional[dict[str, Any]] = None,
-        on_completed: Optional[Callable[[RelayEvent], Any]] = None,
+        control_id: str | None = None,
+        agent: str | None = None,
+        prompt: dict[str, Any] | None = None,
+        post_prompt: dict[str, Any] | None = None,
+        post_prompt_url: str | None = None,
+        post_prompt_auth_user: str | None = None,
+        post_prompt_auth_password: str | None = None,
+        global_data: dict[str, Any] | None = None,
+        pronounce: list[dict[str, Any]] | None = None,
+        hints: list[str] | None = None,
+        languages: list[dict[str, Any]] | None = None,
+        SWAIG: dict[str, Any] | None = None,
+        ai_params: dict[str, Any] | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
         **kwargs: Any,
     ) -> AIAction:
         """Start an AI agent session on the call. Returns an AIAction."""
@@ -1484,12 +1483,12 @@ class Call:
     async def amazon_bedrock(
         self,
         *,
-        prompt: Optional[Any] = None,
-        SWAIG: Optional[dict[str, Any]] = None,
-        ai_params: Optional[dict[str, Any]] = None,
-        global_data: Optional[dict[str, Any]] = None,
-        post_prompt: Optional[dict[str, Any]] = None,
-        post_prompt_url: Optional[str] = None,
+        prompt: Any | None = None,
+        SWAIG: dict[str, Any] | None = None,
+        ai_params: dict[str, Any] | None = None,
+        global_data: dict[str, Any] | None = None,
+        post_prompt: dict[str, Any] | None = None,
+        post_prompt_url: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Connect to an Amazon Bedrock AI agent."""
@@ -1512,10 +1511,10 @@ class Call:
     async def ai_message(
         self,
         *,
-        message_text: Optional[str] = None,
-        role: Optional[str] = None,
-        reset: Optional[dict[str, Any]] = None,
-        global_data: Optional[dict[str, Any]] = None,
+        message_text: str | None = None,
+        role: str | None = None,
+        reset: dict[str, Any] | None = None,
+        global_data: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> dict:
         """Send a message to an active AI agent session."""
@@ -1534,8 +1533,8 @@ class Call:
     async def ai_hold(
         self,
         *,
-        timeout: Optional[str] = None,
-        prompt: Optional[str] = None,
+        timeout: str | None = None,
+        prompt: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Put an AI agent session on hold."""
@@ -1550,7 +1549,7 @@ class Call:
     async def ai_unhold(
         self,
         *,
-        prompt: Optional[str] = None,
+        prompt: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Resume an AI agent session from hold."""
@@ -1567,7 +1566,7 @@ class Call:
     async def user_event(
         self,
         *,
-        event: Optional[str] = None,
+        event: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Send a custom user-defined event."""
@@ -1585,8 +1584,8 @@ class Call:
         self,
         queue_name: str,
         *,
-        control_id: Optional[str] = None,
-        status_url: Optional[str] = None,
+        control_id: str | None = None,
+        status_url: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Place the call in a queue."""
@@ -1604,9 +1603,9 @@ class Call:
         self,
         queue_name: str,
         *,
-        control_id: Optional[str] = None,
-        queue_id: Optional[str] = None,
-        status_url: Optional[str] = None,
+        control_id: str | None = None,
+        queue_id: str | None = None,
+        status_url: str | None = None,
         **kwargs: Any,
     ) -> dict:
         """Remove the call from a queue."""

--- a/signalwire/signalwire/relay/client.py
+++ b/signalwire/signalwire/relay/client.py
@@ -25,7 +25,8 @@ import json
 import os
 import re
 import uuid
-from typing import Any, Callable, Coroutine, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
+from collections.abc import Callable, Coroutine
 
 import websockets
 import websockets.exceptions
@@ -114,12 +115,12 @@ class RelayClient:
 
     def __init__(
         self,
-        project: Optional[str] = None,
-        token: Optional[str] = None,
-        jwt_token: Optional[str] = None,
-        host: Optional[str] = None,
-        contexts: Optional[list[str]] = None,
-        max_active_calls: Optional[int] = None,
+        project: str | None = None,
+        token: str | None = None,
+        jwt_token: str | None = None,
+        host: str | None = None,
+        contexts: list[str] | None = None,
+        max_active_calls: int | None = None,
     ):
         self.project = project or os.environ.get("SIGNALWIRE_PROJECT_ID", "")
         self.token = token or os.environ.get("SIGNALWIRE_API_TOKEN", "")
@@ -157,24 +158,24 @@ class RelayClient:
                 self._max_active_calls = _DEFAULT_MAX_ACTIVE_CALLS
 
         # Internal state
-        self._ws: Optional["ClientConnection"] = None
+        self._ws: ClientConnection | None = None
         self._pending: dict[str, asyncio.Future[dict]] = {}
         # Track the method for each pending request (for code-checking decisions)
         self._pending_methods: dict[str, str] = {}
         self._calls: dict[str, Call] = {}
-        self._on_call_handler: Optional[CallHandler] = None
-        self._on_message_handler: Optional[MessageHandler] = None
+        self._on_call_handler: CallHandler | None = None
+        self._on_message_handler: MessageHandler | None = None
         self._messages: dict[str, Message] = {}  # message_id → Message
         # Pending outbound dials: tag → Future[Call] resolved when dial completes
-        self._pending_dials: dict[str, asyncio.Future["Call"]] = {}
+        self._pending_dials: dict[str, asyncio.Future[Call]] = {}
         # Calls created during dial, indexed by tag for event routing before
         # the winning call_id is known
-        self._dial_calls_by_tag: dict[str, list["Call"]] = {}
+        self._dial_calls_by_tag: dict[str, list[Call]] = {}
         self._connected = False
         self._closing = False
         self._reconnect_delay = RECONNECT_MIN_DELAY
-        self._recv_task: Optional[asyncio.Task] = None
-        self._ping_task: Optional[asyncio.Task] = None
+        self._recv_task: asyncio.Task | None = None
+        self._ping_task: asyncio.Task | None = None
         # Strong references to fire-and-forget background tasks (queued sends,
         # inbound call/message handler dispatch, ws close). asyncio only keeps
         # a weak reference to a running task, so without this the task could be
@@ -195,7 +196,7 @@ class RelayClient:
         self._authorization_state: str = ""
         # Half-open detection: reset on every server ping; fires if no ping
         # arrives within _CHECK_PING_DELAY seconds.
-        self._check_ping_handle: Optional[asyncio.TimerHandle] = None
+        self._check_ping_handle: asyncio.TimerHandle | None = None
         # Track consecutive client ping failures for exponential backoff
         self._ping_failures: int = 0
         # Queue for requests made while disconnected/reconnecting
@@ -204,14 +205,14 @@ class RelayClient:
     def __del__(self) -> None:
         _active_clients.discard(id(self))
 
-    async def __aenter__(self) -> "RelayClient":
+    async def __aenter__(self) -> RelayClient:
         await self.connect()
         return self
 
     async def __aexit__(self, *exc: Any) -> None:
         await self.disconnect()
 
-    def _spawn_bg(self, coro: Coroutine[Any, Any, Any]) -> "asyncio.Task[Any]":
+    def _spawn_bg(self, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
         """Schedule a fire-and-forget coroutine, holding a strong reference.
 
         asyncio keeps only a weak reference to a running task, so a bare
@@ -386,9 +387,9 @@ class RelayClient:
         self,
         devices: list[list[dict[str, Any]]],
         *,
-        tag: Optional[str] = None,
-        max_duration: Optional[int] = None,
-        dial_timeout: Optional[float] = None,
+        tag: str | None = None,
+        max_duration: int | None = None,
+        dial_timeout: float | None = None,
     ) -> Call:
         """Initiate an outbound call using dial. Returns a Call object.
 
@@ -451,12 +452,12 @@ class RelayClient:
         *,
         to_number: str,
         from_number: str,
-        context: Optional[str] = None,
-        body: Optional[str] = None,
-        media: Optional[list[str]] = None,
-        tags: Optional[list[str]] = None,
-        region: Optional[str] = None,
-        on_completed: Optional[Callable] = None,
+        context: str | None = None,
+        body: str | None = None,
+        media: list[str] | None = None,
+        tags: list[str] | None = None,
+        region: str | None = None,
+        on_completed: Callable | None = None,
     ) -> Message:
         """Send an outbound SMS/MMS message.
 

--- a/signalwire/signalwire/relay/event.py
+++ b/signalwire/signalwire/relay/event.py
@@ -7,7 +7,7 @@ also accept the raw dict, so these are optional.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 
 @dataclass
@@ -20,7 +20,7 @@ class RelayEvent:
     timestamp: float = 0.0
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "RelayEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> RelayEvent:
         event_type = payload.get("event_type", "")
         params = payload.get("params", {})
         return cls(
@@ -41,7 +41,7 @@ class CallStateEvent(RelayEvent):
     device: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "CallStateEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> CallStateEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -70,7 +70,7 @@ class CallReceiveEvent(RelayEvent):
     tag: str = ""
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "CallReceiveEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> CallReceiveEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -97,7 +97,7 @@ class PlayEvent(RelayEvent):
     state: str = ""
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "PlayEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> PlayEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -122,7 +122,7 @@ class RecordEvent(RelayEvent):
     record: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "RecordEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> RecordEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         rec = p.get("record", {})
@@ -147,10 +147,10 @@ class CollectEvent(RelayEvent):
     control_id: str = ""
     state: str = ""
     result: dict[str, Any] = field(default_factory=dict)
-    final: Optional[bool] = None
+    final: bool | None = None
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "CollectEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> CollectEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -173,7 +173,7 @@ class ConnectEvent(RelayEvent):
     peer: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "ConnectEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> ConnectEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -194,7 +194,7 @@ class DetectEvent(RelayEvent):
     detect: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "DetectEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> DetectEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -215,7 +215,7 @@ class FaxEvent(RelayEvent):
     fax: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "FaxEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> FaxEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -238,7 +238,7 @@ class TapEvent(RelayEvent):
     device: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "TapEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> TapEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -263,7 +263,7 @@ class StreamEvent(RelayEvent):
     name: str = ""
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "StreamEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> StreamEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -286,7 +286,7 @@ class SendDigitsEvent(RelayEvent):
     state: str = ""
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "SendDigitsEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> SendDigitsEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -308,7 +308,7 @@ class DialEvent(RelayEvent):
     call: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "DialEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> DialEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -332,7 +332,7 @@ class ReferEvent(RelayEvent):
     sip_notify_response_code: str = ""
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "ReferEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> ReferEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -354,7 +354,7 @@ class DenoiseEvent(RelayEvent):
     denoised: bool = False
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "DenoiseEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> DenoiseEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -374,7 +374,7 @@ class PayEvent(RelayEvent):
     state: str = ""
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "PayEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> PayEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -399,7 +399,7 @@ class QueueEvent(RelayEvent):
     size: int = 0
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "QueueEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> QueueEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -423,7 +423,7 @@ class EchoEvent(RelayEvent):
     state: str = ""
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "EchoEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> EchoEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -447,7 +447,7 @@ class TranscribeEvent(RelayEvent):
     size: int = 0
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "TranscribeEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> TranscribeEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -471,7 +471,7 @@ class HoldEvent(RelayEvent):
     state: str = ""
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "HoldEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> HoldEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -492,7 +492,7 @@ class ConferenceEvent(RelayEvent):
     status: str = ""
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "ConferenceEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> ConferenceEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -514,7 +514,7 @@ class CallingErrorEvent(RelayEvent):
     message: str = ""
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "CallingErrorEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> CallingErrorEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -543,7 +543,7 @@ class MessageReceiveEvent(RelayEvent):
     tags: list[str] = field(default_factory=list)
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "MessageReceiveEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> MessageReceiveEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(
@@ -581,7 +581,7 @@ class MessageStateEvent(RelayEvent):
     tags: list[str] = field(default_factory=list)
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "MessageStateEvent":
+    def from_payload(cls, payload: dict[str, Any]) -> MessageStateEvent:
         base = RelayEvent.from_payload(payload)
         p = base.params
         return cls(

--- a/signalwire/signalwire/relay/message.py
+++ b/signalwire/signalwire/relay/message.py
@@ -8,7 +8,8 @@ undelivered/failed).  Inbound messages arrive fully formed with state "received"
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Callable, Coroutine, Optional
+from typing import Any
+from collections.abc import Callable, Coroutine
 
 from signalwire.core.logging_config import get_logger
 
@@ -22,10 +23,10 @@ logger = get_logger("relay_message")
 # returned by a user callback could be garbage-collected mid-flight. The
 # Message instance may be short-lived, so the set is module-level; tasks are
 # discarded on completion.
-_bg_tasks: set["asyncio.Task[Any]"] = set()
+_bg_tasks: set[asyncio.Task[Any]] = set()
 
 
-def _spawn_bg(coro: "Coroutine[Any, Any, Any]") -> None:
+def _spawn_bg(coro: Coroutine[Any, Any, Any]) -> None:
     """Schedule a fire-and-forget coroutine while holding a strong reference."""
     task = asyncio.ensure_future(coro)
     _bg_tasks.add(task)
@@ -48,11 +49,11 @@ class Message:
         from_number: str = "",
         to_number: str = "",
         body: str = "",
-        media: Optional[list[str]] = None,
+        media: list[str] | None = None,
         segments: int = 0,
         state: str = "",
         reason: str = "",
-        tags: Optional[list[str]] = None,
+        tags: list[str] | None = None,
     ):
         self.message_id = message_id
         self.context = context
@@ -70,7 +71,7 @@ class Message:
         self._done: asyncio.Future[RelayEvent] = (
             asyncio.get_event_loop().create_future()
         )
-        self._on_completed: Optional[Callable[[RelayEvent], Any]] = None
+        self._on_completed: Callable[[RelayEvent], Any] | None = None
         self._listeners: list[Callable] = []
 
     @property
@@ -79,7 +80,7 @@ class Message:
         return self._done.done()
 
     @property
-    def result(self) -> Optional[RelayEvent]:
+    def result(self) -> RelayEvent | None:
         """The terminal RelayEvent, or None if not yet done."""
         if self._done.done():
             return self._done.result()
@@ -89,7 +90,7 @@ class Message:
         """Register an event listener for state changes on this message."""
         self._listeners.append(handler)
 
-    async def wait(self, timeout: Optional[float] = None) -> RelayEvent:
+    async def wait(self, timeout: float | None = None) -> RelayEvent:
         """Block until the message reaches a terminal state.
 
         Returns the terminal RelayEvent. Raises asyncio.TimeoutError if

--- a/signalwire/signalwire/rest/namespaces/phone_numbers.py
+++ b/signalwire/signalwire/rest/namespaces/phone_numbers.py
@@ -9,8 +9,6 @@ See LICENSE file in the project root for full license information.
 Phone Numbers namespace — list, search, purchase, get, update, release, bind.
 """
 
-from typing import Optional
-
 from .._base import CrudResource
 from ..call_handler import PhoneCallHandler
 
@@ -59,8 +57,8 @@ class PhoneNumbersResource(CrudResource):
         self,
         resource_id: str,
         url: str,
-        fallback_url: Optional[str] = None,
-        status_callback_url: Optional[str] = None,
+        fallback_url: str | None = None,
+        status_callback_url: str | None = None,
         **extra,
     ) -> dict:
         """Route inbound calls to a cXML (Twilio-compat / LAML) webhook.
@@ -105,7 +103,7 @@ class PhoneNumbersResource(CrudResource):
         self,
         resource_id: str,
         flow_id: str,
-        version: Optional[str] = None,
+        version: str | None = None,
         **extra,
     ) -> dict:
         """Route inbound calls to a Call Flow by ID.
@@ -135,7 +133,7 @@ class PhoneNumbersResource(CrudResource):
         self,
         resource_id: str,
         topic: str,
-        status_callback_url: Optional[str] = None,
+        status_callback_url: str | None = None,
         **extra,
     ) -> dict:
         """Route inbound calls to a RELAY topic (client subscription)."""

--- a/signalwire/signalwire/search/__init__.py
+++ b/signalwire/signalwire/search/__init__.py
@@ -18,11 +18,11 @@ It requires additional dependencies that can be installed with:
 """
 
 import warnings
-from typing import Any, List
+from typing import Any
 
 # Check for core search dependencies
 _SEARCH_AVAILABLE = True
-_MISSING_DEPS: List[str] = []
+_MISSING_DEPS: list[str] = []
 
 # These bare imports probe for optional-dependency availability; the import
 # itself is the test, so the bound name is intentionally unused (F401).

--- a/signalwire/signalwire/search/document_processor.py
+++ b/signalwire/signalwire/search/document_processor.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 
 import re
 import json
-from typing import List, Dict, Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from pathlib import Path
 
 # Document processing imports
@@ -116,7 +116,7 @@ class DocumentProcessor:
         max_sentences_per_chunk: int = 5,
         chunk_size: int = 50,
         chunk_overlap: int = 10,
-        split_newlines: Optional[int] = None,
+        split_newlines: int | None = None,
         index_nlp_backend: str = "nltk",
         verbose: bool = False,
         semantic_threshold: float = 0.5,
@@ -158,7 +158,7 @@ class DocumentProcessor:
 
     def create_chunks(
         self, content: str, filename: str, file_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Create chunks from document content using specified chunking strategy
 
@@ -223,7 +223,7 @@ class DocumentProcessor:
             try:
                 mime = magic.Magic(mime=True)
                 file_type = mime.from_file(file_path)
-            except (FileNotFoundError, IOError, OSError):
+            except (FileNotFoundError, OSError):
                 # Fall back to extension-based detection if magic can't read the file
                 file_path_obj = Path(file_path)
                 extension = file_path_obj.suffix.lower()
@@ -292,7 +292,7 @@ class DocumentProcessor:
         """Extract text from plain text files"""
         try:
             with open(  # noqa: PTH123  # tests patch builtins.open; Path.open() would bypass the mock seam
-                file_path, "r", encoding="utf-8"
+                file_path, encoding="utf-8"
             ) as file:
                 return file.read()
         except Exception as e:
@@ -307,7 +307,7 @@ class DocumentProcessor:
 
         try:
             with open(  # noqa: PTH123  # tests patch builtins.open; Path.open() would bypass the mock seam
-                file_path, "r", encoding="utf-8"
+                file_path, encoding="utf-8"
             ) as file:
                 soup = BeautifulSoup(file, "html.parser")
                 return soup.get_text(separator="\n")
@@ -318,7 +318,7 @@ class DocumentProcessor:
         """Extract text from Markdown files"""
         try:
             with open(  # noqa: PTH123  # tests patch builtins.open; Path.open() would bypass the mock seam
-                file_path, "r", encoding="utf-8"
+                file_path, encoding="utf-8"
             ) as file:
                 content = file.read()
                 if markdown is not None and BeautifulSoup is not None:
@@ -337,7 +337,7 @@ class DocumentProcessor:
 
         try:
             with open(  # noqa: PTH123  # tests patch builtins.open; Path.open() would bypass the mock seam
-                file_path, "r", encoding="utf-8"
+                file_path, encoding="utf-8"
             ) as file:
                 return rtf_to_text(file.read())
         except Exception as e:
@@ -380,7 +380,7 @@ class DocumentProcessor:
 
     def _chunk_document_aware(
         self, content: Any, filename: str, file_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Smart chunking for documents with natural structure"""
         chunks = []
 
@@ -435,7 +435,7 @@ class DocumentProcessor:
 
     def _chunk_markdown_enhanced(
         self, content: str, filename: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Enhanced markdown chunking with code block detection and rich metadata.
 
         Uses markdown-it-py AST when available to keep tables, fenced code,
@@ -446,7 +446,7 @@ class DocumentProcessor:
             return self._chunk_markdown_ast(content, filename)
         return self._chunk_markdown_line_walker(content, filename)
 
-    def _chunk_markdown_ast(self, content: str, filename: str) -> List[Dict[str, Any]]:
+    def _chunk_markdown_ast(self, content: str, filename: str) -> list[dict[str, Any]]:
         """AST-based markdown chunker.
 
         Parses the doc with markdown-it-py, then walks the top-level block tokens,
@@ -493,14 +493,14 @@ class DocumentProcessor:
                     blocks.append(self._leaf_md_block(tok, lines))
 
         # Walk blocks, maintain heading hierarchy, emit chunks.
-        chunks: List[Dict[str, Any]] = []
-        hierarchy: List[str] = []
-        current_lines: List[str] = []
-        current_hierarchy: List[str] = []
-        current_start_line: Optional[int] = None
-        current_end_line: Optional[int] = None
+        chunks: list[dict[str, Any]] = []
+        hierarchy: list[str] = []
+        current_lines: list[str] = []
+        current_hierarchy: list[str] = []
+        current_start_line: int | None = None
+        current_end_line: int | None = None
         current_size = 0
-        current_code_langs: List[str] = []
+        current_code_langs: list[str] = []
         current_has_code = False
 
         def flush():
@@ -572,8 +572,8 @@ class DocumentProcessor:
         return chunks
 
     def _finalize_md_block(
-        self, opened: Dict[str, Any], lines: List[str]
-    ) -> Optional[Dict[str, Any]]:
+        self, opened: dict[str, Any], lines: list[str]
+    ) -> dict[str, Any] | None:
         """Turn an accumulated container token into a block record."""
         tok = opened["token"]
         tmap = opened["map"]
@@ -608,7 +608,7 @@ class DocumentProcessor:
             "has_code": False,
         }
 
-    def _leaf_md_block(self, tok, lines: List[str]) -> Dict[str, Any]:
+    def _leaf_md_block(self, tok, lines: list[str]) -> dict[str, Any]:
         """Turn a leaf (fence, code_block, hr, html_block) token into a block."""
         start, end = tok.map
         source_lines = lines[start:end]
@@ -630,7 +630,7 @@ class DocumentProcessor:
 
     def _chunk_markdown_line_walker(
         self, content: str, filename: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Legacy line-based markdown chunker. Kept as fallback when
         markdown-it-py is unavailable. Preserves original behavior with the
         empty-chunk guard applied.
@@ -638,8 +638,8 @@ class DocumentProcessor:
         chunks = []
         lines = content.split("\n")
 
-        current_hierarchy: List[str] = []  # Track header hierarchy
-        current_chunk: List[str] = []
+        current_hierarchy: list[str] = []  # Track header hierarchy
+        current_chunk: list[str] = []
         current_size = 0
         line_start = 1
         in_code_block = False
@@ -751,14 +751,14 @@ class DocumentProcessor:
 
     def _chunk_python_enhanced(
         self, content: str, filename: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Enhanced Python code chunking with better function/class detection"""
         chunks = []
         lines = content.split("\n")
 
         current_function = None
         current_class = None
-        current_chunk: List[str] = []
+        current_chunk: list[str] = []
         current_size = 0
         line_start = 1
         indent_level = 0
@@ -865,7 +865,7 @@ class DocumentProcessor:
 
         return chunks
 
-    def _chunk_text_enhanced(self, content: str, filename: str) -> List[Dict[str, Any]]:
+    def _chunk_text_enhanced(self, content: str, filename: str) -> list[dict[str, Any]]:
         """Enhanced text chunking using sentence-based approach"""
         if isinstance(content, list):
             content = "\n".join(content)
@@ -889,7 +889,7 @@ class DocumentProcessor:
 
     def _sentence_based_chunking(
         self, text: str, max_sentences_per_chunk: int, split_newlines: int = 2
-    ) -> List[str]:
+    ) -> list[str]:
         """Sentence-based chunking with enhancements"""
         if not sent_tokenize:
             # Fallback to simple splitting
@@ -900,7 +900,7 @@ class DocumentProcessor:
 
             if split_newlines > 0:
                 # Create regex pattern for specified number of newlines
-                newline_pattern = r"(\n{%d,})" % split_newlines
+                newline_pattern = rf"(\n{{{split_newlines},}})"
                 parts = re.split(newline_pattern, text)
 
                 for part in parts:
@@ -940,13 +940,13 @@ class DocumentProcessor:
         optimal_sentences = max(1, int(self.chunk_size / avg_sentence_length))
         return min(optimal_sentences, 10)  # Cap at 10 sentences for readability
 
-    def _build_section_path(self, hierarchy: List[str]) -> Optional[str]:
+    def _build_section_path(self, hierarchy: list[str]) -> str | None:
         """Build hierarchical section path from header hierarchy"""
         return " > ".join(hierarchy) if hierarchy else None
 
     def _build_markdown_metadata(
-        self, hierarchy: List[str], code_languages: List[str], has_code: bool
-    ) -> Dict[str, Any]:
+        self, hierarchy: list[str], code_languages: list[str], has_code: bool
+    ) -> dict[str, Any]:
         """Build rich metadata for markdown chunks
 
         Args:
@@ -957,7 +957,7 @@ class DocumentProcessor:
         Returns:
             Dictionary with markdown-specific metadata including tags
         """
-        metadata: Dict[str, Any] = {
+        metadata: dict[str, Any] = {
             "chunk_type": "markdown",
         }
 
@@ -989,8 +989,8 @@ class DocumentProcessor:
         return metadata
 
     def _build_python_section(
-        self, class_name: Optional[str], function_name: Optional[str]
-    ) -> Optional[str]:
+        self, class_name: str | None, function_name: str | None
+    ) -> str | None:
         """Build section name for Python code"""
         if class_name and function_name:
             return f"{class_name}.{function_name}"
@@ -1000,7 +1000,7 @@ class DocumentProcessor:
             return function_name
         return None
 
-    def _find_best_split_point(self, lines: List[str]) -> int:
+    def _find_best_split_point(self, lines: list[str]) -> int:
         """Find the best point to split a chunk (prefer paragraph boundaries)"""
         # Look for empty lines (paragraph boundaries) in the last 25% of the chunk
         start_search = max(1, len(lines) * 3 // 4)
@@ -1016,11 +1016,11 @@ class DocumentProcessor:
         self,
         content: str,
         filename: str,
-        section: Optional[str] = None,
-        start_line: Optional[int] = None,
-        end_line: Optional[int] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+        section: str | None = None,
+        start_line: int | None = None,
+        end_line: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         """Create chunk dictionary with enhanced metadata"""
         base_metadata = {
             "file_type": Path(filename).suffix.lstrip("."),
@@ -1056,14 +1056,14 @@ class DocumentProcessor:
             "metadata": base_metadata,
         }
 
-    def _get_overlap_lines(self, lines: List[str]) -> List[str]:
+    def _get_overlap_lines(self, lines: list[str]) -> list[str]:
         """Get overlap lines for chunk continuity"""
         if not lines:
             return []
 
         # Calculate overlap size in characters
         overlap_chars = self.chunk_overlap
-        overlap_lines: List[str] = []
+        overlap_lines: list[str] = []
         char_count = 0
 
         # Take lines from the end until we reach overlap size
@@ -1078,7 +1078,7 @@ class DocumentProcessor:
 
     def _chunk_by_sentences(
         self, content: str, filename: str, file_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Chunk content by sentences with specified max sentences per chunk"""
         if isinstance(content, list):
             content = "\n".join(content)
@@ -1109,7 +1109,7 @@ class DocumentProcessor:
 
     def _chunk_by_sliding_window(
         self, content: str, filename: str, file_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Chunk content using sliding window approach with word-based chunks"""
         if isinstance(content, list):
             content = "\n".join(content)
@@ -1149,7 +1149,7 @@ class DocumentProcessor:
 
     def _chunk_by_paragraphs(
         self, content: str, filename: str, file_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Chunk content by paragraphs (split on double newlines)"""
         if isinstance(content, list):
             content = "\n".join(content)
@@ -1178,7 +1178,7 @@ class DocumentProcessor:
 
     def _chunk_by_pages(
         self, content: str, filename: str, file_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Chunk content by pages (for documents that have page boundaries)"""
         if isinstance(content, list):
             # If content is already a list (e.g., from PDF extraction), treat each item as a page
@@ -1225,7 +1225,7 @@ class DocumentProcessor:
 
     def _chunk_by_semantic(
         self, content: str, filename: str, file_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Chunk based on semantic similarity between sentences"""
         if isinstance(content, list):
             content = "\n".join(content)
@@ -1283,7 +1283,7 @@ class DocumentProcessor:
             split_points.append(len(sentences))
 
             # Create chunks
-            chunks: List[Dict[str, Any]] = []
+            chunks: list[dict[str, Any]] = []
             for i in range(len(split_points) - 1):
                 start_idx = split_points[i]
                 end_idx = split_points[i + 1]
@@ -1334,7 +1334,7 @@ class DocumentProcessor:
 
     def _chunk_by_topics(
         self, content: str, filename: str, file_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Chunk based on topic changes using keyword analysis"""
         if isinstance(content, list):
             content = "\n".join(content)
@@ -1445,7 +1445,7 @@ class DocumentProcessor:
                 sentence_keywords.append(set(keywords))
 
             # Find topic boundaries based on keyword overlap
-            chunks: List[Dict[str, Any]] = []
+            chunks: list[dict[str, Any]] = []
             current_chunk = [sentences[0]]
             current_keywords = sentence_keywords[0]
 
@@ -1518,7 +1518,7 @@ class DocumentProcessor:
 
     def _chunk_by_qa_optimization(
         self, content: str, filename: str, file_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Create chunks optimized for question-answering"""
         if isinstance(content, list):
             content = "\n".join(content)
@@ -1538,8 +1538,8 @@ class DocumentProcessor:
             r"(definition|meaning|refers to|means)",
         ]
 
-        chunks: List[Dict[str, Any]] = []
-        current_chunk: List[str] = []
+        chunks: list[dict[str, Any]] = []
+        current_chunk: list[str] = []
         current_context = []
 
         for i, sentence in enumerate(sentences):
@@ -1629,7 +1629,7 @@ class DocumentProcessor:
 
     def _chunk_from_json(
         self, content: str, filename: str, file_type: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Create chunks from pre-processed JSON content
 

--- a/signalwire/signalwire/search/index_builder.py
+++ b/signalwire/signalwire/search/index_builder.py
@@ -12,7 +12,7 @@ import json
 import hashlib
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Dict, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 import fnmatch
 
 if TYPE_CHECKING:
@@ -48,13 +48,13 @@ class IndexBuilder:
         max_sentences_per_chunk: int = 5,
         chunk_size: int = 50,
         chunk_overlap: int = 10,
-        split_newlines: Optional[int] = None,
+        split_newlines: int | None = None,
         index_nlp_backend: str = "nltk",
         verbose: bool = False,
         semantic_threshold: float = 0.5,
         topic_threshold: float = 0.3,
         backend: str = "sqlite",
-        connection_string: Optional[str] = None,
+        connection_string: str | None = None,
     ):
         """
         Initialize the index builder
@@ -116,7 +116,7 @@ class IndexBuilder:
 
     def _extract_metadata_from_json_content(
         self, content: str
-    ) -> tuple[Dict[str, Any], str]:
+    ) -> tuple[dict[str, Any], str]:
         """
         Extract metadata from JSON content if present
 
@@ -180,12 +180,12 @@ class IndexBuilder:
 
     def build_index_from_sources(
         self,
-        sources: List[Path],
+        sources: list[Path],
         output_file: str,
-        file_types: List[str],
-        exclude_patterns: Optional[List[str]] = None,
-        languages: Optional[List[str]] = None,
-        tags: Optional[List[str]] = None,
+        file_types: list[str],
+        exclude_patterns: list[str] | None = None,
+        languages: list[str] | None = None,
+        tags: list[str] | None = None,
         overwrite: bool = False,
     ):
         """
@@ -317,10 +317,10 @@ class IndexBuilder:
         self,
         source_dir: str,
         output_file: str,
-        file_types: List[str],
-        exclude_patterns: Optional[List[str]] = None,
-        languages: Optional[List[str]] = None,
-        tags: Optional[List[str]] = None,
+        file_types: list[str],
+        exclude_patterns: list[str] | None = None,
+        languages: list[str] | None = None,
+        tags: list[str] | None = None,
     ):
         """
         Build complete search index from a single directory
@@ -340,7 +340,7 @@ class IndexBuilder:
             sources, output_file, file_types, exclude_patterns, languages, tags
         )
 
-    def _get_base_directory_for_file(self, file_path: Path, sources: List[Path]) -> str:
+    def _get_base_directory_for_file(self, file_path: Path, sources: list[Path]) -> str:
         """
         Determine the appropriate base directory for a file to calculate relative paths
 
@@ -373,10 +373,10 @@ class IndexBuilder:
 
     def _discover_files_from_sources(
         self,
-        sources: List[Path],
-        file_types: List[str],
-        exclude_patterns: Optional[List[str]] = None,
-    ) -> List[Path]:
+        sources: list[Path],
+        file_types: list[str],
+        exclude_patterns: list[str] | None = None,
+    ) -> list[Path]:
         """
         Discover files from multiple sources (files and directories)
 
@@ -437,7 +437,7 @@ class IndexBuilder:
         return unique_files
 
     def _is_file_excluded(
-        self, file_path: Path, exclude_patterns: Optional[List[str]] = None
+        self, file_path: Path, exclude_patterns: list[str] | None = None
     ) -> bool:
         """
         Check if a file should be excluded based on exclude patterns
@@ -461,9 +461,9 @@ class IndexBuilder:
     def _discover_files(
         self,
         source_dir: str,
-        file_types: List[str],
-        exclude_patterns: Optional[List[str]] = None,
-    ) -> List[Path]:
+        file_types: list[str],
+        exclude_patterns: list[str] | None = None,
+    ) -> list[Path]:
         """Discover files to index"""
         files = []
         source_path = Path(source_dir)
@@ -498,8 +498,8 @@ class IndexBuilder:
         return files
 
     def _process_file(
-        self, file_path: Path, source_dir: str, global_tags: Optional[List[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, file_path: Path, source_dir: str, global_tags: list[str] | None = None
+    ) -> list[dict[str, Any]]:
         """Process single file into chunks"""
         try:
             relative_path = str(file_path.relative_to(source_dir))
@@ -595,10 +595,10 @@ class IndexBuilder:
     def _create_database(
         self,
         output_file: str,
-        chunks: List[Dict[str, Any]],
-        languages: List[str],
-        sources_info: List[str],
-        file_types: List[str],
+        chunks: list[dict[str, Any]],
+        languages: list[str],
+        sources_info: list[str],
+        file_types: list[str],
     ):
         """Create SQLite database with all data"""
 
@@ -773,7 +773,7 @@ class IndexBuilder:
         finally:
             conn.close()
 
-    def validate_index(self, index_file: str) -> Dict[str, Any]:
+    def validate_index(self, index_file: str) -> dict[str, Any]:
         """Validate an existing search index"""
         if not Path(index_file).exists():
             return {"valid": False, "error": "Index file does not exist"}
@@ -818,9 +818,9 @@ class IndexBuilder:
 
     def _store_chunks_pgvector(
         self,
-        chunks: List[Dict[str, Any]],
+        chunks: list[dict[str, Any]],
         collection_name: str,
-        languages: List[str],
+        languages: list[str],
         overwrite: bool = False,
     ):
         """

--- a/signalwire/signalwire/search/migration.py
+++ b/signalwire/signalwire/search/migration.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 
 import sqlite3
 import json
-from typing import Dict, Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from signalwire.core.logging_config import get_logger
 from pathlib import Path
@@ -45,7 +45,7 @@ class SearchIndexMigrator:
         collection_name: str,
         overwrite: bool = False,
         batch_size: int = 100,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Migrate a .swsearch SQLite index to pgvector
 
@@ -65,7 +65,7 @@ class SearchIndexMigrator:
         # Import pgvector backend
         from .pgvector_backend import PgVectorBackend
 
-        stats: Dict[str, Any] = {
+        stats: dict[str, Any] = {
             "source": sqlite_path,
             "target": collection_name,
             "chunks_migrated": 0,
@@ -282,7 +282,7 @@ class SearchIndexMigrator:
         collection_name: str,
         output_path: str,
         batch_size: int = 100,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Migrate a pgvector collection to SQLite .swsearch format
 
@@ -301,7 +301,7 @@ class SearchIndexMigrator:
         if not output_path.endswith(".swsearch"):
             output_path += ".swsearch"
 
-        stats: Dict[str, Any] = {
+        stats: dict[str, Any] = {
             "source": f"{collection_name} (pgvector)",
             "target": output_path,
             "chunks_migrated": 0,
@@ -432,7 +432,7 @@ class SearchIndexMigrator:
 
         return stats
 
-    def get_index_info(self, index_path: str) -> Dict[str, Any]:
+    def get_index_info(self, index_path: str) -> dict[str, Any]:
         """
         Get information about a search index
 
@@ -442,7 +442,7 @@ class SearchIndexMigrator:
         Returns:
             Index information including type, config, and statistics
         """
-        info: Dict[str, Any] = {}
+        info: dict[str, Any] = {}
 
         if index_path.endswith(".swsearch") and Path(index_path).exists():
             # SQLite index

--- a/signalwire/signalwire/search/pgvector_backend.py
+++ b/signalwire/signalwire/search/pgvector_backend.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 
 import json
 import re
-from typing import List, Dict, Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from signalwire.core.logging_config import get_logger
 
@@ -199,7 +199,7 @@ class PgVectorBackend:
             self.conn.commit()
             logger.info(f"Created schema for collection '{collection_name}'")
 
-    def _extract_metadata_from_json_content(self, content: str) -> Dict[str, Any]:
+    def _extract_metadata_from_json_content(self, content: str) -> dict[str, Any]:
         """
         Extract metadata from JSON content if present
 
@@ -231,7 +231,7 @@ class PgVectorBackend:
         return metadata_dict
 
     def store_chunks(
-        self, chunks: List[Dict[str, Any]], collection_name: str, config: Dict[str, Any]
+        self, chunks: list[dict[str, Any]], collection_name: str, config: dict[str, Any]
     ):
         """
         Store document chunks in the database
@@ -369,7 +369,7 @@ class PgVectorBackend:
                 f"Stored {len(chunks)} chunks in collection '{collection_name}'"
             )
 
-    def get_stats(self, collection_name: str) -> Dict[str, Any]:
+    def get_stats(self, collection_name: str) -> dict[str, Any]:
         """Get statistics for a collection"""
         self._ensure_connection()
 
@@ -417,7 +417,7 @@ class PgVectorBackend:
                 "config": config,
             }
 
-    def list_collections(self) -> List[str]:
+    def list_collections(self) -> list[str]:
         """List all collections in the database"""
         self._ensure_connection()
 
@@ -503,7 +503,7 @@ class PgVectorSearchBackend:
         if self.conn is None or self.conn.closed:
             self._connect()
 
-    def _load_config(self) -> Dict[str, Any]:
+    def _load_config(self) -> dict[str, Any]:
         """Load collection configuration"""
         self._ensure_connection()
 
@@ -526,13 +526,13 @@ class PgVectorSearchBackend:
 
     def search(
         self,
-        query_vector: List[float],
+        query_vector: list[float],
         enhanced_text: str,
         count: int = 5,
         similarity_threshold: float = 0.0,
-        tags: Optional[List[str]] = None,
-        keyword_weight: Optional[float] = None,
-    ) -> List[Dict[str, Any]]:
+        tags: list[str] | None = None,
+        keyword_weight: float | None = None,
+    ) -> list[dict[str, Any]]:
         """
         Perform hybrid search (vector + keyword + metadata).
 
@@ -597,7 +597,7 @@ class PgVectorSearchBackend:
 
         return merged_results[:count]
 
-    def _dedupe_by_content(self, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _dedupe_by_content(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Drop duplicate-content chunks, keeping the first (highest-scoring) occurrence."""
         import hashlib
         import re
@@ -624,8 +624,8 @@ class PgVectorSearchBackend:
         return out
 
     def _vector_search(
-        self, query_vector: List[float], count: int, tags: Optional[List[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, query_vector: list[float], count: int, tags: list[str] | None = None
+    ) -> list[dict[str, Any]]:
         """Perform vector similarity search"""
         with self.conn.cursor() as cursor:
             # Set probes for IVFFlat index to ensure we get enough results
@@ -641,7 +641,7 @@ class PgVectorSearchBackend:
             """).format(tbl=tbl)
             ]
 
-            params: List[Any] = [query_vector]
+            params: list[Any] = [query_vector]
 
             # Add tag filter if specified
             if tags:
@@ -686,8 +686,8 @@ class PgVectorSearchBackend:
             return results
 
     def _keyword_search(
-        self, enhanced_text: str, count: int, tags: Optional[List[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, enhanced_text: str, count: int, tags: list[str] | None = None
+    ) -> list[dict[str, Any]]:
         """Perform full-text search"""
         with self.conn.cursor() as cursor:
             # Use PostgreSQL text search
@@ -702,7 +702,7 @@ class PgVectorSearchBackend:
             """).format(tbl=tbl)
             ]
 
-            params: List[Any] = [enhanced_text, enhanced_text]
+            params: list[Any] = [enhanced_text, enhanced_text]
 
             # Add tag filter if specified
             if tags:
@@ -742,15 +742,15 @@ class PgVectorSearchBackend:
             return results
 
     def _metadata_search(
-        self, query_terms: List[str], count: int, tags: Optional[List[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, query_terms: list[str], count: int, tags: list[str] | None = None
+    ) -> list[dict[str, Any]]:
         """
         Perform metadata search using JSONB operators and metadata_text
         """
         with self.conn.cursor() as cursor:
             # Build WHERE conditions
             where_conditions = []
-            params: List[Any] = []
+            params: list[Any] = []
 
             # Use metadata_text for trigram search
             if query_terms:
@@ -838,8 +838,8 @@ class PgVectorSearchBackend:
             return results[:count]
 
     def _filename_search(
-        self, query: str, count: int, tags: Optional[List[str]] = None
-    ) -> List[Dict[str, Any]]:
+        self, query: str, count: int, tags: list[str] | None = None
+    ) -> list[dict[str, Any]]:
         """Search for query in filenames with term coverage scoring.
 
         Phase 1: exact phrase match on filename (highest score).
@@ -865,7 +865,7 @@ class PgVectorSearchBackend:
                 WHERE LOWER(filename) LIKE %s
             """).format(tbl=tbl)
             ]
-            params: List[Any] = [f"%{query_lower}%"]
+            params: list[Any] = [f"%{query_lower}%"]
             if tags:
                 parts.append(psycopg2_sql.SQL(" AND tags ?| %s"))
                 params.append(tags)
@@ -969,13 +969,13 @@ class PgVectorSearchBackend:
 
     def fetch_candidates(
         self,
-        query_vector: List[float],
+        query_vector: list[float],
         enhanced_text: str,
         count: int,
         similarity_threshold: float = 0.0,
-        tags: Optional[List[str]] = None,
-        original_query: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+        tags: list[str] | None = None,
+        original_query: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Fetch raw candidates with per-source signal scores.
 
         Runs vector/keyword/metadata/filename searches, applies similarity
@@ -1015,7 +1015,7 @@ class PgVectorSearchBackend:
             f"keyword={len(keyword_results)}"
         )
 
-        candidates: Dict[Any, Dict[str, Any]] = {}
+        candidates: dict[Any, dict[str, Any]] = {}
 
         # Vector first (primary signal)
         for r in vector_results:
@@ -1046,10 +1046,10 @@ class PgVectorSearchBackend:
 
     def _merge_results(
         self,
-        vector_results: List[Dict[str, Any]],
-        keyword_results: List[Dict[str, Any]],
-        keyword_weight: Optional[float] = None,
-    ) -> List[Dict[str, Any]]:
+        vector_results: list[dict[str, Any]],
+        keyword_results: list[dict[str, Any]],
+        keyword_weight: float | None = None,
+    ) -> list[dict[str, Any]]:
         """Merge and rank results from vector and keyword search.
 
         Uses max-signal-wins scoring: the strongest signal (vector or keyword)
@@ -1060,7 +1060,7 @@ class PgVectorSearchBackend:
 
         # Collect per-source scores for each result
         results_map = {}
-        all_sources: Dict[str, Any] = {}
+        all_sources: dict[str, Any] = {}
 
         for result in vector_results:
             chunk_id = result["id"]
@@ -1088,11 +1088,11 @@ class PgVectorSearchBackend:
 
     def _merge_all_results(
         self,
-        vector_results: List[Dict[str, Any]],
-        keyword_results: List[Dict[str, Any]],
-        metadata_results: List[Dict[str, Any]],
-        keyword_weight: Optional[float] = None,
-    ) -> List[Dict[str, Any]]:
+        vector_results: list[dict[str, Any]],
+        keyword_results: list[dict[str, Any]],
+        metadata_results: list[dict[str, Any]],
+        keyword_weight: float | None = None,
+    ) -> list[dict[str, Any]]:
         """Merge and rank results from vector, keyword, and metadata search.
 
         Uses max-signal-wins scoring: the strongest signal (vector, keyword,
@@ -1104,7 +1104,7 @@ class PgVectorSearchBackend:
 
         # Collect per-source scores for each result
         results_map = {}
-        all_sources: Dict[str, Any] = {}
+        all_sources: dict[str, Any] = {}
 
         for result in vector_results:
             chunk_id = result["id"]
@@ -1138,7 +1138,7 @@ class PgVectorSearchBackend:
 
         return merged
 
-    def get_stats(self) -> Dict[str, Any]:
+    def get_stats(self) -> dict[str, Any]:
         """Get statistics for the collection"""
         backend = PgVectorBackend(self.connection_string)
         stats = backend.get_stats(self.collection_name)

--- a/signalwire/signalwire/search/query_processor.py
+++ b/signalwire/signalwire/search/query_processor.py
@@ -10,7 +10,7 @@ See LICENSE file in the project root for full license information.
 import nltk
 import re
 import threading
-from typing import Dict, Any, List, Optional
+from typing import Any
 from nltk.corpus import wordnet as wn
 from nltk.stem import PorterStemmer
 
@@ -230,7 +230,7 @@ def load_spacy_model(language: str):
 
 
 # Model cache - stores multiple models by name
-_model_cache: Dict[str, Any] = {}  # model_name -> SentenceTransformer instance
+_model_cache: dict[str, Any] = {}  # model_name -> SentenceTransformer instance
 _MAX_MODEL_CACHE_SIZE = 5
 
 _model_lock = threading.Lock()
@@ -257,7 +257,7 @@ def set_global_model(model):
             logger.info(f"Model added to cache: {model_name}")
 
 
-def _get_cached_model(model_name: Optional[str] = None):
+def _get_cached_model(model_name: str | None = None):
     """Get or create cached sentence transformer model
 
     Args:
@@ -303,7 +303,7 @@ def _get_cached_model(model_name: Optional[str] = None):
             return None
 
 
-def vectorize_query(query: str, model=None, model_name: Optional[str] = None):
+def vectorize_query(query: str, model=None, model_name: str | None = None):
     """
     Vectorize query using sentence transformers
     Returns numpy array of embeddings
@@ -404,7 +404,7 @@ def get_wordnet_pos(spacy_pos):
     return pos_mapping.get(spacy_pos, wn.NOUN)
 
 
-def get_synonyms(word: str, pos_tag: str, max_synonyms: int = 5) -> List[str]:
+def get_synonyms(word: str, pos_tag: str, max_synonyms: int = 5) -> list[str]:
     """Get synonyms for a word using WordNet"""
     try:
         wn_pos = get_wordnet_pos(pos_tag)
@@ -449,16 +449,16 @@ def remove_duplicate_words(input_string: str) -> str:
 def preprocess_query(
     query: str,
     language: str = "en",
-    pos_to_expand: Optional[List[str]] = None,
+    pos_to_expand: list[str] | None = None,
     max_synonyms: int = 5,
     debug: bool = False,
     vector: bool = False,
     vectorize_query_param: bool = False,
-    nlp_backend: Optional[str] = None,
+    nlp_backend: str | None = None,
     query_nlp_backend: str = "nltk",
-    model_name: Optional[str] = None,
+    model_name: str | None = None,
     preserve_original: bool = True,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Advanced query preprocessing with language detection, POS tagging, synonym expansion, and vectorization
 
@@ -638,7 +638,7 @@ def preprocess_query(
             f"NLP Backend Used: {query_nlp_backend if nlp or query_nlp_backend == 'nltk' else 'nltk (fallback)'}"
         )
 
-    formatted_output: Dict[str, Any] = {
+    formatted_output: dict[str, Any] = {
         "input": final_query_str,
         "enhanced_text": final_query_str,  # Alias for compatibility
         "language": language,
@@ -662,9 +662,9 @@ def preprocess_query(
 def preprocess_document_content(
     content: str,
     language: str = "en",
-    nlp_backend: Optional[str] = None,
+    nlp_backend: str | None = None,
     index_nlp_backend: str = "nltk",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Preprocess document content for better searchability
 

--- a/signalwire/signalwire/search/search_engine.py
+++ b/signalwire/signalwire/search/search_engine.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 
 import sqlite3
 import json
-from typing import List, Dict, Any, Optional, Union, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from signalwire.core.logging_config import get_logger
 
@@ -39,9 +39,9 @@ class SearchEngine:
     def __init__(
         self,
         backend: str = "sqlite",
-        index_path: Optional[str] = None,
-        connection_string: Optional[str] = None,
-        collection_name: Optional[str] = None,
+        index_path: str | None = None,
+        connection_string: str | None = None,
+        collection_name: str | None = None,
         model=None,
     ):
         """
@@ -79,7 +79,7 @@ class SearchEngine:
                 f"Invalid backend '{backend}'. Must be 'sqlite' or 'pgvector'"
             )
 
-    def _load_config(self) -> Dict[str, str]:
+    def _load_config(self) -> dict[str, str]:
         """Load index configuration"""
         conn = None
         try:
@@ -96,14 +96,14 @@ class SearchEngine:
 
     def search(
         self,
-        query_vector: List[float],
+        query_vector: list[float],
         enhanced_text: str,
         count: int = 3,
         similarity_threshold: float = 0.0,
-        tags: Optional[List[str]] = None,
-        keyword_weight: Optional[float] = None,
-        original_query: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+        tags: list[str] | None = None,
+        keyword_weight: float | None = None,
+        original_query: str | None = None,
+    ) -> list[dict[str, Any]]:
         """
         Unified hybrid search: backends fetch candidates, SearchEngine post-processes.
 
@@ -164,13 +164,13 @@ class SearchEngine:
 
     def _fetch_candidates(
         self,
-        query_vector: List[float],
+        query_vector: list[float],
         enhanced_text: str,
         count: int,
         similarity_threshold: float = 0.0,
-        tags: Optional[List[str]] = None,
-        original_query: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+        tags: list[str] | None = None,
+        original_query: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Dispatch candidate fetching to the active backend.
 
         Returns a list of raw candidates (not yet scored/deduped/diversified).
@@ -224,7 +224,7 @@ class SearchEngine:
             f"keyword={len(keyword_results)}"
         )
 
-        candidates: Dict[Any, Dict[str, Any]] = {}
+        candidates: dict[Any, dict[str, Any]] = {}
 
         # Vector first (primary signal)
         for r in vector_results:
@@ -255,12 +255,12 @@ class SearchEngine:
 
     def _process_candidates(
         self,
-        candidates: List[Dict[str, Any]],
+        candidates: list[dict[str, Any]],
         count: int,
         similarity_threshold: float = 0.0,
-        tags: Optional[List[str]] = None,
-        original_query: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+        tags: list[str] | None = None,
+        original_query: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Backend-agnostic post-processing pipeline.
 
         Steps (in order):
@@ -326,9 +326,9 @@ class SearchEngine:
         self,
         enhanced_text: str,
         count: int,
-        tags: Optional[List[str]] = None,
-        original_query: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+        tags: list[str] | None = None,
+        original_query: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Fallback to keyword search only when vector search is unavailable"""
         keyword_results = self._keyword_search(enhanced_text, count, original_query)
 
@@ -338,8 +338,8 @@ class SearchEngine:
         return keyword_results[:count]
 
     def _vector_search(
-        self, query_vector: Union[NDArray, Any], count: int
-    ) -> List[Dict[str, Any]]:
+        self, query_vector: NDArray | Any, count: int
+    ) -> list[dict[str, Any]]:
         """Perform vector similarity search"""
         if not np or not cosine_similarity:
             return []
@@ -416,8 +416,8 @@ class SearchEngine:
                 conn.close()
 
     def _keyword_search(
-        self, enhanced_text: str, count: int, original_query: Optional[str] = None
-    ) -> List[Dict[str, Any]]:
+        self, enhanced_text: str, count: int, original_query: str | None = None
+    ) -> list[dict[str, Any]]:
         """Perform full-text search"""
         conn = None
         try:
@@ -496,7 +496,7 @@ class SearchEngine:
         escaped_terms = [f'"{term}"' for term in terms if term]
         return " ".join(escaped_terms)
 
-    def _fallback_search(self, enhanced_text: str, count: int) -> List[Dict[str, Any]]:
+    def _fallback_search(self, enhanced_text: str, count: int) -> list[dict[str, Any]]:
         """Fallback search using LIKE when FTS fails"""
         conn = None
         try:
@@ -506,7 +506,7 @@ class SearchEngine:
             # Simple LIKE search with word boundaries
             search_terms = enhanced_text.lower().split()
             like_conditions = []
-            params: List[Any] = []
+            params: list[Any] = []
 
             for term in search_terms[
                 :5
@@ -610,11 +610,11 @@ class SearchEngine:
 
     def _merge_results(
         self,
-        vector_results: List[Dict],
-        keyword_results: List[Dict],
-        vector_weight: Optional[float] = None,
-        keyword_weight: Optional[float] = None,
-    ) -> List[Dict[str, Any]]:
+        vector_results: list[dict],
+        keyword_results: list[dict],
+        vector_weight: float | None = None,
+        keyword_weight: float | None = None,
+    ) -> list[dict[str, Any]]:
         """Merge and rank vector and keyword search results"""
         # Use provided weights or defaults
         if vector_weight is None:
@@ -662,8 +662,8 @@ class SearchEngine:
         return sorted(combined.values(), key=lambda x: x["score"], reverse=True)
 
     def _filter_by_tags(
-        self, results: List[Dict], required_tags: List[str]
-    ) -> List[Dict[str, Any]]:
+        self, results: list[dict], required_tags: list[str]
+    ) -> list[dict[str, Any]]:
         """Filter results by required tags"""
         filtered = []
         for result in results:
@@ -673,8 +673,8 @@ class SearchEngine:
         return filtered
 
     def _boost_exact_matches(
-        self, results: List[Dict[str, Any]], original_query: str
-    ) -> List[Dict[str, Any]]:
+        self, results: list[dict[str, Any]], original_query: str
+    ) -> list[dict[str, Any]]:
         """Boost scores for results that contain exact matches of the original query"""
         if not original_query:
             return results
@@ -715,7 +715,7 @@ class SearchEngine:
         """Escape LIKE wildcard characters in user input"""
         return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
-    def _filename_search(self, query: str, count: int) -> List[Dict[str, Any]]:
+    def _filename_search(self, query: str, count: int) -> list[dict[str, Any]]:
         """Search for query in filenames with term coverage scoring"""
         conn = None
         try:
@@ -777,7 +777,7 @@ class SearchEngine:
             if terms and len(results) < count * 3:  # Get more candidates
                 # Build OR query for any term match (escape LIKE wildcards)
                 conditions = []
-                params: List[Any] = []
+                params: list[Any] = []
                 for term in terms:
                     conditions.append("LOWER(filename) LIKE ? ESCAPE '\\'")
                     params.append(f"%{self._escape_like(term)}%")
@@ -863,7 +863,7 @@ class SearchEngine:
             if conn:
                 conn.close()
 
-    def _metadata_search(self, query: str, count: int) -> List[Dict[str, Any]]:
+    def _metadata_search(self, query: str, count: int) -> list[dict[str, Any]]:
         """Search in all metadata fields (tags, sections, category, product, source)"""
         conn = None
         try:
@@ -888,7 +888,7 @@ class SearchEngine:
                 # Use the new metadata_text column for efficient searching
                 # Build conditions for each term (escape LIKE wildcards)
                 conditions = []
-                params: List[Any] = []
+                params: list[Any] = []
                 for term in terms:
                     conditions.append("metadata_text LIKE ? ESCAPE '\\'")
                     params.append(f"%{self._escape_like(term)}%")
@@ -956,7 +956,7 @@ class SearchEngine:
             if len(results) < count:
                 # Build specific conditions for known patterns
                 specific_conditions = []
-                specific_params: List[Any] = []
+                specific_params: list[Any] = []
 
                 # Look for specific high-value patterns first
                 if "code" in terms and "examples" in terms:
@@ -1139,7 +1139,7 @@ class SearchEngine:
                     metadata.update(nested_meta)
 
                 # Initialize scoring components
-                score_components: Dict[str, float] = {
+                score_components: dict[str, float] = {
                     "tags": 0,
                     "section": 0,
                     "category": 0,
@@ -1302,7 +1302,7 @@ class SearchEngine:
 
     def _add_vector_scores_to_candidates(
         self,
-        candidates: Dict[str, Dict],
+        candidates: dict[str, dict],
         query_vector: NDArray,
         similarity_threshold: float,
     ):
@@ -1362,7 +1362,7 @@ class SearchEngine:
                 conn.close()
 
     def _calculate_combined_score(
-        self, candidate: Dict, similarity_threshold: float
+        self, candidate: dict, similarity_threshold: float
     ) -> float:
         """Calculate final score using max-signal-wins approach.
 
@@ -1390,7 +1390,7 @@ class SearchEngine:
         boost = agreement_boost * (len(scores) - 1)
         return min(1.0, base + boost)
 
-    def _dedupe_by_content(self, results: List[Dict]) -> List[Dict]:
+    def _dedupe_by_content(self, results: list[dict]) -> list[dict]:
         """Collapse exact/near-exact content duplicates, keeping the highest-scoring copy.
 
         Index quality varies: some source docs contain repeated boilerplate (footers,
@@ -1429,14 +1429,14 @@ class SearchEngine:
         return deduped
 
     def _apply_diversity_penalties(
-        self, results: List[Dict], target_count: int
-    ) -> List[Dict]:
+        self, results: list[dict], target_count: int
+    ) -> list[dict]:
         """Apply penalties to prevent single-file dominance while maintaining quality"""
         if not results:
             return results
 
         # Track file occurrences
-        file_counts: Dict[str, int] = {}
+        file_counts: dict[str, int] = {}
         penalized_results = []
 
         # Define penalty multipliers
@@ -1512,8 +1512,8 @@ class SearchEngine:
         return penalized_results
 
     def _apply_match_type_diversity(
-        self, results: List[Dict], target_count: int
-    ) -> List[Dict]:
+        self, results: list[dict], target_count: int
+    ) -> list[dict]:
         """Ensure diversity of match types in final results
 
         Ensures we have a mix of:
@@ -1571,7 +1571,7 @@ class SearchEngine:
 
         return diversified
 
-    def get_stats(self) -> Dict[str, Any]:
+    def get_stats(self) -> dict[str, Any]:
         """Get statistics about the search index"""
         # Use pgvector backend if available
         if self.backend == "pgvector":

--- a/signalwire/signalwire/search/search_service.py
+++ b/signalwire/signalwire/search/search_service.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 
 import hashlib
 import json
-from typing import Dict, Any, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from fastapi import FastAPI, HTTPException, Request, Response, Depends
@@ -52,17 +52,17 @@ if BaseModel is not None:
         index_name: str = "default"
         count: int = 3
         similarity_threshold: float = 0.0
-        tags: Optional[List[str]] = None
-        language: Optional[str] = None
+        tags: list[str] | None = None
+        language: str | None = None
 
     class SearchResult(BaseModel):
         content: str
         score: float
-        metadata: Dict[str, Any]
+        metadata: dict[str, Any]
 
     class SearchResponse(BaseModel):
-        results: List[SearchResult]
-        query_analysis: Optional[Dict[str, Any]] = None
+        results: list[SearchResult]
+        query_analysis: dict[str, Any] | None = None
 else:
     # Fallback classes when FastAPI is not available; these intentionally
     # shadow the pydantic versions above when the optional dep is absent.
@@ -73,8 +73,8 @@ else:
             index_name: str = "default",
             count: int = 3,
             similarity_threshold: float = 0.0,
-            tags: Optional[List[str]] = None,
-            language: Optional[str] = None,
+            tags: list[str] | None = None,
+            language: str | None = None,
         ):
             self.query = query
             self.index_name = index_name
@@ -84,7 +84,7 @@ else:
             self.language = language
 
     class SearchResult:  # type: ignore[no-redef]
-        def __init__(self, content: str, score: float, metadata: Dict[str, Any]):
+        def __init__(self, content: str, score: float, metadata: dict[str, Any]):
             self.content = content
             self.score = score
             self.metadata = metadata
@@ -92,15 +92,15 @@ else:
     class SearchResponse:  # type: ignore[no-redef]
         def __init__(
             self,
-            results: List[SearchResult],
-            query_analysis: Optional[Dict[str, Any]] = None,
+            results: list[SearchResult],
+            query_analysis: dict[str, Any] | None = None,
         ):
             self.results = results
             self.query_analysis = query_analysis
 
 
 def _cache_key(
-    query: str, index_name: str, count: int, tags: Optional[List[str]] = None
+    query: str, index_name: str, count: int, tags: list[str] | None = None
 ) -> str:
     """Generate cache key for query results"""
     key_data = {
@@ -119,11 +119,11 @@ class SearchService:
     def __init__(
         self,
         port: int = 8001,
-        indexes: Optional[Dict[str, str]] = None,
-        basic_auth: Optional[Tuple[str, str]] = None,
-        config_file: Optional[str] = None,
+        indexes: dict[str, str] | None = None,
+        basic_auth: tuple[str, str] | None = None,
+        config_file: str | None = None,
         backend: str = "sqlite",
-        connection_string: Optional[str] = None,
+        connection_string: str | None = None,
     ):
         # Load configuration first
         self._load_config(config_file)
@@ -136,9 +136,9 @@ class SearchService:
         if indexes is not None:
             self.indexes = indexes
 
-        self.search_engines: Dict[str, SearchEngine] = {}
+        self.search_engines: dict[str, SearchEngine] = {}
         self.model: Any = None
-        self._query_cache: Dict[str, Any] = {}  # Simple query result cache
+        self._query_cache: dict[str, Any] = {}  # Simple query result cache
         self._cache_size = 100  # Max number of cached queries
 
         # Load security configuration with optional config file
@@ -148,7 +148,7 @@ class SearchService:
         # Set up authentication
         self._basic_auth = basic_auth or self.security.get_basic_auth()
 
-        self.app: Optional["FastAPI"] = None
+        self.app: FastAPI | None = None
         if FastAPI is not None:
             self.app = FastAPI(title="SignalWire Local Search Service")
             self._setup_security()
@@ -158,7 +158,7 @@ class SearchService:
 
         self._load_resources()
 
-    def _load_config(self, config_file: Optional[str]):
+    def _load_config(self, config_file: str | None):
         """Load configuration from file if available"""
         # Initialize defaults
         self.indexes = {}
@@ -228,8 +228,8 @@ class SearchService:
             return await call_next(request)
 
     def _get_current_username(
-        self, credentials: Optional[HTTPBasicCredentials] = None
-    ) -> Optional[str]:
+        self, credentials: HTTPBasicCredentials | None = None
+    ) -> str | None:
         """Validate basic auth credentials"""
         if not credentials:
             return None
@@ -272,7 +272,7 @@ class SearchService:
         @self.app.post("/search", response_model=SearchResponse)
         async def search(
             request: SearchRequest,
-            credentials: Optional[HTTPBasicCredentials] = None
+            credentials: HTTPBasicCredentials | None = None
             if not security
             else Depends(security),  # noqa: B008  # FastAPI DI: Depends() in default is the intended idiom
         ):
@@ -297,7 +297,7 @@ class SearchService:
         async def reload_index(
             index_name: str,
             index_path: str,
-            credentials: Optional[HTTPBasicCredentials] = None
+            credentials: HTTPBasicCredentials | None = None
             if not security
             else Depends(security),  # noqa: B008  # FastAPI DI: Depends() in default is the intended idiom
         ):
@@ -350,10 +350,10 @@ class SearchService:
         if self.backend == "pgvector":
             # For pgvector, we need to load models for query embeddings
             # Different collections might use different models
-            self.models: Dict[
+            self.models: dict[
                 str, Any
             ] = {}  # model_name -> SentenceTransformer instance
-            self.collection_models: Dict[str, Any] = {}  # collection_name -> model_name
+            self.collection_models: dict[str, Any] = {}  # collection_name -> model_name
 
             # Load search engines for each collection and their models
             for collection_name in self.indexes:
@@ -539,9 +539,9 @@ class SearchService:
         index_name: str = "default",
         count: int = 3,
         distance: float = 0.0,
-        tags: Optional[List[str]] = None,
-        language: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        tags: list[str] | None = None,
+        language: str | None = None,
+    ) -> dict[str, Any]:
         """Direct search method (non-async) for programmatic use"""
         request = SearchRequest(
             query=query,
@@ -580,9 +580,9 @@ class SearchService:
     def start(
         self,
         host: str = "0.0.0.0",  # noqa: S104  # intended server default: listen on all interfaces (overridable)
-        port: Optional[int] = None,
-        ssl_cert: Optional[str] = None,
-        ssl_key: Optional[str] = None,
+        port: int | None = None,
+        ssl_cert: str | None = None,
+        ssl_key: str | None = None,
     ):
         """
         Start the service with optional HTTPS support.
@@ -599,7 +599,7 @@ class SearchService:
         port = port or self.port
 
         # Get SSL configuration
-        ssl_kwargs: Dict[str, Any] = {}
+        ssl_kwargs: dict[str, Any] = {}
         if ssl_cert and ssl_key:
             # Use provided SSL files
             ssl_kwargs = {"ssl_certfile": ssl_cert, "ssl_keyfile": ssl_key}

--- a/signalwire/signalwire/skills/api_ninjas_trivia/skill.py
+++ b/signalwire/signalwire/skills/api_ninjas_trivia/skill.py
@@ -12,7 +12,7 @@ A configurable skill for getting trivia questions from API Ninjas with customiza
 categories and multiple tool instances.
 """
 
-from typing import Dict, Any, List, Optional, ClassVar
+from typing import Any, ClassVar
 from signalwire.core import FunctionResult
 from signalwire.core.skill_base import SkillBase
 
@@ -56,10 +56,10 @@ class ApiNinjasTriviaSkill(SkillBase):
     SKILL_NAME = "api_ninjas_trivia"
     SKILL_DESCRIPTION = "Get trivia questions from API Ninjas"
     SUPPORTS_MULTIPLE_INSTANCES = True
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []  # API key can be passed via params
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []  # API key can be passed via params
 
     # Valid API Ninjas trivia categories with human-readable descriptions
-    VALID_CATEGORIES: ClassVar[Dict[str, str]] = {
+    VALID_CATEGORIES: ClassVar[dict[str, str]] = {
         "artliterature": "Art and Literature",
         "language": "Language",
         "sciencenature": "Science and Nature",
@@ -76,7 +76,7 @@ class ApiNinjasTriviaSkill(SkillBase):
         "sportsleisure": "Sports and Leisure",
     }
 
-    def __init__(self, agent, params: Optional[Dict[str, Any]] = None):
+    def __init__(self, agent, params: dict[str, Any] | None = None):
         """
         Initialize the skill with configuration parameters.
 
@@ -149,7 +149,7 @@ class ApiNinjasTriviaSkill(SkillBase):
         """
         return f"{self.SKILL_NAME}_{self.tool_name}"
 
-    def get_tools(self) -> List[Dict[str, Any]]:
+    def get_tools(self) -> list[dict[str, Any]]:
         """
         Generate the SWAIG tool with DataMap webhook.
 
@@ -205,7 +205,7 @@ class ApiNinjasTriviaSkill(SkillBase):
         return [tool]
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """
         Get the parameter schema for the API Ninjas Trivia skill.
 

--- a/signalwire/signalwire/skills/claude_skills/skill.py
+++ b/signalwire/signalwire/skills/claude_skills/skill.py
@@ -11,7 +11,7 @@ import re
 import subprocess
 import fnmatch
 from pathlib import Path
-from typing import List, Dict, Any, Optional, ClassVar
+from typing import Any, ClassVar
 
 import yaml
 
@@ -55,8 +55,8 @@ class ClaudeSkillsSkill(SkillBase):
     SKILL_NAME = "claude_skills"
     SKILL_DESCRIPTION = "Load Claude SKILL.md files as agent tools"
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = ["yaml"]  # PyYAML - import name is 'yaml'
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []
+    REQUIRED_PACKAGES: ClassVar[list[str]] = ["yaml"]  # PyYAML - import name is 'yaml'
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []
     SUPPORTS_MULTIPLE_INSTANCES = True
 
     def setup(self) -> bool:
@@ -117,7 +117,7 @@ class ClaudeSkillsSkill(SkillBase):
         )
         return True
 
-    def _discover_skills(self) -> List[Dict[str, Any]]:
+    def _discover_skills(self) -> list[dict[str, Any]]:
         """
         Discover and parse all SKILL.md files in the skills directory.
 
@@ -179,7 +179,7 @@ class ClaudeSkillsSkill(SkillBase):
 
         return skills
 
-    def _discover_sections(self, skill_dir: Path) -> Dict[str, Path]:
+    def _discover_sections(self, skill_dir: Path) -> dict[str, Path]:
         """
         Find all .md files in skill directory (recursive), excluding SKILL.md.
 
@@ -218,7 +218,7 @@ class ClaudeSkillsSkill(SkillBase):
 
         return sections
 
-    def _discover_all_files(self, skill_dir: Path) -> Dict[str, List[str]]:
+    def _discover_all_files(self, skill_dir: Path) -> dict[str, list[str]]:
         """
         Discover non-.md files recursively, categorized by location.
 
@@ -226,7 +226,7 @@ class ClaudeSkillsSkill(SkillBase):
             Dictionary with keys 'scripts', 'assets', 'other' mapping to
             lists of relative file paths.
         """
-        files: Dict[str, List[str]] = {"scripts": [], "assets": [], "other": []}
+        files: dict[str, list[str]] = {"scripts": [], "assets": [], "other": []}
 
         for file_path in skill_dir.rglob("*"):
             if not file_path.is_file():
@@ -268,7 +268,7 @@ class ClaudeSkillsSkill(SkillBase):
         # Check includes
         return any(fnmatch.fnmatch(name, pattern) for pattern in self._include_patterns)
 
-    def _parse_skill_md(self, path: Path) -> Optional[Dict[str, Any]]:
+    def _parse_skill_md(self, path: Path) -> dict[str, Any] | None:
         """
         Parse a SKILL.md file with YAML frontmatter and markdown body.
 
@@ -334,7 +334,7 @@ class ClaudeSkillsSkill(SkillBase):
             "_frontmatter": frontmatter,
         }
 
-    def _warn_unsupported_fields(self, parsed: Dict[str, Any]) -> None:
+    def _warn_unsupported_fields(self, parsed: dict[str, Any]) -> None:
         """Log warnings for unsupported frontmatter fields that are set."""
         name = parsed.get("name", "unknown")
 
@@ -363,7 +363,7 @@ class ClaudeSkillsSkill(SkillBase):
                 f"claude_skills: skill '{name}' has compatibility: {parsed['compatibility']}"
             )
 
-    def _warn_shell_patterns(self, parsed: Dict[str, Any]) -> None:
+    def _warn_shell_patterns(self, parsed: dict[str, Any]) -> None:
         """Warn about shell injection patterns when allow_shell_injection is disabled."""
         name = parsed.get("name", "unknown")
         body = parsed.get("body", "")
@@ -376,7 +376,7 @@ class ClaudeSkillsSkill(SkillBase):
                 f"passed through as-is. Set allow_shell_injection=True to enable."
             )
 
-    def _apply_invocation_control(self, parsed: Dict[str, Any]) -> None:
+    def _apply_invocation_control(self, parsed: dict[str, Any]) -> None:
         """
         Set _skip_tool and _skip_prompt flags based on invocation control frontmatter.
 
@@ -465,7 +465,7 @@ class ClaudeSkillsSkill(SkillBase):
         return _SHELL_INJECTION_RE.sub(replace_command, content)
 
     def _substitute_variables(
-        self, content: str, skill_dir: Path, raw_data: Optional[Dict] = None
+        self, content: str, skill_dir: Path, raw_data: dict | None = None
     ) -> str:
         """
         Substitute variable placeholders in content.
@@ -629,7 +629,7 @@ class ClaudeSkillsSkill(SkillBase):
             section_info = f" with sections: {section_names}" if section_names else ""
             logger.debug(f"claude_skills: registered tool '{tool_name}'{section_info}")
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints based on loaded skills."""
         hints = []
         for skill in self._skills:
@@ -638,7 +638,7 @@ class ClaudeSkillsSkill(SkillBase):
             hints.extend(name.replace("-", " ").replace("_", " ").split())
         return list(set(hints))  # Deduplicate
 
-    def _get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def _get_prompt_sections(self) -> list[dict[str, Any]]:
         """
         Return prompt sections describing available Claude skills.
 
@@ -694,7 +694,7 @@ class ClaudeSkillsSkill(SkillBase):
         return f"{self.SKILL_NAME}_{hash(skills_path) % 10000}"
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get the parameter schema for the Claude skills loader."""
         schema = super().get_parameter_schema()
 

--- a/signalwire/signalwire/skills/datasphere/skill.py
+++ b/signalwire/signalwire/skills/datasphere/skill.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 
 import requests
 import json
-from typing import List, Dict, Any, ClassVar
+from typing import Any, ClassVar
 
 from signalwire.core.skill_base import SkillBase
 from signalwire.core.function_result import FunctionResult
@@ -21,16 +21,16 @@ class DataSphereSkill(SkillBase):
     SKILL_NAME = "datasphere"
     SKILL_DESCRIPTION = "Search knowledge using SignalWire DataSphere RAG stack"
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = ["requests"]
+    REQUIRED_PACKAGES: ClassVar[list[str]] = ["requests"]
     REQUIRED_ENV_VARS: ClassVar[
-        List[str]
+        list[str]
     ] = []  # No required env vars since all config comes from params
 
     # Enable multiple instances support
     SUPPORTS_MULTIPLE_INSTANCES = True
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get parameter schema for DataSphere skill"""
         schema = super().get_parameter_schema()
         schema.update(
@@ -270,7 +270,7 @@ class DataSphereSkill(SkillBase):
                 "Sorry, I encountered an error while searching the knowledge base. Please try again later."
             )
 
-    def _format_search_results(self, query: str, chunks: List[Dict[str, Any]]) -> str:
+    def _format_search_results(self, query: str, chunks: list[dict[str, Any]]) -> str:
         """Format search results for display"""
         if len(chunks) == 1:
             result_text = f"I found 1 result for '{query}':\n\n"
@@ -303,7 +303,7 @@ class DataSphereSkill(SkillBase):
         if hasattr(self, "session"):
             self.session.close()
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints"""
         # Currently no hints provided, but you could add them like:
         # return [
@@ -312,7 +312,7 @@ class DataSphereSkill(SkillBase):
         # ]
         return []
 
-    def get_global_data(self) -> Dict[str, Any]:
+    def get_global_data(self) -> dict[str, Any]:
         """Return global data for agent context"""
         return {
             "datasphere_enabled": True,
@@ -320,7 +320,7 @@ class DataSphereSkill(SkillBase):
             "knowledge_provider": "SignalWire DataSphere",
         }
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         return [
             {

--- a/signalwire/signalwire/skills/datasphere_serverless/skill.py
+++ b/signalwire/signalwire/skills/datasphere_serverless/skill.py
@@ -8,7 +8,7 @@ See LICENSE file in the project root for full license information.
 """
 
 import base64
-from typing import List, Dict, Any, ClassVar
+from typing import Any, ClassVar
 
 from signalwire.core.skill_base import SkillBase
 from signalwire.core.data_map import DataMap
@@ -24,17 +24,17 @@ class DataSphereServerlessSkill(SkillBase):
     )
     SKILL_VERSION = "1.0.0"
     REQUIRED_PACKAGES: ClassVar[
-        List[str]
+        list[str]
     ] = []  # DataMap handles API calls serverlessly
     REQUIRED_ENV_VARS: ClassVar[
-        List[str]
+        list[str]
     ] = []  # No required env vars since all config comes from params
 
     # Enable multiple instances support
     SUPPORTS_MULTIPLE_INSTANCES = True
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get parameter schema for DataSphere Serverless skill"""
         schema = super().get_parameter_schema()
         schema.update(
@@ -239,11 +239,11 @@ class DataSphereServerlessSkill(SkillBase):
         # Register the enhanced DataMap tool with the agent
         self.agent.register_swaig_function(swaig_function)
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints"""
         return []
 
-    def get_global_data(self) -> Dict[str, Any]:
+    def get_global_data(self) -> dict[str, Any]:
         """Return global data for agent context"""
         return {
             "datasphere_serverless_enabled": True,
@@ -251,7 +251,7 @@ class DataSphereServerlessSkill(SkillBase):
             "knowledge_provider": "SignalWire DataSphere (Serverless)",
         }
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         return [
             {

--- a/signalwire/signalwire/skills/datetime/skill.py
+++ b/signalwire/signalwire/skills/datetime/skill.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 
 from datetime import datetime, timezone
 import pytz
-from typing import List, Dict, Any, ClassVar
+from typing import Any, ClassVar
 
 from signalwire.core.skill_base import SkillBase
 from signalwire.core.function_result import FunctionResult
@@ -21,8 +21,8 @@ class DateTimeSkill(SkillBase):
     SKILL_NAME = "datetime"
     SKILL_DESCRIPTION = "Get current date, time, and timezone information"
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = ["pytz"]
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []
+    REQUIRED_PACKAGES: ClassVar[list[str]] = ["pytz"]
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []
 
     def setup(self) -> bool:
         """Setup the datetime skill"""
@@ -91,13 +91,13 @@ class DateTimeSkill(SkillBase):
         except Exception as e:
             return FunctionResult(f"Error getting date: {e!s}")
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints"""
         # Currently no hints provided, but you could add them like:
         # return ["time", "date", "today", "now", "current", "timezone"]
         return []
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         return [
             {
@@ -112,7 +112,7 @@ class DateTimeSkill(SkillBase):
         ]
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """
         Get the parameter schema for the datetime skill
 

--- a/signalwire/signalwire/skills/google_maps/skill.py
+++ b/signalwire/signalwire/skills/google_maps/skill.py
@@ -13,7 +13,7 @@ Skill layer:   GoogleMapsSkill  (plug-and-play SWAIG tools)
 """
 
 import json
-from typing import List, Dict, Any, ClassVar
+from typing import Any, ClassVar
 
 import requests
 
@@ -393,7 +393,7 @@ class GoogleMapsClient:
                 "X-Goog-Api-Key": self.api_key,
                 "X-Goog-FieldMask": "routes.distanceMeters,routes.duration",
             }
-            body: Dict[str, Any] = {
+            body: dict[str, Any] = {
                 "origin": {
                     "location": {
                         "latLng": {"latitude": origin_lat, "longitude": origin_lng}
@@ -449,11 +449,11 @@ class GoogleMapsSkill(SkillBase):
         "Validate addresses and compute driving routes using Google Maps"
     )
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = ["requests"]
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []
+    REQUIRED_PACKAGES: ClassVar[list[str]] = ["requests"]
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get parameter schema for google_maps skill"""
         schema = super().get_parameter_schema()
         schema.update(
@@ -589,11 +589,11 @@ class GoogleMapsSkill(SkillBase):
             f"Estimated travel time: {int(duration_min)} minutes"
         )
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints"""
         return ["address", "location", "route", "directions", "miles", "distance"]
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         return [
             {

--- a/signalwire/signalwire/skills/info_gatherer/skill.py
+++ b/signalwire/signalwire/skills/info_gatherer/skill.py
@@ -7,7 +7,7 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-from typing import Dict, Any, List, ClassVar
+from typing import Any, ClassVar
 
 from signalwire.core.skill_base import SkillBase
 from signalwire.core.function_result import FunctionResult
@@ -26,12 +26,12 @@ class InfoGathererSkill(SkillBase):
     SKILL_NAME = "info_gatherer"
     SKILL_DESCRIPTION = "Gather answers to a configurable list of questions"
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = []
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []
+    REQUIRED_PACKAGES: ClassVar[list[str]] = []
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []
     SUPPORTS_MULTIPLE_INSTANCES = True
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         schema = super().get_parameter_schema()
         schema.update(
             {
@@ -126,7 +126,7 @@ class InfoGathererSkill(SkillBase):
     # Global data (initial state)
     # ------------------------------------------------------------------ #
 
-    def get_global_data(self) -> Dict[str, Any]:
+    def get_global_data(self) -> dict[str, Any]:
         namespace = self._get_skill_namespace()
         return {
             namespace: {
@@ -140,7 +140,7 @@ class InfoGathererSkill(SkillBase):
     # Prompt sections
     # ------------------------------------------------------------------ #
 
-    def _get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def _get_prompt_sections(self) -> list[dict[str, Any]]:
         return [
             {
                 "title": f"Info Gatherer ({self.get_instance_key()})",

--- a/signalwire/signalwire/skills/joke/skill.py
+++ b/signalwire/signalwire/skills/joke/skill.py
@@ -7,7 +7,7 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-from typing import List, Dict, Any, ClassVar
+from typing import Any, ClassVar
 
 from signalwire.core.skill_base import SkillBase
 from signalwire.core.data_map import DataMap
@@ -21,12 +21,12 @@ class JokeSkill(SkillBase):
     SKILL_DESCRIPTION = "Tell jokes using the API Ninjas joke API"
     SKILL_VERSION = "1.0.0"
     REQUIRED_PACKAGES: ClassVar[
-        List[str]
+        list[str]
     ] = []  # DataMap doesn't require local packages
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []  # API key comes from parameters
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []  # API key comes from parameters
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get parameter schema for joke skill"""
         schema = super().get_parameter_schema()
         schema.update(
@@ -98,7 +98,7 @@ class JokeSkill(SkillBase):
         # Register the DataMap tool with the agent
         self.agent.register_swaig_function(joke_tool.to_swaig_function())
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints"""
         # Currently no hints are provided, but you could add them like:
         # return [
@@ -107,11 +107,11 @@ class JokeSkill(SkillBase):
         # ]
         return []
 
-    def get_global_data(self) -> Dict[str, Any]:
+    def get_global_data(self) -> dict[str, Any]:
         """Return global data to be available in DataMap variables"""
         return {"joke_skill_enabled": True}
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         return [
             {

--- a/signalwire/signalwire/skills/math/skill.py
+++ b/signalwire/signalwire/skills/math/skill.py
@@ -8,7 +8,8 @@ See LICENSE file in the project root for full license information.
 """
 
 import ast
-from typing import List, Dict, Any, Callable, ClassVar, Type
+from typing import Any, ClassVar
+from collections.abc import Callable
 
 from signalwire.core.skill_base import SkillBase
 from signalwire.core.function_result import FunctionResult
@@ -20,8 +21,8 @@ class MathSkill(SkillBase):
     SKILL_NAME = "math"
     SKILL_DESCRIPTION = "Perform basic mathematical calculations"
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = []
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []
+    REQUIRED_PACKAGES: ClassVar[list[str]] = []
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []
 
     def setup(self) -> bool:
         """Setup the math skill"""
@@ -43,7 +44,7 @@ class MathSkill(SkillBase):
         )
 
     # Allowed AST node types for safe math evaluation
-    _SAFE_OPERATORS: ClassVar[Dict[Type[ast.AST], Callable[..., Any]]] = {
+    _SAFE_OPERATORS: ClassVar[dict[type[ast.AST], Callable[..., Any]]] = {
         ast.Add: lambda a, b: a + b,
         ast.Sub: lambda a, b: a - b,
         ast.Mult: lambda a, b: a * b,
@@ -63,7 +64,7 @@ class MathSkill(SkillBase):
                 return node.value
             raise ValueError(f"Unsupported constant type: {type(node.value).__name__}")
         if isinstance(node, ast.BinOp):
-            op_type: Type[ast.AST] = type(node.op)
+            op_type: type[ast.AST] = type(node.op)
             if op_type not in self._SAFE_OPERATORS:
                 raise ValueError(f"Unsupported binary operator: {op_type.__name__}")
             left = self._safe_eval(node.left)
@@ -108,7 +109,7 @@ class MathSkill(SkillBase):
                 f"Error calculating '{expression}': Invalid expression"
             )
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints"""
         # Currently no hints provided, but you could add them like:
         # return [
@@ -117,7 +118,7 @@ class MathSkill(SkillBase):
         # ]
         return []
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         return [
             {
@@ -132,7 +133,7 @@ class MathSkill(SkillBase):
         ]
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """
         Get the parameter schema for the math skill
 

--- a/signalwire/signalwire/skills/mcp_gateway/skill.py
+++ b/signalwire/signalwire/skills/mcp_gateway/skill.py
@@ -8,7 +8,7 @@ See LICENSE file in the project root for full license information.
 """
 
 import requests
-from typing import List, Dict, Any, Optional, ClassVar
+from typing import Any, ClassVar
 from requests.auth import HTTPBasicAuth
 
 from signalwire.core.skill_base import SkillBase
@@ -29,11 +29,11 @@ class MCPGatewaySkill(SkillBase):
     SKILL_NAME = "mcp_gateway"
     SKILL_DESCRIPTION = "Bridge MCP servers with SWAIG functions"
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = ["requests"]
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []
+    REQUIRED_PACKAGES: ClassVar[list[str]] = ["requests"]
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get parameter schema for MCP Gateway skill"""
         schema = super().get_parameter_schema()
         schema.update(
@@ -126,7 +126,7 @@ class MCPGatewaySkill(SkillBase):
             if missing_params:
                 self.logger.error(f"Missing required parameters: {missing_params}")
                 return False
-            self.auth: Optional[HTTPBasicAuth] = HTTPBasicAuth(
+            self.auth: HTTPBasicAuth | None = HTTPBasicAuth(
                 self.params["auth_user"], self.params["auth_password"]
             )
         else:
@@ -238,7 +238,7 @@ class MCPGatewaySkill(SkillBase):
             is_hangup_hook=True,
         )
 
-    def _register_mcp_tool(self, service_name: str, tool_def: Dict[str, Any]):
+    def _register_mcp_tool(self, service_name: str, tool_def: dict[str, Any]):
         """Register a single MCP tool as a SWAIG function"""
         tool_name = tool_def.get("name")
         if not tool_name:
@@ -293,8 +293,8 @@ class MCPGatewaySkill(SkillBase):
         self,
         service_name: str,
         tool_name: str,
-        args: Dict[str, Any],
-        raw_data: Dict[str, Any],
+        args: dict[str, Any],
+        raw_data: dict[str, Any],
     ) -> FunctionResult:
         """Call an MCP tool through the gateway"""
         # Check for mcp_call_id in global_data first, then fall back to top-level call_id
@@ -376,7 +376,7 @@ class MCPGatewaySkill(SkillBase):
         return FunctionResult(error_msg)
 
     def _hangup_handler(
-        self, args: Dict[str, Any], raw_data: Dict[str, Any]
+        self, args: dict[str, Any], raw_data: dict[str, Any]
     ) -> FunctionResult:
         """Handle call hangup - cleanup MCP session"""
         # Check for mcp_call_id in global_data first, then fall back to top-level call_id
@@ -407,7 +407,7 @@ class MCPGatewaySkill(SkillBase):
 
         return FunctionResult("Session cleanup complete")
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints"""
         hints = ["MCP", "gateway"]
 
@@ -420,7 +420,7 @@ class MCPGatewaySkill(SkillBase):
 
         return hints
 
-    def get_global_data(self) -> Dict[str, Any]:
+    def get_global_data(self) -> dict[str, Any]:
         """Return global data for DataMap variables"""
         return {
             "mcp_gateway_url": self.gateway_url,
@@ -430,7 +430,7 @@ class MCPGatewaySkill(SkillBase):
             ],
         }
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         sections = []
 

--- a/signalwire/signalwire/skills/native_vector_search/skill.py
+++ b/signalwire/signalwire/skills/native_vector_search/skill.py
@@ -10,7 +10,7 @@ See LICENSE file in the project root for full license information.
 import contextlib
 import os
 import shutil
-from typing import Dict, Any, List, Optional, ClassVar
+from typing import Any, ClassVar
 from pathlib import Path
 
 from signalwire.core.skill_base import SkillBase
@@ -23,16 +23,16 @@ class NativeVectorSearchSkill(SkillBase):
     SKILL_NAME = "native_vector_search"
     SKILL_DESCRIPTION = "Search document indexes using vector similarity and keyword search (local or remote)"
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = []  # Optional packages checked at runtime
+    REQUIRED_PACKAGES: ClassVar[list[str]] = []  # Optional packages checked at runtime
     REQUIRED_ENV_VARS: ClassVar[
-        List[str]
+        list[str]
     ] = []  # No required env vars since all config comes from params
 
     # Enable multiple instances support
     SUPPORTS_MULTIPLE_INSTANCES = True
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get parameter schema for Native Vector Search skill
 
         This skill supports three modes of operation:
@@ -625,13 +625,13 @@ class NativeVectorSearchSkill(SkillBase):
                 assert self.search_engine is not None  # noqa: S101  # type-narrowing invariant: the guard above returns early when search_engine is falsy
 
                 # Get model name from index config if available
-                model_for_query: Optional[str] = None
+                model_for_query: str | None = None
                 if hasattr(self.search_engine, "config"):
                     model_for_query = self.search_engine.config.get("embedding_model")
 
                 # preprocess_query's model_name defaults to None when unspecified,
                 # so omit the kwarg entirely when we don't have a model name.
-                extra_kwargs: Dict[str, Any] = {}
+                extra_kwargs: dict[str, Any] = {}
                 if model_for_query is not None:
                     extra_kwargs["model_name"] = model_for_query  # Use model from index
 
@@ -814,7 +814,7 @@ class NativeVectorSearchSkill(SkillBase):
 
             return FunctionResult(user_msg)
 
-    def _search_remote(self, query: str, enhanced: Optional[dict], count: int) -> list:
+    def _search_remote(self, query: str, enhanced: dict | None, count: int) -> list:
         """Perform search using remote search server"""
         try:
             import requests
@@ -859,7 +859,7 @@ class NativeVectorSearchSkill(SkillBase):
             self.logger.error(f"Remote search error: {e}")
             return []
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints for this skill"""
         hints = ["search", "find", "look up", "documentation", "knowledge base"]
 
@@ -869,7 +869,7 @@ class NativeVectorSearchSkill(SkillBase):
 
         return hints
 
-    def get_global_data(self) -> Dict[str, Any]:
+    def get_global_data(self) -> dict[str, Any]:
         """Return data to add to agent's global context"""
         global_data = {}
 
@@ -882,7 +882,7 @@ class NativeVectorSearchSkill(SkillBase):
 
         return global_data
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         # We'll handle this in register_tools after the agent is set
         return []

--- a/signalwire/signalwire/skills/play_background_file/skill.py
+++ b/signalwire/signalwire/skills/play_background_file/skill.py
@@ -12,7 +12,7 @@ A configurable skill for managing background file playback with custom tool name
 and multiple file collections. Supports both audio and video files.
 """
 
-from typing import Dict, Any, List, Optional
+from typing import Any
 from signalwire.core import FunctionResult
 from signalwire.core.skill_base import SkillBase
 
@@ -47,7 +47,7 @@ class PlayBackgroundFileSkill(SkillBase):
     SUPPORTS_MULTIPLE_INSTANCES = True
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get parameter schema for Play Background File skill"""
         schema = super().get_parameter_schema()
         schema.update(
@@ -84,7 +84,7 @@ class PlayBackgroundFileSkill(SkillBase):
         )
         return schema
 
-    def __init__(self, agent, params: Optional[Dict[str, Any]] = None):
+    def __init__(self, agent, params: dict[str, Any] | None = None):
         """
         Initialize the skill with configuration parameters.
 
@@ -159,7 +159,7 @@ class PlayBackgroundFileSkill(SkillBase):
                 tool.update(self.swaig_fields)
             self.agent.register_swaig_function(tool)
 
-    def get_tools(self) -> List[Dict[str, Any]]:
+    def get_tools(self) -> list[dict[str, Any]]:
         """
         Generate the SWAIG tool with DataMap expressions.
 
@@ -202,7 +202,7 @@ class PlayBackgroundFileSkill(SkillBase):
 
         return [tool]
 
-    def _build_expressions(self) -> List[Dict[str, Any]]:
+    def _build_expressions(self) -> list[dict[str, Any]]:
         """
         Build DataMap expressions for file playback and stop actions.
 

--- a/signalwire/signalwire/skills/registry.py
+++ b/signalwire/signalwire/skills/registry.py
@@ -13,7 +13,7 @@ import importlib.util
 import inspect
 import sys
 import threading
-from typing import Dict, List, Type, Optional, Any
+from typing import Any
 from pathlib import Path
 
 from signalwire.core.skill_base import SkillBase
@@ -24,13 +24,13 @@ class SkillRegistry:
     """Global registry for on-demand skill loading"""
 
     def __init__(self):
-        self._skills: Dict[str, Type[SkillBase]] = {}
-        self._external_paths: List[Path] = []  # Additional paths to search for skills
+        self._skills: dict[str, type[SkillBase]] = {}
+        self._external_paths: list[Path] = []  # Additional paths to search for skills
         self._entry_points_loaded = False
         self._lock = threading.RLock()
         self.logger = get_logger("skill_registry")
 
-    def _load_skill_on_demand(self, skill_name: str) -> Optional[Type[SkillBase]]:
+    def _load_skill_on_demand(self, skill_name: str) -> type[SkillBase] | None:
         """Load a skill on-demand by name"""
         with self._lock:
             if skill_name in self._skills:
@@ -68,7 +68,7 @@ class SkillRegistry:
 
     def _load_skill_from_path(
         self, skill_name: str, base_path: Path
-    ) -> Optional[Type[SkillBase]]:
+    ) -> type[SkillBase] | None:
         """Try to load a skill from a specific base path"""
         # Prevent path traversal in skill names
         if ".." in skill_name or os.sep in skill_name or "/" in skill_name:
@@ -133,7 +133,7 @@ class SkillRegistry:
             )
             return None
 
-    def discover_skills(self) -> List[Dict[str, str]]:
+    def discover_skills(self) -> list[dict[str, str]]:
         """Discover and return all available skills.
 
         Skills load on-demand, so there is nothing to eagerly register; this
@@ -146,7 +146,7 @@ class SkillRegistry:
         # Keep this method for backwards compatibility but make it a no-op
         pass
 
-    def register_skill(self, skill_class: Type[SkillBase]) -> None:
+    def register_skill(self, skill_class: type[SkillBase]) -> None:
         """
         Register a skill class directly
 
@@ -236,7 +236,7 @@ class SkillRegistry:
                 "skill_registered", extra={"skill": skill_class.SKILL_NAME}
             )
 
-    def get_skill_class(self, skill_name: str) -> Optional[Type[SkillBase]]:
+    def get_skill_class(self, skill_name: str) -> type[SkillBase] | None:
         """Get skill class by name, loading on-demand if needed"""
         # First check if already loaded
         if skill_name in self._skills:
@@ -245,7 +245,7 @@ class SkillRegistry:
         # Try to load on-demand
         return self._load_skill_on_demand(skill_name)
 
-    def list_skills(self) -> List[Dict[str, Any]]:
+    def list_skills(self) -> list[dict[str, Any]]:
         """List all available skills by scanning directories (only when explicitly requested)"""
         # Only scan when this method is explicitly called (e.g., for CLI tools)
         skills_dir = Path(__file__).parent
@@ -271,7 +271,7 @@ class SkillRegistry:
 
         return available_skills
 
-    def get_all_skills_schema(self) -> Dict[str, Dict[str, Any]]:
+    def get_all_skills_schema(self) -> dict[str, dict[str, Any]]:
         """
         Get complete schema for all available skills including parameter metadata
 
@@ -497,7 +497,7 @@ class SkillRegistry:
         except Exception as e:
             self.logger.debug(f"Entry point loading failed: {e}")
 
-    def list_all_skill_sources(self) -> Dict[str, List[str]]:
+    def list_all_skill_sources(self) -> dict[str, list[str]]:
         """
         List all skill sources and the skills available from each
 
@@ -509,7 +509,7 @@ class SkillRegistry:
             'registered': ['my_skill', ...]
         }
         """
-        sources: Dict[str, List[str]] = {
+        sources: dict[str, list[str]] = {
             "built-in": [],
             "external_paths": [],
             "entry_points": [],

--- a/signalwire/signalwire/skills/spider/skill.py
+++ b/signalwire/signalwire/skills/spider/skill.py
@@ -11,7 +11,7 @@ Spider skill for fast web scraping with SignalWire AI Agents.
 
 import re
 import collections
-from typing import Dict, Any, Optional, List, ClassVar
+from typing import Any, ClassVar
 from urllib.parse import urljoin, urlparse
 import requests
 from lxml import html
@@ -27,17 +27,17 @@ class SpiderSkill(SkillBase):
     SKILL_NAME = "spider"
     SKILL_DESCRIPTION = "Fast web scraping and crawling capabilities"
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = [
+    REQUIRED_PACKAGES: ClassVar[list[str]] = [
         "lxml"
     ]  # beautifulsoup4 and requests are in base dependencies
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []  # No required env vars by default
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []  # No required env vars by default
     SUPPORTS_MULTIPLE_INSTANCES = True
 
     # Compiled regex for performance
     WHITESPACE_REGEX = re.compile(r"\s+")
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get parameter schema for Spider skill"""
         schema = super().get_parameter_schema()
         schema.update(
@@ -145,7 +145,7 @@ class SpiderSkill(SkillBase):
         )
         return schema
 
-    def __init__(self, agent, params: Dict[str, Any]):
+    def __init__(self, agent, params: dict[str, Any]):
         """Initialize the spider skill with configuration parameters."""
         super().__init__(agent, params)
 
@@ -179,7 +179,7 @@ class SpiderSkill(SkillBase):
         self.session.headers.update(self.headers)
 
         # Cache for responses (bounded OrderedDict for LRU-style eviction)
-        self._cache: Optional["collections.OrderedDict[str, Any]"] = (
+        self._cache: collections.OrderedDict[str, Any] | None = (
             collections.OrderedDict() if self.cache_enabled else None
         )
         self._cache_max_size = 100
@@ -274,7 +274,7 @@ class SpiderSkill(SkillBase):
             handler=self._extract_structured_handler,
         )
 
-    def _fetch_url(self, url: str) -> Optional[requests.Response]:
+    def _fetch_url(self, url: str) -> requests.Response | None:
         """Fetch a URL with caching and error handling."""
         # Check cache first
         if self.cache_enabled and self._cache is not None and url in self._cache:
@@ -386,12 +386,12 @@ class SpiderSkill(SkillBase):
             return self._fast_text_extract(response)
 
     def _structured_extract(
-        self, response: requests.Response, selectors: Optional[Dict[str, str]] = None
-    ) -> Dict[str, Any]:
+        self, response: requests.Response, selectors: dict[str, str] | None = None
+    ) -> dict[str, Any]:
         """Extract structured data using selectors."""
         try:
             tree = html.fromstring(response.content)
-            result: Dict[str, Any] = {
+            result: dict[str, Any] = {
                 "url": response.url,
                 "status_code": response.status_code,
                 "title": "",
@@ -434,7 +434,7 @@ class SpiderSkill(SkillBase):
             return {"error": str(e)}
 
     def _scrape_url_handler(
-        self, args: Dict[str, Any], raw_data: Dict[str, Any]
+        self, args: dict[str, Any], raw_data: dict[str, Any]
     ) -> FunctionResult:
         """Handle single page scraping."""
         url = args.get("url", "").strip()
@@ -487,7 +487,7 @@ class SpiderSkill(SkillBase):
             return FunctionResult(f"Error processing {url}: {e!s}")
 
     def _crawl_site_handler(
-        self, args: Dict[str, Any], raw_data: Dict[str, Any]
+        self, args: dict[str, Any], raw_data: dict[str, Any]
     ) -> FunctionResult:
         """Handle multi-page crawling."""
         start_url = args.get("start_url", "").strip()
@@ -602,7 +602,7 @@ class SpiderSkill(SkillBase):
         return FunctionResult(summary)
 
     def _extract_structured_handler(
-        self, args: Dict[str, Any], raw_data: Dict[str, Any]
+        self, args: dict[str, Any], raw_data: dict[str, Any]
     ) -> FunctionResult:
         """Handle structured data extraction."""
         url = args.get("url", "").strip()
@@ -649,7 +649,7 @@ class SpiderSkill(SkillBase):
 
         return FunctionResult(output)
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints for this skill."""
         return [
             "scrape",

--- a/signalwire/signalwire/skills/swml_transfer/skill.py
+++ b/signalwire/signalwire/skills/swml_transfer/skill.py
@@ -7,7 +7,7 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-from typing import List, Dict, Any, ClassVar
+from typing import Any, ClassVar
 
 from signalwire.core.skill_base import SkillBase
 from signalwire.core.data_map import DataMap
@@ -20,14 +20,14 @@ class SWMLTransferSkill(SkillBase):
     SKILL_NAME = "swml_transfer"
     SKILL_DESCRIPTION = "Transfer calls between agents based on pattern matching"
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = []
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []
+    REQUIRED_PACKAGES: ClassVar[list[str]] = []
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []
 
     # Enable multiple instances support
     SUPPORTS_MULTIPLE_INSTANCES = True
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get parameter schema for SWML Transfer skill"""
         schema = super().get_parameter_schema()
         schema.update(
@@ -270,9 +270,9 @@ class SWMLTransferSkill(SkillBase):
             # Fallback to define_tool if register_swaig_function is not available
             self.logger.error("Agent does not have register_swaig_function method")
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints"""
-        hints: List[str] = []
+        hints: list[str] = []
 
         # Extract common words from patterns for hints
         for pattern in self.transfers:
@@ -302,7 +302,7 @@ class SWMLTransferSkill(SkillBase):
 
         return hints
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         sections = []
 

--- a/signalwire/signalwire/skills/weather_api/skill.py
+++ b/signalwire/signalwire/skills/weather_api/skill.py
@@ -12,7 +12,7 @@ A configurable skill for getting weather information from WeatherAPI.com with cu
 temperature units and TTS-friendly responses.
 """
 
-from typing import Dict, Any, List, ClassVar, Optional
+from typing import Any, ClassVar
 from signalwire.core import FunctionResult
 from signalwire.core.skill_base import SkillBase
 
@@ -40,10 +40,10 @@ class WeatherApiSkill(SkillBase):
     SKILL_NAME = "weather_api"
     SKILL_DESCRIPTION = "Get current weather information from WeatherAPI.com"
     SUPPORTS_MULTIPLE_INSTANCES = False
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []  # API key can be passed via params
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []  # API key can be passed via params
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get parameter schema for weather API skill"""
         schema = super().get_parameter_schema()
         schema.update(
@@ -72,7 +72,7 @@ class WeatherApiSkill(SkillBase):
         )
         return schema
 
-    def __init__(self, agent, params: Optional[Dict[str, Any]] = None):
+    def __init__(self, agent, params: dict[str, Any] | None = None):
         """
         Initialize the skill with configuration parameters.
 
@@ -126,7 +126,7 @@ class WeatherApiSkill(SkillBase):
                 tool.update(self.swaig_fields)
             self.agent.register_swaig_function(tool)
 
-    def get_tools(self) -> List[Dict[str, Any]]:
+    def get_tools(self) -> list[dict[str, Any]]:
         """
         Generate the SWAIG tool with DataMap webhook.
 

--- a/signalwire/signalwire/skills/web_search/skill.py
+++ b/signalwire/signalwire/skills/web_search/skill.py
@@ -12,7 +12,7 @@ import time
 import re
 from urllib.parse import urlparse
 from bs4 import BeautifulSoup
-from typing import List, Dict, Any, Tuple, Optional, ClassVar
+from typing import Any, ClassVar
 
 from signalwire.core.skill_base import SkillBase
 from signalwire.core.function_result import FunctionResult
@@ -38,7 +38,7 @@ class GoogleSearchScraper:
         """Search Google using Custom Search JSON API"""
         url = "https://www.googleapis.com/customsearch/v1"
 
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "key": self.api_key,
             "cx": self.search_engine_id,
             "q": query,
@@ -71,8 +71,8 @@ class GoogleSearchScraper:
         return "reddit.com" in domain or "redd.it" in domain
 
     def extract_reddit_content(
-        self, url: str, content_limit: Optional[int] = None, timeout: float = 10
-    ) -> Tuple[str, Dict[str, Any]]:
+        self, url: str, content_limit: int | None = None, timeout: float = 10
+    ) -> tuple[str, dict[str, Any]]:
         """
         Extract Reddit content using JSON API for better quality
 
@@ -212,8 +212,8 @@ class GoogleSearchScraper:
             return self.extract_html_content(url, content_limit, timeout)
 
     def extract_text_from_url(
-        self, url: str, content_limit: Optional[int] = None, timeout: float = 10
-    ) -> Tuple[str, Dict[str, Any]]:
+        self, url: str, content_limit: int | None = None, timeout: float = 10
+    ) -> tuple[str, dict[str, Any]]:
         """
         Main extraction method that routes to appropriate extractor
 
@@ -225,8 +225,8 @@ class GoogleSearchScraper:
         return self.extract_html_content(url, content_limit, timeout)
 
     def extract_html_content(
-        self, url: str, content_limit: Optional[int] = None, timeout: float = 10
-    ) -> Tuple[str, Dict[str, Any]]:
+        self, url: str, content_limit: int | None = None, timeout: float = 10
+    ) -> tuple[str, dict[str, Any]]:
         """
         Original HTML extraction method (renamed from extract_text_from_url)
         """
@@ -345,7 +345,7 @@ class GoogleSearchScraper:
 
     def _calculate_content_quality(
         self, text: str, url: str, query: str = ""
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Calculate quality metrics for extracted content
 
@@ -359,7 +359,7 @@ class GoogleSearchScraper:
         if not text:
             return {"quality_score": 0, "text_length": 0}
 
-        metrics: Dict[str, Any] = {}
+        metrics: dict[str, Any] = {}
 
         # Text length (MUCH stricter - prefer 2000-10000 chars of actual content)
         text_length = len(text)
@@ -693,7 +693,7 @@ class GoogleSearchScraper:
         processed_results.sort(key=lambda x: x["quality_score"], reverse=True)
 
         # Select diverse results (prefer different domains)
-        best_results: List[Dict[str, Any]] = []
+        best_results: list[dict[str, Any]] = []
         seen_domains = set()
 
         # First pass: Add highest quality result from each unique domain
@@ -776,8 +776,8 @@ class WebSearchSkill(SkillBase):
     SKILL_NAME = "web_search"
     SKILL_DESCRIPTION = "Search the web for information using Google Custom Search API"
     SKILL_VERSION = "2.0.0"  # Bumped version for improved functionality
-    REQUIRED_PACKAGES: ClassVar[List[str]] = ["bs4", "requests"]
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []
+    REQUIRED_PACKAGES: ClassVar[list[str]] = ["bs4", "requests"]
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []
 
     # Enable multiple instances support
     SUPPORTS_MULTIPLE_INSTANCES = True
@@ -927,11 +927,11 @@ class WebSearchSkill(SkillBase):
                 "Sorry, I encountered an error while searching. Please try again later."
             )
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints"""
         return []
 
-    def get_global_data(self) -> Dict[str, Any]:
+    def get_global_data(self) -> dict[str, Any]:
         """Return global data for agent context"""
         return {
             "web_search_enabled": True,
@@ -939,7 +939,7 @@ class WebSearchSkill(SkillBase):
             "quality_filtering": True,
         }
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         return [
             {
@@ -955,7 +955,7 @@ class WebSearchSkill(SkillBase):
         ]
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get the parameter schema for the web search skill"""
         schema = super().get_parameter_schema()
 

--- a/signalwire/signalwire/skills/web_search/skill_improved.py
+++ b/signalwire/signalwire/skills/web_search/skill_improved.py
@@ -12,7 +12,7 @@ import time
 import re
 from urllib.parse import urlparse
 from bs4 import BeautifulSoup
-from typing import List, Dict, Any, Tuple, Optional, ClassVar
+from typing import Any, ClassVar
 
 from signalwire.core.skill_base import SkillBase
 from signalwire.core.function_result import FunctionResult
@@ -38,7 +38,7 @@ class GoogleSearchScraper:
         """Search Google using Custom Search JSON API"""
         url = "https://www.googleapis.com/customsearch/v1"
 
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "key": self.api_key,
             "cx": self.search_engine_id,
             "q": query,
@@ -66,8 +66,8 @@ class GoogleSearchScraper:
             return []
 
     def extract_text_from_url(
-        self, url: str, content_limit: Optional[int] = None, timeout: int = 10
-    ) -> Tuple[str, Dict[str, Any]]:
+        self, url: str, content_limit: int | None = None, timeout: int = 10
+    ) -> tuple[str, dict[str, Any]]:
         """
         Scrape a URL and extract readable text content with quality metrics
 
@@ -179,7 +179,7 @@ class GoogleSearchScraper:
         except Exception as e:
             return "", {"error": str(e), "quality_score": 0}
 
-    def _calculate_content_quality(self, text: str, url: str) -> Dict[str, Any]:
+    def _calculate_content_quality(self, text: str, url: str) -> dict[str, Any]:
         """
         Calculate quality metrics for extracted content
 
@@ -193,7 +193,7 @@ class GoogleSearchScraper:
         if not text:
             return {"quality_score": 0, "text_length": 0}
 
-        metrics: Dict[str, Any] = {}
+        metrics: dict[str, Any] = {}
 
         # Text length (prefer 500-5000 chars of actual content)
         text_length = len(text)
@@ -426,8 +426,8 @@ class WebSearchSkill(SkillBase):
     SKILL_NAME = "web_search"
     SKILL_DESCRIPTION = "Search the web for information using Google Custom Search API"
     SKILL_VERSION = "2.0.0"  # Bumped version for improved functionality
-    REQUIRED_PACKAGES: ClassVar[List[str]] = ["bs4", "requests"]
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []
+    REQUIRED_PACKAGES: ClassVar[list[str]] = ["bs4", "requests"]
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []
 
     # Enable multiple instances support
     SUPPORTS_MULTIPLE_INSTANCES = True
@@ -545,11 +545,11 @@ class WebSearchSkill(SkillBase):
                 "Sorry, I encountered an error while searching. Please try again later."
             )
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints"""
         return []
 
-    def get_global_data(self) -> Dict[str, Any]:
+    def get_global_data(self) -> dict[str, Any]:
         """Return global data for agent context"""
         return {
             "web_search_enabled": True,
@@ -557,7 +557,7 @@ class WebSearchSkill(SkillBase):
             "quality_filtering": True,
         }
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         return [
             {
@@ -573,7 +573,7 @@ class WebSearchSkill(SkillBase):
         ]
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get the parameter schema for the web search skill"""
         schema = super().get_parameter_schema()
 

--- a/signalwire/signalwire/skills/web_search/skill_original.py
+++ b/signalwire/signalwire/skills/web_search/skill_original.py
@@ -10,7 +10,7 @@ See LICENSE file in the project root for full license information.
 import requests
 import time
 from bs4 import BeautifulSoup
-from typing import List, Dict, Any, Optional, ClassVar
+from typing import Any, ClassVar
 
 from signalwire.core.skill_base import SkillBase
 from signalwire.core.function_result import FunctionResult
@@ -36,7 +36,7 @@ class GoogleSearchScraper:
         """Search Google using Custom Search JSON API"""
         url = "https://www.googleapis.com/customsearch/v1"
 
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "key": self.api_key,
             "cx": self.search_engine_id,
             "q": query,
@@ -64,7 +64,7 @@ class GoogleSearchScraper:
             return []
 
     def extract_text_from_url(
-        self, url: str, content_limit: Optional[int] = None, timeout: int = 10
+        self, url: str, content_limit: int | None = None, timeout: int = 10
     ) -> str:
         """Scrape a URL and extract readable text content
 
@@ -158,9 +158,9 @@ class WebSearchSkill(SkillBase):
     SKILL_NAME = "web_search"
     SKILL_DESCRIPTION = "Search the web for information using Google Custom Search API"
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = ["bs4", "requests"]
+    REQUIRED_PACKAGES: ClassVar[list[str]] = ["bs4", "requests"]
     REQUIRED_ENV_VARS: ClassVar[
-        List[str]
+        list[str]
     ] = []  # No required env vars since all config comes from params
 
     # Enable multiple instances support
@@ -269,7 +269,7 @@ class WebSearchSkill(SkillBase):
                 "Sorry, I encountered an error while searching. Please try again later."
             )
 
-    def get_hints(self) -> List[str]:
+    def get_hints(self) -> list[str]:
         """Return speech recognition hints"""
         # Currently no hints provided, but you could add them like:
         # return [
@@ -278,11 +278,11 @@ class WebSearchSkill(SkillBase):
         # ]
         return []
 
-    def get_global_data(self) -> Dict[str, Any]:
+    def get_global_data(self) -> dict[str, Any]:
         """Return global data for agent context"""
         return {"web_search_enabled": True, "search_provider": "Google Custom Search"}
 
-    def get_prompt_sections(self) -> List[Dict[str, Any]]:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """Return prompt sections to add to agent"""
         return [
             {
@@ -298,7 +298,7 @@ class WebSearchSkill(SkillBase):
         ]
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """
         Get the parameter schema for the web search skill
 

--- a/signalwire/signalwire/skills/wikipedia_search/skill.py
+++ b/signalwire/signalwire/skills/wikipedia_search/skill.py
@@ -13,7 +13,7 @@ Provides Wikipedia search capabilities using the Wikipedia API.
 
 import requests
 from urllib.parse import quote
-from typing import Dict, Any, List, ClassVar
+from typing import Any, ClassVar
 from signalwire.core.skill_base import SkillBase
 
 
@@ -31,14 +31,14 @@ class WikipediaSearchSkill(SkillBase):
         "Search Wikipedia for information about a topic and get article summaries"
     )
     SKILL_VERSION = "1.0.0"
-    REQUIRED_PACKAGES: ClassVar[List[str]] = ["requests"]
-    REQUIRED_ENV_VARS: ClassVar[List[str]] = []  # No environment variables required
+    REQUIRED_PACKAGES: ClassVar[list[str]] = ["requests"]
+    REQUIRED_ENV_VARS: ClassVar[list[str]] = []  # No environment variables required
 
     # Does not support multiple instances
     SUPPORTS_MULTIPLE_INSTANCES = False
 
     @classmethod
-    def get_parameter_schema(cls) -> Dict[str, Dict[str, Any]]:
+    def get_parameter_schema(cls) -> dict[str, dict[str, Any]]:
         """Get parameter schema for Wikipedia search skill"""
         schema = super().get_parameter_schema()
         schema.update(

--- a/signalwire/signalwire/utils/schema_utils.py
+++ b/signalwire/signalwire/utils/schema_utils.py
@@ -15,7 +15,7 @@ Uses jsonschema-rs for full JSON Schema validation with type checking.
 import os
 import json
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Any
 
 import jsonschema_rs
 
@@ -25,7 +25,7 @@ from signalwire.core.logging_config import get_logger
 class SchemaValidationError(Exception):
     """Raised when SWML schema validation fails."""
 
-    def __init__(self, verb_name: str, errors: List[str]):
+    def __init__(self, verb_name: str, errors: list[str]):
         self.verb_name = verb_name
         self.errors = errors
         message = f"Schema validation failed for '{verb_name}': {'; '.join(errors)}"
@@ -41,9 +41,7 @@ class SchemaUtils:
     Utility class for loading and working with SWML schemas
     """
 
-    def __init__(
-        self, schema_path: Optional[str] = None, schema_validation: bool = True
-    ):
+    def __init__(self, schema_path: str | None = None, schema_validation: bool = True):
         """
         Initialize the schema utilities.
 
@@ -80,7 +78,7 @@ class SchemaUtils:
             self.log.debug("first_verbs_extracted", verbs=list(self.verbs.keys())[:5])
 
         # Initialize full schema validator if validation is enabled
-        self._full_validator: Optional["jsonschema_rs.Draft202012Validator"] = None
+        self._full_validator: jsonschema_rs.Draft202012Validator | None = None
         if self._validation_enabled and self.schema:
             self._init_full_validator()
         elif not self._validation_enabled:
@@ -100,7 +98,7 @@ class SchemaUtils:
         """Check if full JSON Schema validation is available."""
         return self._full_validator is not None
 
-    def _get_default_schema_path(self) -> Optional[str]:
+    def _get_default_schema_path(self) -> str | None:
         """
         Get the default path to the schema file using the same robust logic as SWMLService
 
@@ -175,7 +173,7 @@ class SchemaUtils:
         self.log.warning("schema_not_found_in_any_location")
         return None
 
-    def load_schema(self) -> Dict[str, Any]:
+    def load_schema(self) -> dict[str, Any]:
         """
         Load the JSON schema from the specified path
 
@@ -215,7 +213,7 @@ class SchemaUtils:
             self.log.error("schema_loading_error", error=str(e), path=self.schema_path)
             return {}
 
-    def _extract_verb_definitions(self) -> Dict[str, Dict[str, Any]]:
+    def _extract_verb_definitions(self) -> dict[str, dict[str, Any]]:
         """
         Extract verb definitions from the schema
 
@@ -265,7 +263,7 @@ class SchemaUtils:
 
         return verbs
 
-    def get_verb_properties(self, verb_name: str) -> Dict[str, Any]:
+    def get_verb_properties(self, verb_name: str) -> dict[str, Any]:
         """
         Get the properties for a specific verb
 
@@ -281,7 +279,7 @@ class SchemaUtils:
                 return verb_def["properties"][verb_name]
         return {}
 
-    def get_verb_required_properties(self, verb_name: str) -> List[str]:
+    def get_verb_required_properties(self, verb_name: str) -> list[str]:
         """
         Get the required properties for a specific verb
 
@@ -299,8 +297,8 @@ class SchemaUtils:
         return []
 
     def validate_verb(
-        self, verb_name: str, verb_config: Dict[str, Any]
-    ) -> Tuple[bool, List[str]]:
+        self, verb_name: str, verb_config: dict[str, Any]
+    ) -> tuple[bool, list[str]]:
         """
         Validate a verb configuration against the schema.
 
@@ -334,8 +332,8 @@ class SchemaUtils:
         return self._validate_verb_lightweight(verb_name, verb_config)
 
     def _validate_verb_full(
-        self, verb_name: str, verb_config: Dict[str, Any]
-    ) -> Tuple[bool, List[str]]:
+        self, verb_name: str, verb_config: dict[str, Any]
+    ) -> tuple[bool, list[str]]:
         """
         Perform full JSON Schema validation using jsonschema-rs.
 
@@ -375,8 +373,8 @@ class SchemaUtils:
             return False, [f"Schema validation error for '{verb_name}': {error_msg}"]
 
     def _validate_verb_lightweight(
-        self, verb_name: str, verb_config: Dict[str, Any]
-    ) -> Tuple[bool, List[str]]:
+        self, verb_name: str, verb_config: dict[str, Any]
+    ) -> tuple[bool, list[str]]:
         """
         Perform lightweight validation (verb existence + required fields only).
 
@@ -403,7 +401,7 @@ class SchemaUtils:
 
         return len(errors) == 0, errors
 
-    def validate_document(self, document: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    def validate_document(self, document: dict[str, Any]) -> tuple[bool, list[str]]:
         """
         Validate a complete SWML document against the schema.
 
@@ -425,7 +423,7 @@ class SchemaUtils:
                 error_msg = error_msg[:500] + "..."
             return False, [f"Document validation error: {error_msg}"]
 
-    def get_all_verb_names(self) -> List[str]:
+    def get_all_verb_names(self) -> list[str]:
         """
         Get all verb names defined in the schema
 
@@ -434,7 +432,7 @@ class SchemaUtils:
         """
         return list(self.verbs.keys())
 
-    def get_verb_parameters(self, verb_name: str) -> Dict[str, Any]:
+    def get_verb_parameters(self, verb_name: str) -> dict[str, Any]:
         """
         Get the parameter definitions for a specific verb
 
@@ -538,7 +536,7 @@ class SchemaUtils:
 
         return "\n".join(body)
 
-    def _get_type_annotation(self, param_def: Dict[str, Any]) -> str:
+    def _get_type_annotation(self, param_def: dict[str, Any]) -> str:
         """
         Get the Python type annotation for a parameter
 

--- a/signalwire/signalwire/web/web_service.py
+++ b/signalwire/signalwire/web/web_service.py
@@ -10,7 +10,7 @@ See LICENSE file in the project root for full license information.
 import os
 import mimetypes
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from fastapi import FastAPI, HTTPException, Request, Response, Depends
@@ -45,12 +45,12 @@ class WebService:
     def __init__(
         self,
         port: int = 8002,
-        directories: Optional[Dict[str, str]] = None,
-        basic_auth: Optional[Tuple[str, str]] = None,
-        config_file: Optional[str] = None,
+        directories: dict[str, str] | None = None,
+        basic_auth: tuple[str, str] | None = None,
+        config_file: str | None = None,
         enable_directory_browsing: bool = False,
-        allowed_extensions: Optional[list] = None,
-        blocked_extensions: Optional[list] = None,
+        allowed_extensions: list | None = None,
+        blocked_extensions: list | None = None,
         max_file_size: int = 100 * 1024 * 1024,  # 100MB default
         enable_cors: bool = True,
     ):
@@ -109,7 +109,7 @@ class WebService:
         # Set up authentication
         self._basic_auth = basic_auth or self.security.get_basic_auth()
 
-        self.app: Optional["FastAPI"] = None
+        self.app: FastAPI | None = None
         if FastAPI is not None:
             self.app = FastAPI(
                 title="SignalWire Web Service",
@@ -122,7 +122,7 @@ class WebService:
             self.app = None
             logger.warning("FastAPI not available. HTTP service will not be available.")
 
-    def _load_config(self, config_file: Optional[str]):
+    def _load_config(self, config_file: str | None):
         """Load configuration from file if available"""
         # Initialize defaults
         self.directories = {}
@@ -205,7 +205,7 @@ class WebService:
 
     def _get_current_username(
         self, credentials: Optional["HTTPBasicCredentials"] = None
-    ) -> Optional[str]:
+    ) -> str | None:
         """Validate basic auth credentials"""
         if not credentials:
             return None
@@ -534,9 +534,9 @@ class WebService:
     def start(
         self,
         host: str = "0.0.0.0",  # noqa: S104  # intended server default: listen on all interfaces (overridable)
-        port: Optional[int] = None,
-        ssl_cert: Optional[str] = None,
-        ssl_key: Optional[str] = None,
+        port: int | None = None,
+        ssl_cert: str | None = None,
+        ssl_key: str | None = None,
     ):
         """
         Start the service with optional HTTPS support
@@ -553,7 +553,7 @@ class WebService:
         port = port or self.port
 
         # Get SSL configuration
-        ssl_kwargs: Dict[str, Any] = {}
+        ssl_kwargs: dict[str, Any] = {}
         if ssl_cert and ssl_key:
             # Use provided SSL files
             ssl_kwargs = {"ssl_certfile": ssl_cert, "ssl_keyfile": ssl_key}


### PR DESCRIPTION
The final ruff family: **UP (pyupgrade)** — modernize to py3.10+ idioms and add UP to the LINT gate. Completes the Python lint hardening (E/F + B/S/C4/PERF/SIM/PTH/RET/RUF already gated).

## Changes (~1974 findings → 0, 92 files)
- PEP 585: `Dict→dict`, `List→list`, `Tuple→tuple` (UP006). PEP 604: `Optional[X]→X | None` (UP045), `Union→|` (UP007).
- Unquoted forward-refs, f-strings, deprecated `typing` imports removed (UP035 + F401 cleanup). Adds `UP` to the ruff select set.

## Manual touch-ups
- `agent_base`: hoisted `PromptObjectModel` to a module-level import (no cycle — `pom.py` imports nothing agent-related) so the UP-unquoted annotation resolves.
- 1 printf→f-string in `document_processor` — regex verified byte-identical (`(\n{3,})`).

## Verification
ruff "All checks passed!" (13 families), format clean, **mypy still 0** (176 files), pytest 5246 passed / 3 skipped. No runtime/wire-type behavior change.

## Coupling
~42 public-signature annotations refine the canonical oracle (mostly *fixing* previously-unresolved `class:Dict`/`class:Call` types). Depends on porting-sdk `chore/python-pyupgrade-oracle` (#41) — merge first; DRIFT then passes. Verified: **0 port re-drift** — all 9 ports already match the refined oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau