### PR TITLE
ci(rest): add SPEC-PARITY gate + gap-baseline to REST-COVERAGE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,3 +213,14 @@ warn_unused_ignores = true
 # `# type: ignore` is reserved for genuinely-unfixable third-party-stub gaps and
 # must carry an error code + reason. warn_unused_ignores keeps them honest.
 show_error_codes = true
+
+# numpy (a search/relay-extra runtime dep we do NOT type — same class as nltk /
+# sentence_transformers above) ships a `.pyi` that uses the 3.12+ `type X = …`
+# statement. mypy pinned to python_version 3.10 parses that stub under the 3.10
+# grammar and errors ("Type statement is only supported in Python 3.12 and
+# greater") on the 3.12/3.13 CI runners where the new numpy is installed. We
+# don't check numpy's types, so skip following into its stubs entirely.
+[[tool.mypy.overrides]]
+module = "numpy.*"
+follow_imports = "skip"
+follow_imports_for_stubs = true

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -151,10 +151,25 @@ rest_coverage_gate() {
         --mock-url "http://127.0.0.1:$port" \
         --spec-root "$PORTING_SDK_DIR/rest-apis" \
         --allowlist "$PORTING_SDK_DIR/REST_COVERAGE_BASELINE.md" \
-        --allowlist "$PORT_ROOT/REST_COVERAGE_GAPS.md"
+        --allowlist "$PORT_ROOT/REST_COVERAGE_GAPS.md" \
+        --gap-baseline "$PORTING_SDK_DIR/REST_COVERAGE_GAP_BASELINE.md"
 }
 run_gate "REST-COVERAGE" "every implemented REST route covered success+error (parity + allowlist)" \
     rest_coverage_gate
+
+# Gate 4c: SPEC-PARITY — the routes the SDK actually IMPLEMENTS must equal the
+# canonical spec route set, modulo a checked-in not-implemented gaps file. This
+# is the spec-first guard: REST-COVERAGE only proves tested routes match the
+# spec, so a route the SDK implements but the spec doesn't define (or vice
+# versa) would slip past it. The route registry is built by driving the live
+# client through a recording HttpClient (not an AST scrape, not the test
+# journal), so it sees every implemented route whether or not it's tested.
+#   * B−A (SDK route absent from the spec) → fail (new API must enter the spec)
+#   * A−B (canonical route not implemented) → fail unless in SPEC_IMPLEMENTATION_GAPS.md
+run_gate "SPEC-PARITY" "implemented routes == canonical spec (modulo SPEC_IMPLEMENTATION_GAPS.md)" \
+    python3 "$PORTING_SDK_DIR/scripts/diff_spec_implementation.py" \
+        --sdk "$PORT_ROOT/signalwire/signalwire" \
+        --gaps "$PORTING_SDK_DIR/SPEC_IMPLEMENTATION_GAPS.md"
 
 # Gate 5: FMT — ruff format. Config in pyproject.toml [tool.ruff]. Source-style
 # only (no public-API change → the SIGNATURES/DRIFT oracle is unaffected).


### PR DESCRIPTION
Wires the reference SDK into porting-sdk's new spec-parity enforcement (porting-sdk#44). Companion to that PR — merge porting-sdk#44 first (this depends on the new scripts + baseline files it adds).

## What changes (`scripts/run-ci.sh`)
- **New SPEC-PARITY gate** (Gate 4c, after REST-COVERAGE): `diff_spec_implementation.py` proves the routes the SDK actually implements equal the canonical spec route set, modulo `SPEC_IMPLEMENTATION_GAPS.md`. This is the spec-first guard REST-COVERAGE can't provide — REST-COVERAGE only checks *tested* routes; SPEC-PARITY reads the live implementation via a recording-client route registry.
- **REST-COVERAGE now passes `--gap-baseline REST_COVERAGE_GAP_BASELINE.md`** — a new accepted gap must be sanctioned in the checked-in baseline, not added silently.

## Result
Full `run-ci.sh` green including both new checks:
`TEST · SIGNATURES · DRIFT · NO-CHEAT · REST-COVERAGE · SPEC-PARITY · FMT · LINT · TYPECHECK → CI PASS`

SPEC-PARITY today: **286/307 implemented, 21 accepted gaps, 1 allowed spec divergence**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau