### PR TITLE
chore(types): harden type annotations on the reference SDK (drift-aware, no port re-drift)

### DIFF
--- a/signalwire/signalwire/agents/bedrock.py
+++ b/signalwire/signalwire/agents/bedrock.py
@@ -46,8 +46,8 @@ class BedrockAgent(AgentBase):
         temperature: float = 0.7,
         top_p: float = 0.9,
         max_tokens: int = 1024,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize BedrockAgent
 
@@ -77,7 +77,7 @@ class BedrockAgent(AgentBase):
         logger.info(f"BedrockAgent initialized: {name} on route {route}")
 
     def _render_swml(
-        self, call_id: str | None = None, modifications: dict | None = None
+        self, call_id: str | None = None, modifications: dict[str, Any] | None = None
     ) -> str:
         """
         Render SWML document with amazon_bedrock verb
@@ -264,7 +264,7 @@ class BedrockAgent(AgentBase):
         """
         self.set_inference_params(temperature=temperature)
 
-    def set_post_prompt_llm_params(self, **params) -> None:
+    def set_post_prompt_llm_params(self, **params: Any) -> None:
         """
         Set post-prompt LLM parameters - not applicable for Bedrock
 
@@ -278,7 +278,7 @@ class BedrockAgent(AgentBase):
             "set_post_prompt_llm_params() called but Bedrock post-prompt uses OpenAI configured in C code"
         )
 
-    def set_prompt_llm_params(self, **params) -> None:
+    def set_prompt_llm_params(self, **params: Any) -> None:
         """
         Set prompt LLM parameters - use set_inference_params instead
 

--- a/signalwire/signalwire/cli/build_search.py
+++ b/signalwire/signalwire/cli/build_search.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse, urlunparse
 from signalwire.search.models import MODEL_ALIASES, DEFAULT_MODEL, resolve_model_alias
 
 
-def _mask_connection_string(conn_str):
+def _mask_connection_string(conn_str: str) -> str:
     """Mask password in connection string for safe logging."""
     try:
         parsed = urlparse(conn_str)
@@ -32,7 +32,7 @@ def _mask_connection_string(conn_str):
     return "****"
 
 
-def main():
+def main() -> None:
     """Main entry point for the build-search command"""
     parser = argparse.ArgumentParser(
         description="Build local search index from documents",
@@ -659,7 +659,7 @@ Examples:
         sys.exit(1)
 
 
-def validate_command():
+def validate_command() -> None:
     """Validate an existing search index"""
     parser = argparse.ArgumentParser(description="Validate a search index file")
     parser.add_argument("index_file", help="Path to .swsearch file to validate")
@@ -702,7 +702,7 @@ def validate_command():
         sys.exit(1)
 
 
-def search_command():
+def search_command() -> None:
     """Search within an existing search index"""
     parser = argparse.ArgumentParser(
         description="Search within a .swsearch index file or pgvector collection"
@@ -1091,7 +1091,7 @@ def search_command():
         sys.exit(1)
 
 
-def migrate_command():
+def migrate_command() -> None:
     """Migrate search indexes between backends"""
     parser = argparse.ArgumentParser(
         description="Migrate search indexes between SQLite and pgvector backends",
@@ -1242,7 +1242,7 @@ Examples:
         sys.exit(1)
 
 
-def remote_command():
+def remote_command() -> None:
     """Search via remote API endpoint"""
     parser = argparse.ArgumentParser(description="Search via remote API endpoint")
     parser.add_argument(
@@ -1413,7 +1413,7 @@ def remote_command():
         sys.exit(1)
 
 
-def console_entry_point():
+def console_entry_point() -> None:
     """Console script entry point for pip installation"""
     import sys
 

--- a/signalwire/signalwire/cli/core/agent_loader.py
+++ b/signalwire/signalwire/cli/core/agent_loader.py
@@ -511,12 +511,12 @@ def _load_service_impl(
             captured_services = []
             patches_applied = []
 
-            def mock_serve(self, *args, **kwargs):
+            def mock_serve(self: Any, *args: Any, **kwargs: Any) -> Any:
                 captured_services.append(self)
                 print("  (Intercepted serve() call, service captured for testing)")
                 return self
 
-            def mock_run(self, *args, **kwargs):
+            def mock_run(self: Any, *args: Any, **kwargs: Any) -> Any:
                 captured_services.append(self)
                 print("  (Intercepted run() call, service captured for testing)")
                 return self

--- a/signalwire/signalwire/cli/core/argparse_helpers.py
+++ b/signalwire/signalwire/cli/core/argparse_helpers.py
@@ -12,23 +12,23 @@ Custom argument parsing and function argument parsing
 
 import sys
 import argparse
-from typing import Any
+from typing import Any, NoReturn
 
 
 class CustomArgumentParser(argparse.ArgumentParser):
     """Custom ArgumentParser with better error handling"""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._suppress_usage = False
 
-    def _print_message(self, message, file=None):
+    def _print_message(self, message: str, file: Any = None) -> None:
         """Override to suppress usage output for specific errors"""
         if self._suppress_usage:
             return
         super()._print_message(message, file)
 
-    def error(self, message):
+    def error(self, message: str) -> NoReturn:
         """Override error method to provide user-friendly error messages"""
         if "required" in message.lower() and "agent_path" in message:
             self._suppress_usage = True
@@ -49,13 +49,13 @@ class CustomArgumentParser(argparse.ArgumentParser):
             # For other errors, use the default behavior
             super().error(message)
 
-    def print_usage(self, file=None):
+    def print_usage(self, file: Any = None) -> None:
         """Override print_usage to suppress output when we want custom error handling"""
         if self._suppress_usage:
             return
         super().print_usage(file)
 
-    def parse_args(self, args=None, namespace=None):
+    def parse_args(self, args: Any = None, namespace: Any = None) -> Any:
         """Override parse_args to provide custom error handling for missing arguments"""
         # Check if no arguments provided (just the program name)
         if args is None:

--- a/signalwire/signalwire/cli/core/service_loader.py
+++ b/signalwire/signalwire/cli/core/service_loader.py
@@ -195,7 +195,9 @@ async def simulate_request_to_service(
         # FastAPI Response
         import json
 
-        return json.loads(result.body.decode())
+        # json.loads() is typed -> Any; a FastAPI Response body is the rendered
+        # SWML JSON object, matching the declared dict return.
+        return cast(dict[Any, Any], json.loads(result.body.decode()))
     if isinstance(result, dict):
         return result
     # Try to get content from response

--- a/signalwire/signalwire/cli/core/service_loader.py
+++ b/signalwire/signalwire/cli/core/service_loader.py
@@ -44,9 +44,9 @@ else:
 class ServiceCapture:
     """Captures SWMLService instances when they try to run/serve"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.captured_services: list[SWMLService] = []
-        self.original_methods = {}
+        self.original_methods: dict[Any, Any] = {}
 
     def capture(
         self, service_path: str, suppress_output: bool = False
@@ -115,20 +115,20 @@ class ServiceCapture:
 
         return self.captured_services
 
-    def _apply_patches(self):
+    def _apply_patches(self) -> None:
         """Apply patches to capture services"""
 
         # Store reference to self for use in closures
         capture_self = self
 
-        def mock_run(service_instance, *args, **kwargs):
+        def mock_run(service_instance: Any, *args: Any, **kwargs: Any) -> Any:
             """Capture service when run() is called"""
             capture_self.captured_services.append(service_instance)
             # Don't print during stdout suppression
             # Don't actually run - we're just capturing
             return service_instance
 
-        def mock_serve(service_instance, *args, **kwargs):
+        def mock_serve(service_instance: Any, *args: Any, **kwargs: Any) -> Any:
             """Capture service when serve() is called"""
             capture_self.captured_services.append(service_instance)
             # Don't print during stdout suppression
@@ -146,7 +146,7 @@ class ServiceCapture:
                     self.original_methods[(base_class, "serve")] = base_class.serve
                     base_class.serve = mock_serve
 
-    def _restore_patches(self):
+    def _restore_patches(self) -> None:
         """Restore original methods"""
         for (base_class, method_name), original_method in self.original_methods.items():
             setattr(base_class, method_name, original_method)
@@ -156,10 +156,10 @@ class ServiceCapture:
 async def simulate_request_to_service(
     service: SWMLService,
     method: str = "POST",
-    body: dict | None = None,
-    query_params: dict | None = None,
-    headers: dict | None = None,
-) -> dict:
+    body: dict[str, Any] | None = None,
+    query_params: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
     """
     Simulate a request to a SWMLService instance
 
@@ -197,7 +197,7 @@ async def simulate_request_to_service(
 
         # json.loads() is typed -> Any; a FastAPI Response body is the rendered
         # SWML JSON object, matching the declared dict return.
-        return cast(dict[Any, Any], json.loads(result.body.decode()))
+        return cast(dict[str, Any], json.loads(result.body.decode()))
     if isinstance(result, dict):
         return result
     # Try to get content from response
@@ -208,11 +208,11 @@ def load_and_simulate_service(
     service_path: str,
     route: str | None = None,
     method: str = "POST",
-    body: dict | None = None,
-    query_params: dict | None = None,
-    headers: dict | None = None,
+    body: dict[str, Any] | None = None,
+    query_params: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
     suppress_output: bool = False,
-) -> dict:
+) -> dict[str, Any]:
     """
     Load a service file and simulate a request to it
 

--- a/signalwire/signalwire/cli/dokku.py
+++ b/signalwire/signalwire/cli/dokku.py
@@ -2232,7 +2232,9 @@ def _get_app_name() -> str:
             with open(  # noqa: PTH123  # tests patch builtins.open while mocking Path; Path.open() would bypass the mock seam
                 "app.json"
             ) as f:
-                return json.load(f).get("name", "")
+                # json.load() is typed -> Any; the "name" field is a string
+                # (default "" when absent). Coerce to satisfy the str return.
+                return str(json.load(f).get("name", ""))
         except Exception:  # noqa: S110  # best-effort read of optional app.json; falls through to interactive prompt on failure
             pass
     return prompt("App name", Path.cwd().name)

--- a/signalwire/signalwire/cli/dokku.py
+++ b/signalwire/signalwire/cli/dokku.py
@@ -43,23 +43,23 @@ class Colors:
     NC = "\033[0m"
 
 
-def print_step(msg: str):
+def print_step(msg: str) -> None:
     print(f"{Colors.BLUE}==>{Colors.NC} {msg}")
 
 
-def print_success(msg: str):
+def print_success(msg: str) -> None:
     print(f"{Colors.GREEN}✓{Colors.NC} {msg}")
 
 
-def print_warning(msg: str):
+def print_warning(msg: str) -> None:
     print(f"{Colors.YELLOW}!{Colors.NC} {msg}")
 
 
-def print_error(msg: str):
+def print_error(msg: str) -> None:
     print(f"{Colors.RED}✗{Colors.NC} {msg}")
 
 
-def print_header(msg: str):
+def print_header(msg: str) -> None:
     print(f"\n{Colors.BOLD}{Colors.CYAN}{msg}{Colors.NC}")
 
 
@@ -1849,7 +1849,7 @@ class DokkuProjectGenerator:
             print_error(f"Failed to generate project: {e}")
             return False
 
-    def _write_core_files(self):
+    def _write_core_files(self) -> None:
         """Write files common to both modes."""
         # Procfile
         self._write_file("Procfile", PROCFILE_TEMPLATE)
@@ -1895,7 +1895,7 @@ class DokkuProjectGenerator:
                 ),
             )
 
-    def _write_web_files(self):
+    def _write_web_files(self) -> None:
         """Write web interface files."""
         # Create web directory
         web_dir = self.project_dir / "web"
@@ -1909,7 +1909,7 @@ class DokkuProjectGenerator:
             WEB_INDEX_TEMPLATE.format(agent_name=self.app_name, route=route),
         )
 
-    def _write_simple_files(self):
+    def _write_simple_files(self) -> None:
         """Write files for simple deployment mode."""
         dokku_host = self.options.get("dokku_host", "dokku.yourdomain.com")
         route = self.options.get("route", "swaig")
@@ -1929,7 +1929,7 @@ class DokkuProjectGenerator:
         )
         self._write_file("README.md", readme)
 
-    def _write_cicd_files(self):
+    def _write_cicd_files(self) -> None:
         """Write files for CI/CD deployment mode."""
         # Create .github/workflows directory
         workflows_dir = self.project_dir / ".github" / "workflows"
@@ -1957,7 +1957,7 @@ class DokkuProjectGenerator:
         readme = README_CICD_TEMPLATE.format(app_name=self.app_name)
         self._write_file("README.md", readme)
 
-    def _write_file(self, path: str, content: str, executable: bool = False):
+    def _write_file(self, path: str, content: str, executable: bool = False) -> None:
         """Write a file to the project directory."""
         file_path = self.project_dir / path
         file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1974,7 +1974,7 @@ class DokkuProjectGenerator:
 # =============================================================================
 
 
-def cmd_init(args):
+def cmd_init(args: argparse.Namespace) -> int:
     """Initialize a new Dokku project."""
     app_name = args.name
 
@@ -2031,7 +2031,9 @@ def cmd_init(args):
     return 1
 
 
-def _print_simple_instructions(app_name: str, dokku_host: str, project_dir: Path):
+def _print_simple_instructions(
+    app_name: str, dokku_host: str, project_dir: Path
+) -> None:
     """Print instructions for simple mode."""
     print(f"""To deploy your agent:
 
@@ -2046,7 +2048,7 @@ Or manually:
 """)
 
 
-def _print_cicd_instructions(app_name: str):
+def _print_cicd_instructions(app_name: str) -> None:
     """Print instructions for CI/CD mode."""
     print(f"""
 {Colors.BOLD}═══════════════════════════════════════════════════════════{Colors.NC}
@@ -2082,7 +2084,7 @@ def _print_cicd_instructions(app_name: str):
 """)
 
 
-def cmd_deploy(args):
+def cmd_deploy(args: argparse.Namespace) -> int:
     """Deploy to Dokku."""
     # Check if we're in a Dokku project
     if not Path("Procfile").exists():
@@ -2150,7 +2152,7 @@ def cmd_deploy(args):
     return 0
 
 
-def cmd_logs(args):
+def cmd_logs(args: argparse.Namespace) -> int:
     """Tail Dokku logs."""
     app_name = args.app
     dokku_host = args.host
@@ -2172,7 +2174,7 @@ def cmd_logs(args):
     return 0
 
 
-def cmd_config(args):
+def cmd_config(args: argparse.Namespace) -> int:
     """Manage Dokku config."""
     app_name = args.app
     dokku_host = args.host
@@ -2202,7 +2204,7 @@ def cmd_config(args):
     return 0
 
 
-def cmd_scale(args):
+def cmd_scale(args: argparse.Namespace) -> int:
     """Scale Dokku processes."""
     app_name = args.app
     dokku_host = args.host
@@ -2245,7 +2247,7 @@ def _get_app_name() -> str:
 # =============================================================================
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser(
         description="SignalWire Agent Dokku Deployment Tool",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/signalwire/signalwire/cli/execution/webhook_exec.py
+++ b/signalwire/signalwire/cli/execution/webhook_exec.py
@@ -12,7 +12,7 @@ Webhook function execution (including external)
 
 import json
 import requests
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, cast
 from ..config import HTTP_REQUEST_TIMEOUT
 
 if TYPE_CHECKING:
@@ -92,7 +92,9 @@ def execute_external_webhook_function(
 
         if response.status_code == 200:
             try:
-                result = response.json()
+                # requests' .json() is typed -> Any; a successful webhook returns
+                # a JSON object, matching the declared dict return.
+                result = cast(dict[str, Any], response.json())
                 if verbose:
                     print("✓ External webhook succeeded")
                     print(f"Response: {json.dumps(result, indent=2)}")

--- a/signalwire/signalwire/cli/init_project.py
+++ b/signalwire/signalwire/cli/init_project.py
@@ -46,19 +46,19 @@ class Colors:
     NC = "\033[0m"  # No Color
 
 
-def print_step(msg: str):
+def print_step(msg: str) -> None:
     print(f"{Colors.BLUE}==>{Colors.NC} {msg}")
 
 
-def print_success(msg: str):
+def print_success(msg: str) -> None:
     print(f"{Colors.GREEN}✓{Colors.NC} {msg}")
 
 
-def print_warning(msg: str):
+def print_warning(msg: str) -> None:
     print(f"{Colors.YELLOW}!{Colors.NC} {msg}")
 
 
-def print_error(msg: str):
+def print_error(msg: str) -> None:
     print(f"{Colors.RED}✗{Colors.NC} {msg}")
 
 
@@ -2066,7 +2066,7 @@ class ProjectGenerator:
             "auth_password": auth_password,
         }
 
-    def _create_cloud_env_example(self, platform: str):
+    def _create_cloud_env_example(self, platform: str) -> None:
         """Create .env.example for cloud platforms."""
         env_content = """# Optional: Basic authentication credentials
 # If not set, the SDK will auto-generate secure credentials
@@ -2076,7 +2076,7 @@ SWML_BASIC_AUTH_PASSWORD=your-secure-password
         (self.project_dir / ".env.example").write_text(env_content)
         print_success("Created .env.example")
 
-    def _create_cloud_readme(self, platform: str):
+    def _create_cloud_readme(self, platform: str) -> None:
         """Create README.md for cloud platforms."""
         platform_names = {
             "aws": "AWS Lambda",
@@ -2272,7 +2272,7 @@ Set your phone number's SWML URL to the endpoint URL shown after deployment.
         (self.project_dir / "README.md").write_text(readme)
         print_success("Created README.md")
 
-    def _create_directories(self):
+    def _create_directories(self) -> None:
         """Create project directory structure."""
         dirs = ["agents", "skills"]
         if self.features.get("tests"):
@@ -2286,7 +2286,7 @@ Set your phone number's SWML URL to the endpoint URL shown after deployment.
         for d in dirs:
             (self.project_dir / d).mkdir(exist_ok=True)
 
-    def _create_agent_files(self):
+    def _create_agent_files(self) -> None:
         """Create agent module files."""
         agents_dir = self.project_dir / "agents"
 
@@ -2305,13 +2305,13 @@ Set your phone number's SWML URL to the endpoint URL shown after deployment.
         (self.project_dir / "skills" / "__init__.py").write_text(TEMPLATE_SKILLS_INIT)
         print_success("Created skills/__init__.py")
 
-    def _create_app_file(self):
+    def _create_app_file(self) -> None:
         """Create main app.py entry point."""
         app_code = get_app_template(self.features)
         (self.project_dir / "app.py").write_text(app_code)
         print_success("Created app.py")
 
-    def _create_config_files(self):
+    def _create_config_files(self) -> None:
         """Create configuration files."""
         # .env
         env_content = f"""# SignalWire Credentials
@@ -2357,7 +2357,7 @@ DEBUG_WEBHOOK_LEVEL=1
         (self.project_dir / "requirements.txt").write_text(TEMPLATE_REQUIREMENTS)
         print_success("Created requirements.txt")
 
-    def _create_test_files(self):
+    def _create_test_files(self) -> None:
         """Create test files."""
         tests_dir = self.project_dir / "tests"
 
@@ -2368,20 +2368,20 @@ DEBUG_WEBHOOK_LEVEL=1
         (tests_dir / "test_agent.py").write_text(test_code)
         print_success("Created tests/test_agent.py")
 
-    def _create_web_files(self):
+    def _create_web_files(self) -> None:
         """Create web UI files."""
         web_dir = self.project_dir / "web"
 
         (web_dir / "index.html").write_text(get_web_index_template())
         print_success("Created web/index.html")
 
-    def _create_readme(self):
+    def _create_readme(self) -> None:
         """Create README.md."""
         readme = get_readme_template(self.project_name, self.features)
         (self.project_dir / "README.md").write_text(readme)
         print_success("Created README.md")
 
-    def _create_virtualenv(self):
+    def _create_virtualenv(self) -> None:
         """Create and set up virtual environment."""
         venv_dir = self.project_dir / ".venv"
 
@@ -2627,7 +2627,7 @@ def run_quick(project_name: str, args: Any) -> dict[str, Any]:
     }
 
 
-def main():
+def main() -> None:
     """Main entry point."""
     import argparse
 

--- a/signalwire/signalwire/cli/output/swml_dump.py
+++ b/signalwire/signalwire/cli/output/swml_dump.py
@@ -28,14 +28,14 @@ if TYPE_CHECKING:
 original_print = print
 
 
-def setup_output_suppression():
+def setup_output_suppression() -> None:
     """Set up output suppression for SWML dumping"""
     # The central logging system is already configured via environment variable
     # Just suppress any remaining warnings
     warnings.filterwarnings("ignore")
 
     # Capture and suppress print statements
-    def suppressed_print(*args, **kwargs):
+    def suppressed_print(*args: Any, **kwargs: Any) -> None:
         # If file is specified (like stderr), allow it
         if "file" in kwargs and kwargs["file"] is not sys.stdout:
             original_print(*args, **kwargs)

--- a/signalwire/signalwire/cli/simulation/mock_env.py
+++ b/signalwire/signalwire/cli/simulation/mock_env.py
@@ -12,6 +12,7 @@ Mock environment and serverless simulation functionality
 
 import os
 import json
+from collections.abc import ItemsView, KeysView, ValuesView
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -31,13 +32,13 @@ class MockQueryParams:
     def __contains__(self, key: str) -> bool:
         return key in self._params
 
-    def items(self):
+    def items(self) -> ItemsView[str, str]:
         return self._params.items()
 
-    def keys(self):
+    def keys(self) -> KeysView[str]:
         return self._params.keys()
 
-    def values(self):
+    def values(self) -> ValuesView[str]:
         return self._params.values()
 
 
@@ -60,13 +61,13 @@ class MockHeaders:
     def __contains__(self, key: str) -> bool:
         return key.lower() in self._headers
 
-    def items(self):
+    def items(self) -> ItemsView[str, str]:
         return self._headers.items()
 
-    def keys(self):
+    def keys(self) -> KeysView[str]:
         return self._headers.keys()
 
-    def values(self):
+    def values(self) -> ValuesView[str]:
         return self._headers.values()
 
 
@@ -94,7 +95,7 @@ class MockURL:
             self.scheme = "http"
             self.netloc = "localhost:8080"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._url
 
 
@@ -126,7 +127,7 @@ class MockRequest:
         """Return the raw body bytes"""
         return self._body
 
-    def client(self):
+    def client(self) -> Any:
         """Mock client property"""
         return type("MockClient", (), {"host": "127.0.0.1", "port": 0})()
 
@@ -189,7 +190,7 @@ class ServerlessSimulator:
         self.active = False
         self._cleared_vars: dict[str, str] = {}
 
-    def activate(self, verbose: bool = False):
+    def activate(self, verbose: bool = False) -> None:
         """Apply serverless environment simulation"""
         if self.active:
             return
@@ -246,7 +247,7 @@ class ServerlessSimulator:
             else:
                 print("  ✓ SWML_PROXY_URL_BASE cleared successfully")
 
-    def deactivate(self, verbose: bool = False):
+    def deactivate(self, verbose: bool = False) -> None:
         """Restore original environment"""
         if not self.active:
             return
@@ -258,7 +259,7 @@ class ServerlessSimulator:
         if verbose:
             print(f"✓ Deactivated {self.platform} environment simulation")
 
-    def _clear_conflicting_env(self):
+    def _clear_conflicting_env(self) -> None:
         """Clear environment variables that might conflict with simulation"""
         # Remove variables from other platforms
         conflicting_vars: list[str] = []
@@ -275,7 +276,7 @@ class ServerlessSimulator:
                 self._cleared_vars[var] = os.environ[var]
                 os.environ.pop(var)
 
-    def add_override(self, key: str, value: str):
+    def add_override(self, key: str, value: str) -> None:
         """Add an environment variable override"""
         self.overrides[key] = value
         if self.active:

--- a/signalwire/signalwire/cli/swaig_test_wrapper.py
+++ b/signalwire/signalwire/cli/swaig_test_wrapper.py
@@ -16,7 +16,7 @@ import sys
 import subprocess
 
 
-def main():
+def main() -> None:
     """Main entry point for the swaig-test command"""
     # Determine if we should show logs based on arguments
     args = sys.argv[1:]

--- a/signalwire/signalwire/cli/test_swaig.py
+++ b/signalwire/signalwire/cli/test_swaig.py
@@ -53,7 +53,7 @@ from .output.swml_dump import handle_dump_swml, setup_output_suppression
 from .output.output_formatter import display_agent_tools, format_result
 
 
-def print_help_platforms():
+def print_help_platforms() -> None:
     """Print detailed help for serverless platform options"""
     print("""
 Serverless Platform Configuration Options
@@ -97,7 +97,7 @@ Examples:
 """)
 
 
-def print_help_examples():
+def print_help_examples() -> None:
     """Print comprehensive usage examples"""
     print("""
 Comprehensive Usage Examples
@@ -224,7 +224,7 @@ swaig-test agent.py --simulate-serverless cgi --cgi-host example.com --dump-swml
 """)
 
 
-def main():
+def main() -> int:
     """Main entry point for the CLI tool"""
     # Set up suppression early if we're dumping SWML
     if "--dump-swml" in sys.argv:
@@ -840,7 +840,7 @@ def main():
     return 0
 
 
-def console_entry_point():
+def console_entry_point() -> None:
     """Console script entry point for pip installation"""
     # Check for --dump-swml or --raw BEFORE imports happen
     if "--raw" in sys.argv or "--dump-swml" in sys.argv:

--- a/signalwire/signalwire/core/agent/prompt/manager.py
+++ b/signalwire/signalwire/core/agent/prompt/manager.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 Prompt management functionality for AgentBase.
 """
 
-from typing import Any
+from typing import Any, cast
 import inspect
 
 from signalwire.core.logging_config import get_logger
@@ -28,7 +28,7 @@ class PromptManager:
             agent: Parent AgentBase instance
         """
         self.agent = agent
-        self._prompt_text = None
+        self._prompt_text: str | None = None
         self._post_prompt_text = None
         self._contexts = None
 
@@ -64,9 +64,11 @@ class PromptManager:
         if self._prompt_text:
             return self._prompt_text
 
-        # Otherwise use POM sections if available
+        # Otherwise use POM sections if available. `self.agent` is untyped here
+        # (the PromptManager holds a back-reference to the AgentBase host), so
+        # pom.to_dict() returns Any; narrow it to the POM section-list shape.
         if self.agent._use_pom and self.agent.pom:
-            sections = self.agent.pom.to_dict()
+            sections = cast("list[dict[str, Any]]", self.agent.pom.to_dict())
             if sections:
                 return sections
 

--- a/signalwire/signalwire/core/mixins/prompt_mixin.py
+++ b/signalwire/signalwire/core/mixins/prompt_mixin.py
@@ -7,7 +7,7 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-from typing import Union, Any, TYPE_CHECKING
+from typing import Union, Any, TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from signalwire.core.agent_base import AgentBase  # type: ignore[attr-defined]  # cycle: agent_base imports the mixins; the name resolves at type-check time but mypy flags the back-reference
@@ -325,7 +325,9 @@ class PromptMixin(_HostTyped):
         Returns:
             True if section exists, False otherwise
         """
-        return self._prompt_manager.prompt_has_section(title)
+        # `_prompt_manager` is host-Any (mixin pattern); PromptManager
+        # .prompt_has_section() is declared -> bool.
+        return cast(bool, self._prompt_manager.prompt_has_section(title))
 
     def get_prompt(self) -> str | list[dict[str, Any]]:
         """
@@ -334,21 +336,25 @@ class PromptMixin(_HostTyped):
         Returns:
             Either a string prompt or a POM object as list of dicts
         """
-        # First check if prompt manager has a prompt
+        # First check if prompt manager has a prompt. `_prompt_manager` is
+        # host-Any (mixin pattern); PromptManager.get_prompt() is declared
+        # -> str | list[dict[str, Any]] | None, so narrow the non-None branch.
         prompt_result = self._prompt_manager.get_prompt()
         if prompt_result is not None:
-            return prompt_result
+            return cast("str | list[dict[str, Any]]", prompt_result)
 
-        # If using POM, return the POM structure
+        # If using POM, return the POM structure. `self.pom` is host-Any and the
+        # POM implementation is duck-typed (whichever render method it exposes);
+        # narrow each branch back to this method's declared return contract.
         if self._use_pom and self.pom:
             try:
                 # Try different methods that might be available on the POM implementation
                 if hasattr(self.pom, "render_dict"):
-                    return self.pom.render_dict()
+                    return cast("list[dict[str, Any]]", self.pom.render_dict())
                 if hasattr(self.pom, "to_dict"):
-                    return self.pom.to_dict()
+                    return cast("list[dict[str, Any]]", self.pom.to_dict())
                 if hasattr(self.pom, "to_list"):
-                    return self.pom.to_list()
+                    return cast("list[dict[str, Any]]", self.pom.to_list())
                 if hasattr(self.pom, "render"):
                     render_result = self.pom.render()
                     # If render returns a string, we need to convert it to JSON
@@ -356,11 +362,13 @@ class PromptMixin(_HostTyped):
                         try:
                             import json
 
-                            return json.loads(render_result)
+                            return cast(
+                                "list[dict[str, Any]]", json.loads(render_result)
+                            )
                         except (ValueError, json.JSONDecodeError):
                             # If we can't parse as JSON, fall back to raw text
                             pass
-                    return render_result
+                    return cast("str | list[dict[str, Any]]", render_result)
                 # Last resort: attempt to convert the POM object directly to a list/dict
                 # This assumes the POM object has a reasonable __str__ or __repr__ method
                 pom_data = self.pom.__dict__
@@ -381,4 +389,5 @@ class PromptMixin(_HostTyped):
         Returns:
             Post-prompt text or None if not set
         """
-        return self._prompt_manager.get_post_prompt()
+        # `_prompt_manager` is host-Any; PromptManager.get_post_prompt() -> str | None.
+        return cast("str | None", self._prompt_manager.get_post_prompt())

--- a/signalwire/signalwire/core/mixins/skill_mixin.py
+++ b/signalwire/signalwire/core/mixins/skill_mixin.py
@@ -7,7 +7,7 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from signalwire.core.agent_base import AgentBase  # type: ignore[attr-defined]  # cycle: agent_base imports the mixins; the name resolves at type-check time but mypy flags the back-reference
@@ -62,8 +62,11 @@ class SkillMixin(_HostTyped):
 
     def list_skills(self) -> list[str]:
         """List currently loaded skills"""
-        return self.skill_manager.list_loaded_skills()
+        # `skill_manager` is host-Any (mixin pattern); SkillManager
+        # .list_loaded_skills() is declared -> list[str].
+        return cast(list[str], self.skill_manager.list_loaded_skills())
 
     def has_skill(self, skill_name: str) -> bool:
         """Check if skill is loaded"""
-        return self.skill_manager.has_skill(skill_name)
+        # `skill_manager` is host-Any; SkillManager.has_skill() -> bool.
+        return cast(bool, self.skill_manager.has_skill(skill_name))

--- a/signalwire/signalwire/core/mixins/state_mixin.py
+++ b/signalwire/signalwire/core/mixins/state_mixin.py
@@ -7,6 +7,8 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
+from typing import cast
+
 from signalwire.core.mixins._mixin_host import _HostTyped
 
 
@@ -32,8 +34,10 @@ class StateMixin(_HostTyped):
                 self.log.error("no_session_manager")
                 return ""
 
-            # Create the token using the session manager
-            return self._session_manager.create_tool_token(tool_name, call_id)
+            # Create the token using the session manager. The host attribute
+            # `_session_manager` is typed Any (mixin-host pattern), so narrow the
+            # SessionManager.create_tool_token() -> str result back to str.
+            return cast(str, self._session_manager.create_tool_token(tool_name, call_id))
         except Exception as e:
             self.log.error(
                 "token_creation_error", error=str(e), tool=tool_name, call_id=call_id
@@ -155,7 +159,9 @@ class StateMixin(_HostTyped):
             else:
                 self.log.warning("token_invalid", function=function_name)
 
-            return is_valid
+            # `_session_manager` is host-Any; SessionManager.validate_tool_token
+            # is declared -> bool, so narrow back to bool.
+            return cast(bool, is_valid)
         except Exception as e:
             self.log.error(
                 "token_validation_error", error=str(e), function=function_name

--- a/signalwire/signalwire/core/mixins/state_mixin.py
+++ b/signalwire/signalwire/core/mixins/state_mixin.py
@@ -37,7 +37,9 @@ class StateMixin(_HostTyped):
             # Create the token using the session manager. The host attribute
             # `_session_manager` is typed Any (mixin-host pattern), so narrow the
             # SessionManager.create_tool_token() -> str result back to str.
-            return cast(str, self._session_manager.create_tool_token(tool_name, call_id))
+            return cast(
+                str, self._session_manager.create_tool_token(tool_name, call_id)
+            )
         except Exception as e:
             self.log.error(
                 "token_creation_error", error=str(e), tool=tool_name, call_id=call_id

--- a/signalwire/signalwire/core/skill_base.py
+++ b/signalwire/signalwire/core/skill_base.py
@@ -8,7 +8,7 @@ See LICENSE file in the project root for full license information.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, TYPE_CHECKING
+from typing import Any, ClassVar, TYPE_CHECKING, cast
 
 from signalwire.core.logging_config import get_logger
 
@@ -73,8 +73,10 @@ class SkillBase(ABC):
         merged_kwargs = dict(self.swaig_fields)
         merged_kwargs.update(kwargs)
 
-        # Call the agent's define_tool with merged arguments
-        return self.agent.define_tool(**merged_kwargs)
+        # Call the agent's define_tool with merged arguments. agent.define_tool
+        # returns the AgentBase (fluent), but this wrapper's contract is -> None
+        # and `self.agent` is untyped, so don't propagate the Any return.
+        self.agent.define_tool(**merged_kwargs)
 
     def get_hints(self) -> list[str]:
         """Return speech recognition hints for this skill"""
@@ -174,8 +176,10 @@ class SkillBase(ABC):
             dict: The skill's namespaced state, or empty dict if not found.
         """
         namespace = self._get_skill_namespace()
+        # raw_data is dict[str, Any], so global_data and the namespaced lookup
+        # are Any; the skill's namespaced state is itself a dict.
         global_data = raw_data.get("global_data", {})
-        return global_data.get(namespace, {})
+        return cast(dict[str, Any], global_data.get(namespace, {}))
 
     def update_skill_data(
         self, result: "FunctionResult", data: dict[str, Any]

--- a/signalwire/signalwire/core/swml_renderer.py
+++ b/signalwire/signalwire/core/swml_renderer.py
@@ -141,7 +141,9 @@ class SwmlRenderer:
         if format.lower() == "yaml":
             import yaml
 
-            return yaml.dump(builder.build(), sort_keys=False)
+            # yaml has no type stubs (ignore_missing_imports), so dump() is Any;
+            # with no stream argument it returns the serialized str.
+            return cast(str, yaml.dump(builder.build(), sort_keys=False))
         return builder.render()
 
     @staticmethod
@@ -187,5 +189,6 @@ class SwmlRenderer:
         if format.lower() == "yaml":
             import yaml
 
-            return yaml.dump(service.get_document(), sort_keys=False)
+            # yaml.dump() is Any (no stubs); returns the serialized str.
+            return cast(str, yaml.dump(service.get_document(), sort_keys=False))
         return service.render_document()

--- a/signalwire/signalwire/core/swml_service.py
+++ b/signalwire/signalwire/core/swml_service.py
@@ -19,7 +19,7 @@ import re
 import base64
 import sys
 import types
-from typing import Any
+from typing import Any, cast
 from collections.abc import Callable
 from urllib.parse import urlparse
 
@@ -451,12 +451,14 @@ class SWMLService(ToolMixin):
             ),  # Parent's data subdirectory
         ]
 
-        # Try to find the schema file
-        for path in potential_paths:
+        # Try to find the schema file. Use a distinct loop variable: the outer
+        # `path` is annotated Any (importlib Traversable, above), and reusing it
+        # here would leak Any into this str-returning function.
+        for candidate in potential_paths:
             if os.path.exists(  # noqa: PTH110  # tests patch global os.path.exists; Path.exists() would bypass the mock seam
-                path
+                candidate
             ):
-                return path
+                return candidate
 
         return None
 
@@ -906,7 +908,9 @@ class SWMLService(ToolMixin):
         try:
             # Check if we have call data with a 'to' field
             if "call" in request_body and "to" in request_body["call"]:
-                to_field = request_body["call"]["to"]
+                # request_body is dict[str, Any], so the 'to' field is Any; it is
+                # a SIP/TEL URI string here (AttributeError below catches non-str).
+                to_field = cast(str, request_body["call"]["to"])
 
                 # Handle SIP URIs like "sip:username@domain"
                 if to_field.startswith("sip:"):

--- a/signalwire/signalwire/livewire/__init__.py
+++ b/signalwire/signalwire/livewire/__init__.py
@@ -20,8 +20,11 @@ import inspect
 import logging
 import threading
 import asyncio
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 from collections.abc import Callable
+
+if TYPE_CHECKING:
+    from signalwire.core.function_result import FunctionResult
 
 # ---------------------------------------------------------------------------
 # Sentinel for "not given" keyword arguments (distinct from None)
@@ -45,7 +48,7 @@ BANNER = r"""
 """
 
 
-def _print_banner():
+def _print_banner() -> None:
     """Print the ASCII banner to stderr, using ANSI cyan if a terminal."""
     if sys.stderr.isatty():
         sys.stderr.write(f"\033[36m{BANNER}\033[0m\n")
@@ -81,7 +84,7 @@ TIPS = [
 ]
 
 
-def _print_tip():
+def _print_tip() -> None:
     """Print a random 'Did you know?' tip to stderr."""
     tip = random.choice(TIPS)  # noqa: S311  # not cryptographic: picks a cosmetic "Did you know?" CLI tip to print
     sys.stderr.write(f"\n\U0001f4a1 Did you know?  {tip}\n\n")
@@ -97,7 +100,7 @@ _logger = logging.getLogger("LiveWire")
 class _NoopTracker:
     """Ensures each noop message is printed at most once."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._lock = threading.Lock()
         self._logged: dict[str, bool] = {}
 
@@ -114,7 +117,7 @@ class _NoopTracker:
         with self._lock:
             return self._logged.get(key, False)
 
-    def reset(self):
+    def reset(self) -> None:
         with self._lock:
             self._logged.clear()
 
@@ -142,7 +145,7 @@ class ToolError(Exception):
 class AgentHandoff:
     """Signals a handoff to another agent in multi-agent scenarios."""
 
-    def __init__(self, agent, *, returns=None):
+    def __init__(self, agent: Any, *, returns: Any = None) -> None:
         self.agent = agent
         self.returns = returns
 
@@ -155,10 +158,10 @@ class AgentHandoff:
 class ChatContext:
     """Minimal stub mirroring livekit ChatContext."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.messages: list[dict[str, str]] = []
 
-    def append(self, *, role: str = "user", text: str = ""):
+    def append(self, *, role: str = "user", text: str = "") -> "ChatContext":
         self.messages.append({"role": role, "content": text})
         return self
 
@@ -169,8 +172,11 @@ class ChatContext:
 
 
 def function_tool(
-    func=None, *, name: str | None = None, description: str | None = None
-):
+    func: "Callable[..., Any] | None" = None,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+) -> "Callable[..., Any]":
     """Mirrors the livekit ``@function_tool`` decorator.
 
     Wraps a plain function so it can be passed into ``Agent(tools=[...])``.
@@ -178,7 +184,7 @@ def function_tool(
     description when *description* is not provided explicitly.
     """
 
-    def _wrap(fn: Callable) -> Callable:
+    def _wrap(fn: "Callable[..., Any]") -> "Callable[..., Any]":
         tool_name = name or fn.__name__
         tool_desc = description or (inspect.getdoc(fn) or "")
 
@@ -223,7 +229,7 @@ def function_tool(
     return _wrap
 
 
-def _is_run_context(annotation) -> bool:
+def _is_run_context(annotation: Any) -> bool:
     """Return True if *annotation* looks like a RunContext type."""
     if annotation is RunContext:
         return True
@@ -231,7 +237,7 @@ def _is_run_context(annotation) -> bool:
     return "RunContext" in name
 
 
-def _python_type_to_json(annotation) -> str:
+def _python_type_to_json(annotation: Any) -> str:
     """Map a Python type annotation to a JSON-Schema type string."""
     mapping = {
         str: "string",
@@ -250,13 +256,19 @@ def _python_type_to_json(annotation) -> str:
 class RunContext:
     """Mirrors livekit RunContext -- available inside tool handlers."""
 
-    def __init__(self, session=None, *, speech_handle=None, function_call=None):
+    def __init__(
+        self,
+        session: Any = None,
+        *,
+        speech_handle: Any = None,
+        function_call: Any = None,
+    ) -> None:
         self.session = session
         self.speech_handle = speech_handle
         self.function_call = function_call
 
     @property
-    def userdata(self):
+    def userdata(self) -> Any:
         if self.session is not None:
             return self.session.userdata
         return {}
@@ -335,22 +347,24 @@ class Agent:
         return self._session
 
     @session.setter
-    def session(self, value):
+    def session(self, value: "AgentSession | None") -> None:
         self._session = value
 
     # ------------------------------------------------------------------
     # Lifecycle hooks (override in subclass)
     # ------------------------------------------------------------------
 
-    async def on_enter(self):
+    async def on_enter(self) -> None:
         """Called when the agent enters.  Override in subclass."""
         pass
 
-    async def on_exit(self):
+    async def on_exit(self) -> None:
         """Called when the agent exits.  Override in subclass."""
         pass
 
-    async def on_user_turn_completed(self, turn_ctx=None, new_message=None):
+    async def on_user_turn_completed(
+        self, turn_ctx: Any = None, new_message: Any = None
+    ) -> None:
         """Called when the user finishes speaking.  Override in subclass."""
         pass
 
@@ -358,7 +372,7 @@ class Agent:
     # Pipeline nodes -- all noop + log
     # ------------------------------------------------------------------
 
-    async def stt_node(self, audio=None, model_settings=None):
+    async def stt_node(self, audio: Any = None, model_settings: Any = None) -> None:
         """Noop -- SignalWire handles STT in its control plane."""
         _global_noop.once(
             "stt_node",
@@ -366,7 +380,9 @@ class Agent:
             "recognition -- this node is a no-op",
         )
 
-    async def llm_node(self, chat_ctx=None, tools=None, model_settings=None):
+    async def llm_node(
+        self, chat_ctx: Any = None, tools: Any = None, model_settings: Any = None
+    ) -> None:
         """Noop -- SignalWire handles LLM in its control plane."""
         _global_noop.once(
             "llm_node",
@@ -374,7 +390,7 @@ class Agent:
             "inference -- this node is a no-op",
         )
 
-    async def tts_node(self, text=None, model_settings=None):
+    async def tts_node(self, text: Any = None, model_settings: Any = None) -> None:
         """Noop -- SignalWire handles TTS in its control plane."""
         _global_noop.once(
             "tts_node",
@@ -386,11 +402,11 @@ class Agent:
     # Dynamic updates
     # ------------------------------------------------------------------
 
-    async def update_instructions(self, instructions: str):
+    async def update_instructions(self, instructions: str) -> None:
         """Update the agent's instructions mid-session."""
         self.instructions = instructions
 
-    async def update_tools(self, tools: list[Any]):
+    async def update_tools(self, tools: list[Any]) -> None:
         """Update the agent's tool list mid-session."""
         self._tools = list(tools)
 
@@ -486,11 +502,11 @@ class AgentSession:
     # ------------------------------------------------------------------
 
     @property
-    def userdata(self):
+    def userdata(self) -> Any:
         return self._userdata
 
     @userdata.setter
-    def userdata(self, val):
+    def userdata(self, val: Any) -> None:
         self._userdata = val
 
     @property
@@ -501,23 +517,25 @@ class AgentSession:
     # Lifecycle
     # ------------------------------------------------------------------
 
-    async def start(self, agent: Agent, *, room=None, record: bool = False):
+    async def start(
+        self, agent: Agent, *, room: Any = None, record: bool = False
+    ) -> None:
         """Bind to an Agent and prepare the underlying SignalWire AgentBase."""
         self._agent = agent
         agent.session = self
         self._started = True
 
-    def say(self, text: str):
+    def say(self, text: str) -> None:
         """Queue text to be spoken by the agent."""
         self._say_queue.append(text)
 
-    def generate_reply(self, *, instructions: str | None = None):
+    def generate_reply(self, *, instructions: str | None = None) -> None:
         """Trigger the agent to generate a reply.  On SignalWire the prompt
         handles this; if *instructions* is provided they are noted."""
         if instructions:
             self._say_queue.append(instructions)
 
-    def interrupt(self):
+    def interrupt(self) -> None:
         """Noop -- SignalWire handles barge-in automatically."""
         self._noop.once(
             "interrupt",
@@ -525,7 +543,7 @@ class AgentSession:
             "automatically via its control plane",
         )
 
-    def update_agent(self, agent: Agent):
+    def update_agent(self, agent: Agent) -> None:
         """Swap in a new Agent."""
         self._agent = agent
         agent.session = self
@@ -534,7 +552,7 @@ class AgentSession:
     # Build the real SignalWire agent (called by run_app)
     # ------------------------------------------------------------------
 
-    def _build_sw_agent(self):
+    def _build_sw_agent(self) -> Any:
         """Translate the LiveWire session into a SignalWire AgentBase."""
         from signalwire import AgentBase as _AgentBase
 
@@ -598,14 +616,16 @@ class AgentSession:
         return sw
 
 
-def _register_function_tool(sw_agent, fn):
+def _register_function_tool(sw_agent: Any, fn: "Callable[..., Any]") -> None:
     """Register a @function_tool-decorated function on a SignalWire AgentBase."""
-    tool_name = fn._tool_name
-    tool_desc = fn._tool_description
-    tool_params = fn._tool_parameters
+    tool_name = fn._tool_name  # type: ignore[attr-defined]  # dynamic attr set by function_tool()
+    tool_desc = fn._tool_description  # type: ignore[attr-defined]  # dynamic attr set by function_tool()
+    tool_params = fn._tool_parameters  # type: ignore[attr-defined]  # dynamic attr set by function_tool()
 
     # Build a handler compatible with define_tool expectations
-    def handler(args, raw_data=None):
+    def handler(
+        args: dict[str, Any], raw_data: dict[str, Any] | None = None
+    ) -> "FunctionResult":
         from signalwire.core.function_result import FunctionResult
 
         sig = inspect.signature(fn)
@@ -649,19 +669,19 @@ class Room:
 class JobProcess:
     """Mirrors a livekit JobProcess -- used for prewarm/setup."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.userdata: dict[str, Any] = {}
 
 
 class JobContext:
     """Mirrors a livekit JobContext -- provides room and connection info."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.room = Room()
         self.proc = JobProcess()
         self._agent = None
 
-    async def connect(self):
+    async def connect(self) -> None:
         """Noop -- SignalWire agents connect automatically when the platform
         invokes the SWML endpoint."""
         _global_noop.once(
@@ -670,7 +690,7 @@ class JobContext:
             "connection lifecycle at scale automatically",
         )
 
-    async def wait_for_participant(self, *, identity=None):
+    async def wait_for_participant(self, *, identity: Any = None) -> None:
         """Noop -- SignalWire handles participant management automatically."""
         _global_noop.once(
             "wait_for_participant",
@@ -687,20 +707,20 @@ class JobContext:
 class AgentServer:
     """Mirrors a livekit AgentServer -- registers entrypoints and starts."""
 
-    def __init__(self, **kwargs):
-        self.setup_fnc: Callable | None = None
-        self._entrypoint: Callable | None = None
+    def __init__(self, **kwargs: Any) -> None:
+        self.setup_fnc: Callable[..., Any] | None = None
+        self._entrypoint: Callable[..., Any] | None = None
         self._agent_name: str = ""
 
     def rtc_session(
         self,
-        func=None,
+        func: "Callable[..., Any] | None" = None,
         *,
         agent_name: str = "",
         type: str = "room",
-        on_request=None,
-        on_session_end=None,
-    ):
+        on_request: Any = None,
+        on_session_end: Any = None,
+    ) -> "Callable[..., Any]":
         """Decorator that registers the session entrypoint."""
         if type != "room":
             _global_noop.once(
@@ -709,7 +729,7 @@ class AgentServer:
                 f"plane handles server topology at scale automatically",
             )
 
-        def _decorator(fn):
+        def _decorator(fn: "Callable[..., Any]") -> "Callable[..., Any]":
             self._entrypoint = fn
             if agent_name:
                 self._agent_name = agent_name
@@ -741,7 +761,7 @@ from signalwire.livewire.plugins import (  # noqa: E402
 class InferenceSTT:
     """Stub for livekit inference.STT."""
 
-    def __init__(self, model: str = "", **kwargs):
+    def __init__(self, model: str = "", **kwargs: Any) -> None:
         self.model = model
         _global_noop.once(
             "inference_stt",
@@ -753,14 +773,14 @@ class InferenceSTT:
 class InferenceLLM:
     """Stub for livekit inference.LLM."""
 
-    def __init__(self, model: str = "", **kwargs):
+    def __init__(self, model: str = "", **kwargs: Any) -> None:
         self.model = model
 
 
 class InferenceTTS:
     """Stub for livekit inference.TTS."""
 
-    def __init__(self, model: str = "", **kwargs):
+    def __init__(self, model: str = "", **kwargs: Any) -> None:
         self.model = model
         _global_noop.once(
             "inference_tts",
@@ -803,7 +823,7 @@ inference = _InferenceNamespace()
 # ---------------------------------------------------------------------------
 
 
-def run_app(server: AgentServer):
+def run_app(server: AgentServer) -> None:
     """Print banner, print a random tip, run the agent.
 
     This is the main entry point -- mirrors ``livekit.agents.cli.run_app``.

--- a/signalwire/signalwire/livewire/plugins.py
+++ b/signalwire/signalwire/livewire/plugins.py
@@ -24,7 +24,7 @@ _lock = threading.Lock()
 _logged: dict[str, bool] = {}
 
 
-def _log_once(key: str, message: str):
+def _log_once(key: str, message: str) -> None:
     global _logged
     with _lock:
         if _logged.get(key):
@@ -33,7 +33,7 @@ def _log_once(key: str, message: str):
         _logger.info("[LiveWire] %s", message)
 
 
-def _reset_logged():
+def _reset_logged() -> None:
     """Reset the per-module noop tracker (for testing)."""
     global _logged
     with _lock:
@@ -121,6 +121,6 @@ class SileroVAD:
         )
 
     @classmethod
-    def load(cls):
+    def load(cls) -> "SileroVAD":
         """Mirrors the SileroVAD.load() factory."""
         return cls()

--- a/signalwire/signalwire/mcp_gateway/gateway_service.py
+++ b/signalwire/signalwire/mcp_gateway/gateway_service.py
@@ -14,6 +14,7 @@ Manages sessions, handles authentication, and translates between protocols.
 """
 
 import contextlib
+from collections.abc import Callable
 import os
 import json
 import logging
@@ -48,7 +49,7 @@ logger = logging.getLogger("gateway_service")
 class MCPGateway:
     """Main gateway service class"""
 
-    def __init__(self, config_path: str = "config.json"):
+    def __init__(self, config_path: str = "config.json") -> None:
         # Use unified config loader
         self.config_loader = ConfigLoader([config_path])
 
@@ -90,7 +91,7 @@ class MCPGateway:
 
         # Configure security headers
         @self.app.after_request
-        def set_security_headers(response):
+        def set_security_headers(response: Response) -> Response:
             response.headers["X-Content-Type-Options"] = "nosniff"
             response.headers["X-Frame-Options"] = "DENY"
             response.headers["X-XSS-Protection"] = "1; mode=block"
@@ -154,7 +155,7 @@ class MCPGateway:
             raise ValueError("Tool name contains invalid characters")
         return name
 
-    def _log_security_event(self, event_type: str, details: dict[str, Any]):
+    def _log_security_event(self, event_type: str, details: dict[str, Any]) -> None:
         """Log security-relevant events with proper sanitization"""
         # Sanitize any user input in details
         sanitized = {}
@@ -280,11 +281,11 @@ class MCPGateway:
         # object, matching the declared dict return.
         return cast(dict[str, Any], config)
 
-    def _check_auth(self, f):
+    def _check_auth(self, f: Callable[..., Any]) -> Callable[..., Any]:
         """Decorator for authentication using Bearer tokens or Basic auth"""
 
         @wraps(f)
-        def decorated(*args, **kwargs):
+        def decorated(*args: Any, **kwargs: Any) -> Any:
             # Try Bearer token first
             auth_header = request.headers.get("Authorization", "")
             server_config = self.config.get("server", {})
@@ -327,11 +328,11 @@ class MCPGateway:
 
         return decorated
 
-    def _setup_routes(self):
+    def _setup_routes(self) -> None:
         """Set up Flask routes"""
 
         @self.app.route("/health", methods=["GET"])
-        def health():
+        def health() -> Any:
             """Health check endpoint"""
             return jsonify(
                 {
@@ -343,7 +344,7 @@ class MCPGateway:
 
         @self.app.route("/services", methods=["GET"])
         @self._check_auth
-        def list_services():
+        def list_services() -> Any:
             """List available MCP services"""
             services = self.mcp_manager.list_services()
             return jsonify(services)
@@ -351,7 +352,7 @@ class MCPGateway:
         @self.app.route("/services/<service_name>/tools", methods=["GET"])
         @self.limiter.limit(self.rate_config.get("tools_limit", "30 per minute"))
         @self._check_auth
-        def get_service_tools(service_name):
+        def get_service_tools(service_name: str) -> Any:
             """Get tools for a specific service"""
             try:
                 # Validate input
@@ -368,7 +369,7 @@ class MCPGateway:
         @self.app.route("/services/<service_name>/call", methods=["POST"])
         @self.limiter.limit(self.rate_config.get("call_limit", "10 per minute"))
         @self._check_auth
-        def call_service_tool(service_name):
+        def call_service_tool(service_name: str) -> Any:
             """Call a tool on a service"""
             try:
                 # Validate service name
@@ -483,7 +484,7 @@ class MCPGateway:
 
         @self.app.route("/sessions", methods=["GET"])
         @self._check_auth
-        def list_sessions():
+        def list_sessions() -> Any:
             """List active sessions"""
             sessions = self.session_manager.list_sessions()
             return jsonify(sessions)
@@ -493,7 +494,7 @@ class MCPGateway:
             self.rate_config.get("session_delete_limit", "20 per minute")
         )
         @self._check_auth
-        def close_session(session_id):
+        def close_session(session_id: str) -> Any:
             """Close a specific session"""
             try:
                 # Validate session ID
@@ -510,11 +511,11 @@ class MCPGateway:
                 return jsonify({"error": str(e)}), 400
 
         @self.app.errorhandler(Exception)
-        def handle_error(error):
+        def handle_error(error: Exception) -> Any:
             logger.error(f"Unhandled error: {error}")
             return jsonify({"error": "Internal server error"}), 500
 
-    def run(self):
+    def run(self) -> None:
         """Run the gateway service"""
         server_config = self.config.get("server", {})
         host = server_config.get("host", "0.0.0.0")  # noqa: S104  # intended server default: listen on all interfaces (overridable)
@@ -550,7 +551,7 @@ class MCPGateway:
         finally:
             self.shutdown()
 
-    def _signal_handler(self, signum, frame):
+    def _signal_handler(self, signum: int, frame: Any) -> None:
         """Handle shutdown signals"""
         logger.info(f"Received signal {signum}")
         self._shutdown_requested = True
@@ -558,7 +559,7 @@ class MCPGateway:
         if self.server:
             threading.Thread(target=self.server.shutdown, daemon=True).start()
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """Shutdown the gateway service"""
         if self._shutdown_cleanup_done:
             # Already cleaned up
@@ -594,7 +595,7 @@ class MCPGateway:
         logger.info("MCP Gateway shutdown complete")
 
 
-def main():
+def main() -> None:
     """Main entry point"""
     parser = argparse.ArgumentParser(description="MCP-SWAIG Gateway Service")
     parser.add_argument(

--- a/signalwire/signalwire/mcp_gateway/gateway_service.py
+++ b/signalwire/signalwire/mcp_gateway/gateway_service.py
@@ -21,7 +21,7 @@ import argparse
 from pathlib import Path
 import signal
 import re
-from typing import Any
+from typing import Any, cast
 from datetime import datetime
 import ssl
 import concurrent.futures
@@ -276,7 +276,9 @@ class MCPGateway:
                     }
                     session_config[key] = defaults.get(key, 60)
 
-        return config
+        # config originates from json.load() (Any); the config file is a JSON
+        # object, matching the declared dict return.
+        return cast(dict[str, Any], config)
 
     def _check_auth(self, f):
         """Decorator for authentication using Bearer tokens or Basic auth"""

--- a/signalwire/signalwire/mcp_gateway/mcp_manager.py
+++ b/signalwire/signalwire/mcp_gateway/mcp_manager.py
@@ -297,9 +297,10 @@ class MCPClient:
         """Call a tool on the MCP server"""
         # call_method() is declared -> Any (generic RPC); a tools/call result is
         # a JSON-RPC result object.
-        return cast(dict[str, Any], self.call_method(
-            "tools/call", {"name": tool_name, "arguments": arguments}
-        ))
+        return cast(
+            dict[str, Any],
+            self.call_method("tools/call", {"name": tool_name, "arguments": arguments}),
+        )
 
     def call_method(self, method: str, params: dict[str, Any]) -> Any:
         """Call an RPC method and wait for response"""

--- a/signalwire/signalwire/mcp_gateway/mcp_manager.py
+++ b/signalwire/signalwire/mcp_gateway/mcp_manager.py
@@ -50,7 +50,7 @@ class MCPService:
                 "restricted_env": True,
             }
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.name)
 
 
@@ -123,7 +123,7 @@ class MCPClient:
 
         return env, working_dir
 
-    def _sandbox_preexec(self):
+    def _sandbox_preexec(self) -> None:
         """Pre-exec function to sandbox the process"""
         sandbox_config = self.service.sandbox_config or {}
 
@@ -223,7 +223,7 @@ class MCPClient:
             logger.error(f"Error starting MCP service '{self.service.name}': {e}")
             return False
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop the MCP server process and clean up sandbox"""
         # Signal shutdown to reader thread
         self._shutdown.set()
@@ -344,7 +344,7 @@ class MCPClient:
         """Get the list of available tools"""
         return self.tools.copy()
 
-    def _send_message(self, message: dict[str, Any]):
+    def _send_message(self, message: dict[str, Any]) -> None:
         """Send a JSON-RPC message to the server"""
         if not self.process or self.process.poll() is not None:
             raise RuntimeError("MCP server process is not running")
@@ -356,7 +356,7 @@ class MCPClient:
         self.process.stdin.flush()
         logger.debug(f"Sent to '{self.service.name}': {json_str}")
 
-    def _read_loop(self):
+    def _read_loop(self) -> None:
         """Background thread to read responses from the MCP server"""
         while (
             not self._shutdown.is_set() and self.process and self.process.poll() is None
@@ -470,7 +470,7 @@ class MCPManager:
         # Load services from config
         self._load_services()
 
-    def _load_services(self):
+    def _load_services(self) -> None:
         """Load service definitions from configuration"""
         services_config = self.config.get("services", {})
 
@@ -564,7 +564,7 @@ class MCPManager:
 
             return results
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """Shutdown all active MCP clients"""
         with self._clients_lock:
             logger.info(f"Shutting down {len(self.clients)} active MCP clients")

--- a/signalwire/signalwire/mcp_gateway/mcp_manager.py
+++ b/signalwire/signalwire/mcp_gateway/mcp_manager.py
@@ -25,7 +25,7 @@ import pwd
 import shutil
 import resource
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -295,9 +295,11 @@ class MCPClient:
 
     def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         """Call a tool on the MCP server"""
-        return self.call_method(
+        # call_method() is declared -> Any (generic RPC); a tools/call result is
+        # a JSON-RPC result object.
+        return cast(dict[str, Any], self.call_method(
             "tools/call", {"name": tool_name, "arguments": arguments}
-        )
+        ))
 
     def call_method(self, method: str, params: dict[str, Any]) -> Any:
         """Call an RPC method and wait for response"""
@@ -439,7 +441,8 @@ class MCPClient:
         """Get the list of available tools from the server"""
         try:
             result = self.call_method("tools/list", {})
-            return result.get("tools", [])
+            # result is Any (RPC); "tools" is a JSON array of tool definitions.
+            return cast(list[dict[str, Any]], result.get("tools", []))
 
         except Exception as e:
             logger.error(f"Failed to list tools for '{self.service.name}': {e}")

--- a/signalwire/signalwire/mcp_gateway/session_manager.py
+++ b/signalwire/signalwire/mcp_gateway/session_manager.py
@@ -48,7 +48,7 @@ class Session:
             and self.process.process.poll() is None
         )
 
-    def touch(self):
+    def touch(self) -> None:
         """Update last accessed time"""
         self.last_accessed = datetime.now()
 
@@ -205,7 +205,7 @@ class SessionManager:
                 if s.service_name == service_name and s.is_alive and not s.is_expired
             )
 
-    def _cleanup_loop(self):
+    def _cleanup_loop(self) -> None:
         """Background thread that cleans up expired sessions"""
         logger.info("Session cleanup thread started")
 
@@ -236,7 +236,7 @@ class SessionManager:
 
         logger.info("Session cleanup thread stopped")
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """Shutdown all sessions and cleanup"""
         logger.info("Shutting down SessionManager")
 

--- a/signalwire/signalwire/pom/pom.py
+++ b/signalwire/signalwire/pom/pom.py
@@ -49,13 +49,13 @@ class Section:
         self.numbered = numbered
         self.numberedBullets = numberedBullets
 
-    def add_body(self, body: str):
+    def add_body(self, body: str) -> None:
         """Add or replace the body text for this section."""
         if not isinstance(body, str):
             raise TypeError(f"body must be a string, not {type(body).__name__}")
         self.body = body
 
-    def add_bullets(self, bullets: list[str]):
+    def add_bullets(self, bullets: list[str]) -> None:
         """Add bullet points to this section."""
         if not isinstance(bullets, list):
             raise TypeError(f"bullets must be a list, not {type(bullets).__name__}")
@@ -277,7 +277,7 @@ class PromptObjectModel:
     """
 
     @staticmethod
-    def from_json(json_data: str | dict | list) -> "PromptObjectModel":
+    def from_json(json_data: str | dict[str, Any] | list[dict[str, Any]]) -> "PromptObjectModel":
         """
         Create a PromptObjectModel instance from JSON data.
 
@@ -296,7 +296,7 @@ class PromptObjectModel:
         return PromptObjectModel._from_dict(data)
 
     @staticmethod
-    def from_yaml(yaml_data: str | dict) -> "PromptObjectModel":
+    def from_yaml(yaml_data: str | dict[str, Any]) -> "PromptObjectModel":
         """
         Create a PromptObjectModel instance from YAML data.
 
@@ -484,7 +484,7 @@ class PromptObjectModel:
             ),
         )
 
-    def to_dict(self) -> list[dict]:
+    def to_dict(self) -> list[dict[str, Any]]:
         """
         Convert the entire model to a list of dictionaries.
 
@@ -568,7 +568,7 @@ class PromptObjectModel:
 
     def add_pom_as_subsection(
         self, target: str | Section, pom_to_add: "PromptObjectModel"
-    ):
+    ) -> None:
         """
         Add another PromptObjectModel as a subsection to a section with the given title or section object.
 

--- a/signalwire/signalwire/pom/pom.py
+++ b/signalwire/signalwire/pom/pom.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 import json
 import yaml
 
@@ -473,10 +473,15 @@ class PromptObjectModel:
         Returns:
             A YAML string representation of the model
         """
-        return yaml.dump(
-            [s.to_dict() for s in self.sections],
-            default_flow_style=False,
-            sort_keys=False,
+        # yaml has no type stubs (ignore_missing_imports) so dump() is Any; with
+        # no stream argument it returns the serialized str.
+        return cast(
+            str,
+            yaml.dump(
+                [s.to_dict() for s in self.sections],
+                default_flow_style=False,
+                sort_keys=False,
+            ),
         )
 
     def to_dict(self) -> list[dict]:

--- a/signalwire/signalwire/pom/pom.py
+++ b/signalwire/signalwire/pom/pom.py
@@ -277,7 +277,9 @@ class PromptObjectModel:
     """
 
     @staticmethod
-    def from_json(json_data: str | dict[str, Any] | list[dict[str, Any]]) -> "PromptObjectModel":
+    def from_json(
+        json_data: str | dict[str, Any] | list[dict[str, Any]],
+    ) -> "PromptObjectModel":
         """
         Create a PromptObjectModel instance from JSON data.
 

--- a/signalwire/signalwire/prefabs/concierge.py
+++ b/signalwire/signalwire/prefabs/concierge.py
@@ -10,6 +10,7 @@ ConciergeAgent - Prefab agent for providing virtual concierge services
 """
 
 import json
+from typing import Any
 
 from signalwire.core.agent_base import AgentBase
 from signalwire.core.function_result import FunctionResult
@@ -47,8 +48,8 @@ class ConciergeAgent(AgentBase):
         welcome_message: str | None = None,
         name: str = "concierge",
         route: str = "/concierge",
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize a concierge agent
 
@@ -76,7 +77,7 @@ class ConciergeAgent(AgentBase):
         # Set up the agent's configuration
         self._setup_concierge_agent(welcome_message)
 
-    def _setup_concierge_agent(self, welcome_message: str | None = None):
+    def _setup_concierge_agent(self, welcome_message: str | None = None) -> None:
         """Configure the concierge agent with appropriate settings"""
         # Basic personality and instructions
         self.prompt_add_section(
@@ -194,7 +195,9 @@ class ConciergeAgent(AgentBase):
             },
         },
     )
-    def check_availability(self, args, raw_data):
+    def check_availability(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """
         Check availability for a service on a specific date and time
 
@@ -227,7 +230,9 @@ class ConciergeAgent(AgentBase):
             }
         },
     )
-    def get_directions(self, args, raw_data):
+    def get_directions(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Provide directions to a specific location or amenity"""
         location = args.get("location", "").lower()
 
@@ -243,7 +248,11 @@ class ConciergeAgent(AgentBase):
             f"You can ask our staff at the front desk for assistance."
         )
 
-    def on_summary(self, summary, raw_data=None):
+    def on_summary(
+        self,
+        summary: dict[str, Any] | None,
+        raw_data: dict[str, Any] | None = None,
+    ) -> None:
         """
         Process the interaction summary
 

--- a/signalwire/signalwire/prefabs/faq_bot.py
+++ b/signalwire/signalwire/prefabs/faq_bot.py
@@ -48,8 +48,8 @@ class FAQBotAgent(AgentBase):
         persona: str | None = None,
         name: str = "faq_bot",
         route: str = "/faq",
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize an FAQ bot agent
 
@@ -83,7 +83,7 @@ class FAQBotAgent(AgentBase):
         # Configure additional agent settings
         self._configure_agent_settings()
 
-    def _build_faq_bot_prompt(self):
+    def _build_faq_bot_prompt(self) -> None:
         """Build the agent prompt for the FAQ bot"""
         # Set up the personality
         self.prompt_add_section("Personality", body=self.persona)
@@ -143,7 +143,7 @@ class FAQBotAgent(AgentBase):
                 body="When appropriate, suggest other related questions from the FAQ database that might be helpful.",
             )
 
-    def _setup_post_prompt(self):
+    def _setup_post_prompt(self) -> None:
         """Set up the post-prompt for summary"""
         post_prompt = """
         Return a JSON summary of this interaction:
@@ -156,7 +156,7 @@ class FAQBotAgent(AgentBase):
         """
         self.set_post_prompt(post_prompt)
 
-    def _configure_agent_settings(self):
+    def _configure_agent_settings(self) -> None:
         """Configure additional agent settings"""
         # Add hints for better recognition of FAQ-related terms
         hints = []
@@ -216,7 +216,9 @@ class FAQBotAgent(AgentBase):
             },
         },
     )
-    def search_faqs(self, args, raw_data):
+    def search_faqs(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """
         Search for FAQs matching a specific query or category
 
@@ -269,7 +271,11 @@ class FAQBotAgent(AgentBase):
             return FunctionResult(result_text)
         return FunctionResult("No matching FAQs found.")
 
-    def on_summary(self, summary, raw_data=None):
+    def on_summary(
+        self,
+        summary: dict[str, Any] | None,
+        raw_data: dict[str, Any] | None = None,
+    ) -> None:
         """
         Process the interaction summary
 

--- a/signalwire/signalwire/prefabs/info_gatherer.py
+++ b/signalwire/signalwire/prefabs/info_gatherer.py
@@ -13,6 +13,7 @@ by a callback function) configuration modes.
 """
 
 from collections.abc import Callable
+from typing import Any
 
 from signalwire.core.agent_base import AgentBase
 from signalwire.core.function_result import FunctionResult
@@ -42,8 +43,8 @@ class InfoGathererAgent(AgentBase):
         questions: list[dict[str, str]] | None = None,
         name: str = "info_gatherer",
         route: str = "/info_gatherer",
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize an information gathering agent
 
@@ -63,7 +64,11 @@ class InfoGathererAgent(AgentBase):
         # Store whether we're in static or dynamic mode
         self._static_questions = questions
         self._question_callback: (
-            Callable[[dict, dict, dict], list[dict[str, str]]] | None
+            Callable[
+                [dict[str, Any], dict[str, Any], dict[str, Any]],
+                list[dict[str, str]],
+            ]
+            | None
         ) = None
 
         if questions is not None:
@@ -83,8 +88,11 @@ class InfoGathererAgent(AgentBase):
         self._configure_agent_settings()
 
     def set_question_callback(
-        self, callback: Callable[[dict, dict, dict], list[dict[str, str]]]
-    ):
+        self,
+        callback: Callable[
+            [dict[str, Any], dict[str, Any], dict[str, Any]], list[dict[str, str]]
+        ],
+    ) -> None:
         """
         Set a callback function for dynamic question configuration
 
@@ -110,7 +118,7 @@ class InfoGathererAgent(AgentBase):
         """
         self._question_callback = callback
 
-    def _validate_questions(self, questions):
+    def _validate_questions(self, questions: list[dict[str, str]]) -> None:
         """Validate that questions are in the correct format"""
         if not questions:
             raise ValueError("At least one question is required")
@@ -126,7 +134,7 @@ class InfoGathererAgent(AgentBase):
             if "question_text" not in question:
                 raise ValueError(f"Question {i + 1} is missing 'question_text' field")
 
-    def _build_prompt(self, mode="static"):
+    def _build_prompt(self, mode: str = "static") -> None:
         """Build a minimal prompt with just the objective"""
         if mode == "dynamic":
             # Generic prompt for dynamic mode - will be customized later
@@ -141,7 +149,7 @@ class InfoGathererAgent(AgentBase):
                 body="Your role is to get answers to a series of questions. Begin by asking the user if they are ready to answer some questions. If they confirm they are ready, call the start_questions function to begin the process.",
             )
 
-    def _configure_agent_settings(self):
+    def _configure_agent_settings(self) -> None:
         """Configure additional agent settings"""
         # Set AI behavior parameters
         self.set_params(
@@ -151,7 +159,12 @@ class InfoGathererAgent(AgentBase):
             }
         )
 
-    def on_swml_request(self, request_data=None, callback_path=None, request=None):
+    def on_swml_request(
+        self,
+        request_data: dict[str, Any] | None = None,
+        callback_path: str | None = None,
+        request: Any = None,
+    ) -> dict[str, Any] | None:
         """
         Handle dynamic configuration using the callback function
 
@@ -263,7 +276,9 @@ class InfoGathererAgent(AgentBase):
         description="Start the question sequence with the first question",
         parameters={},
     )
-    def start_questions(self, args, raw_data):
+    def start_questions(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """
         Start the question sequence by retrieving the first question
 
@@ -306,7 +321,9 @@ class InfoGathererAgent(AgentBase):
             }
         },
     )
-    def submit_answer(self, args, raw_data):
+    def submit_answer(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """
         Submit an answer to the current question and move to the next one
 

--- a/signalwire/signalwire/prefabs/receptionist.py
+++ b/signalwire/signalwire/prefabs/receptionist.py
@@ -9,6 +9,8 @@ See LICENSE file in the project root for full license information.
 ReceptionistAgent - Prefab agent for greeting callers and transferring them to appropriate departments
 """
 
+from typing import Any
+
 from signalwire.core.agent_base import AgentBase
 from signalwire.core.function_result import FunctionResult
 
@@ -36,8 +38,8 @@ class ReceptionistAgent(AgentBase):
         route: str = "/receptionist",
         greeting: str = "Thank you for calling. How can I help you today?",
         voice: str = "rime.spore",
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize a receptionist agent
 
@@ -73,7 +75,7 @@ class ReceptionistAgent(AgentBase):
         # Register tools
         self._register_tools()
 
-    def _validate_departments(self, departments):
+    def _validate_departments(self, departments: list[dict[str, str]]) -> None:
         """Validate that departments are in the correct format"""
         if not departments:
             raise ValueError("At least one department is required")
@@ -86,7 +88,7 @@ class ReceptionistAgent(AgentBase):
             if "number" not in dept:
                 raise ValueError(f"Department {i + 1} is missing 'number' field")
 
-    def _build_prompt(self):
+    def _build_prompt(self) -> None:
         """Build the agent's prompt with personality, goals, and instructions"""
 
         # Set personality
@@ -136,7 +138,7 @@ class ReceptionistAgent(AgentBase):
         }
         """)
 
-    def _configure_agent_settings(self, voice):
+    def _configure_agent_settings(self, voice: str) -> None:
         """Configure additional agent settings"""
 
         # Set AI behavior parameters
@@ -151,7 +153,7 @@ class ReceptionistAgent(AgentBase):
         # Set language with specified voice
         self.add_language(name="English", code="en-US", voice=voice)
 
-    def _register_tools(self):
+    def _register_tools(self) -> None:
         """Register the tools this agent needs"""
 
         # Define collect_caller_info tool
@@ -184,7 +186,9 @@ class ReceptionistAgent(AgentBase):
             handler=self._transfer_call_handler,
         )
 
-    def _collect_caller_info_handler(self, args, raw_data):
+    def _collect_caller_info_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handler for collect_caller_info tool"""
 
         # Get the caller info
@@ -203,7 +207,9 @@ class ReceptionistAgent(AgentBase):
 
         return result
 
-    def _transfer_call_handler(self, args, raw_data):
+    def _transfer_call_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handler for transfer_call tool"""
 
         # Get the department
@@ -248,7 +254,11 @@ class ReceptionistAgent(AgentBase):
 
         return result
 
-    def on_summary(self, summary, raw_data=None):
+    def on_summary(
+        self,
+        summary: dict[str, Any] | None,
+        raw_data: dict[str, Any] | None = None,
+    ) -> None:
         """
         Process the conversation summary
 

--- a/signalwire/signalwire/prefabs/survey.py
+++ b/signalwire/signalwire/prefabs/survey.py
@@ -58,8 +58,8 @@ class SurveyAgent(AgentBase):
         max_retries: int = 2,
         name: str = "survey",
         route: str = "/survey",
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize a survey agent
 
@@ -105,7 +105,7 @@ class SurveyAgent(AgentBase):
         # Set up the agent's configuration
         self._setup_survey_agent()
 
-    def _validate_questions(self):
+    def _validate_questions(self) -> None:
         """Validate the question format and structure"""
         valid_types = ["rating", "multiple_choice", "yes_no", "open_ended"]
 
@@ -137,7 +137,7 @@ class SurveyAgent(AgentBase):
             if question["type"] == "rating" and "scale" not in question:
                 question["scale"] = 5  # Default to 5-point scale
 
-    def _setup_survey_agent(self):
+    def _setup_survey_agent(self) -> None:
         """Configure the survey agent with appropriate settings"""
         # Basic personality and instructions
         self.prompt_add_section(
@@ -257,7 +257,9 @@ class SurveyAgent(AgentBase):
             },
         },
     )
-    def validate_response(self, args, raw_data):
+    def validate_response(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """
         Validate if a response meets the requirements for a specific question
 
@@ -319,7 +321,9 @@ class SurveyAgent(AgentBase):
             },
         },
     )
-    def log_response(self, args, raw_data):
+    def log_response(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """
         Log a validated response to a survey question
 
@@ -341,7 +345,11 @@ class SurveyAgent(AgentBase):
 
         return FunctionResult(message)
 
-    def on_summary(self, summary, raw_data=None):
+    def on_summary(
+        self,
+        summary: dict[str, Any] | None,
+        raw_data: dict[str, Any] | None = None,
+    ) -> None:
         """
         Process the survey results summary
 

--- a/signalwire/signalwire/relay/call.py
+++ b/signalwire/signalwire/relay/call.py
@@ -1262,7 +1262,9 @@ class Call:
         params.update(kwargs)
         return await self._execute("join_conference", params)
 
-    async def leave_conference(self, conference_id: str, **kwargs: Any) -> dict[str, Any]:
+    async def leave_conference(
+        self, conference_id: str, **kwargs: Any
+    ) -> dict[str, Any]:
         """Leave an audio conference."""
         params: dict[str, Any] = {"conference_id": conference_id}
         params.update(kwargs)

--- a/signalwire/signalwire/relay/call.py
+++ b/signalwire/signalwire/relay/call.py
@@ -130,16 +130,16 @@ class PlayAction(Action):
             call, control_id, EVENT_CALL_PLAY, (PLAY_STATE_FINISHED, PLAY_STATE_ERROR)
         )
 
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         return await self.call._execute("play.stop", {"control_id": self.control_id})
 
-    async def pause(self) -> dict:
+    async def pause(self) -> dict[str, Any]:
         return await self.call._execute("play.pause", {"control_id": self.control_id})
 
-    async def resume(self) -> dict:
+    async def resume(self) -> dict[str, Any]:
         return await self.call._execute("play.resume", {"control_id": self.control_id})
 
-    async def volume(self, volume: float) -> dict:
+    async def volume(self, volume: float) -> dict[str, Any]:
         return await self.call._execute(
             "play.volume",
             {
@@ -160,16 +160,16 @@ class RecordAction(Action):
             (RECORD_STATE_FINISHED, RECORD_STATE_NO_INPUT),
         )
 
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         return await self.call._execute("record.stop", {"control_id": self.control_id})
 
-    async def pause(self, behavior: str | None = None) -> dict:
+    async def pause(self, behavior: str | None = None) -> dict[str, Any]:
         params: dict[str, Any] = {"control_id": self.control_id}
         if behavior:
             params["behavior"] = behavior
         return await self.call._execute("record.pause", params)
 
-    async def resume(self) -> dict:
+    async def resume(self) -> dict[str, Any]:
         return await self.call._execute(
             "record.resume", {"control_id": self.control_id}
         )
@@ -189,7 +189,7 @@ class DetectAction(Action):
         if (detect or state in self._terminal_states) and not self._done.done():
             self._resolve(event)
 
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         return await self.call._execute("detect.stop", {"control_id": self.control_id})
 
 
@@ -215,12 +215,12 @@ class CollectAction(Action):
         else:
             super()._check_event(event)
 
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         return await self.call._execute(
             "play_and_collect.stop", {"control_id": self.control_id}
         )
 
-    async def volume(self, volume: float) -> dict:
+    async def volume(self, volume: float) -> dict[str, Any]:
         return await self.call._execute(
             "play_and_collect.volume",
             {
@@ -229,7 +229,7 @@ class CollectAction(Action):
             },
         )
 
-    async def start_input_timers(self) -> dict:
+    async def start_input_timers(self) -> dict[str, Any]:
         """Start the initial_timeout timer on an active collect."""
         return await self.call._execute(
             "collect.start_input_timers", {"control_id": self.control_id}
@@ -255,10 +255,10 @@ class StandaloneCollectAction(Action):
         if (result or state in self._terminal_states) and not self._done.done():
             self._resolve(event)
 
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         return await self.call._execute("collect.stop", {"control_id": self.control_id})
 
-    async def start_input_timers(self) -> dict:
+    async def start_input_timers(self) -> dict[str, Any]:
         """Start the initial_timeout timer on an active collect."""
         return await self.call._execute(
             "collect.start_input_timers", {"control_id": self.control_id}
@@ -272,7 +272,7 @@ class FaxAction(Action):
         super().__init__(call, control_id, EVENT_CALL_FAX, ("finished", "error"))
         self._method_prefix = method_prefix
 
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         return await self.call._execute(
             f"{self._method_prefix}.stop", {"control_id": self.control_id}
         )
@@ -284,7 +284,7 @@ class TapAction(Action):
     def __init__(self, call: Call, control_id: str):
         super().__init__(call, control_id, EVENT_CALL_TAP, ("finished",))
 
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         return await self.call._execute("tap.stop", {"control_id": self.control_id})
 
 
@@ -294,7 +294,7 @@ class StreamAction(Action):
     def __init__(self, call: Call, control_id: str):
         super().__init__(call, control_id, EVENT_CALL_STREAM, ("finished",))
 
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         return await self.call._execute("stream.stop", {"control_id": self.control_id})
 
 
@@ -304,7 +304,7 @@ class PayAction(Action):
     def __init__(self, call: Call, control_id: str):
         super().__init__(call, control_id, EVENT_CALL_PAY, ("finished", "error"))
 
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         return await self.call._execute("pay.stop", {"control_id": self.control_id})
 
 
@@ -314,7 +314,7 @@ class TranscribeAction(Action):
     def __init__(self, call: Call, control_id: str):
         super().__init__(call, control_id, EVENT_CALL_TRANSCRIBE, ("finished",))
 
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         return await self.call._execute(
             "transcribe.stop", {"control_id": self.control_id}
         )
@@ -329,7 +329,7 @@ class AIAction(Action):
         # and "error" as terminal states from calling.call.ai events if any.
         super().__init__(call, control_id, "calling.call.ai", ("finished", "error"))
 
-    async def stop(self) -> dict:
+    async def stop(self) -> dict[str, Any]:
         return await self.call._execute("ai.stop", {"control_id": self.control_id})
 
 
@@ -385,7 +385,7 @@ class Call:
 
     async def _execute(
         self, method: str, extra_params: dict[str, Any] | None = None
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Send a ``calling.<method>`` JSON-RPC request for this call.
 
         The outer JSON-RPC method is ``"calling.<method>"`` (e.g.
@@ -536,15 +536,15 @@ class Call:
     # Call lifecycle methods
     # ------------------------------------------------------------------
 
-    async def answer(self, **kwargs: Any) -> dict:
+    async def answer(self, **kwargs: Any) -> dict[str, Any]:
         """Answer an inbound call."""
         return await self._execute("answer", kwargs or None)
 
-    async def hangup(self, reason: str = "hangup") -> dict:
+    async def hangup(self, reason: str = "hangup") -> dict[str, Any]:
         """End/hang up the call."""
         return await self._execute("end", {"reason": reason})
 
-    async def pass_(self) -> dict:
+    async def pass_(self) -> dict[str, Any]:
         """Decline control of an inbound call, returning it to routing."""
         return await self._execute("pass")
 
@@ -904,7 +904,7 @@ class Call:
         max_price_per_minute: float | None = None,
         status_url: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Bridge the call to one or more destinations."""
         params: dict[str, Any] = {"devices": devices}
         if ringback is not None:
@@ -920,7 +920,7 @@ class Call:
         params.update(kwargs)
         return await self._execute("connect", params)
 
-    async def disconnect(self) -> dict:
+    async def disconnect(self) -> dict[str, Any]:
         """Disconnect (unbridge) a connected call."""
         return await self._execute("disconnect")
 
@@ -933,7 +933,7 @@ class Call:
         digits: str,
         *,
         control_id: str | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Send DTMF digits on the call."""
         cid = control_id or str(uuid.uuid4())
         return await self._execute(
@@ -978,7 +978,7 @@ class Call:
         *,
         status_url: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Transfer a SIP call to an external SIP endpoint via REFER."""
         params: dict[str, Any] = {"device": device}
         if status_url is not None:
@@ -1180,7 +1180,7 @@ class Call:
         self,
         dest: str,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Transfer call control to another RELAY app or SWML script."""
         params: dict[str, Any] = {"dest": dest}
         params.update(kwargs)
@@ -1214,7 +1214,7 @@ class Call:
         recording_status_callback_method: str | None = None,
         stream_obj: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Join an ad-hoc audio conference."""
         params: dict[str, Any] = {"name": name}
         if muted is not None:
@@ -1262,7 +1262,7 @@ class Call:
         params.update(kwargs)
         return await self._execute("join_conference", params)
 
-    async def leave_conference(self, conference_id: str, **kwargs: Any) -> dict:
+    async def leave_conference(self, conference_id: str, **kwargs: Any) -> dict[str, Any]:
         """Leave an audio conference."""
         params: dict[str, Any] = {"conference_id": conference_id}
         params.update(kwargs)
@@ -1272,11 +1272,11 @@ class Call:
     # Hold / Unhold
     # ------------------------------------------------------------------
 
-    async def hold(self) -> dict:
+    async def hold(self) -> dict[str, Any]:
         """Put the call on hold."""
         return await self._execute("hold")
 
-    async def unhold(self) -> dict:
+    async def unhold(self) -> dict[str, Any]:
         """Release the call from hold."""
         return await self._execute("unhold")
 
@@ -1284,11 +1284,11 @@ class Call:
     # Denoise
     # ------------------------------------------------------------------
 
-    async def denoise(self) -> dict:
+    async def denoise(self) -> dict[str, Any]:
         """Start noise reduction on the call."""
         return await self._execute("denoise")
 
-    async def denoise_stop(self) -> dict:
+    async def denoise_stop(self) -> dict[str, Any]:
         """Stop noise reduction on the call."""
         return await self._execute("denoise.stop")
 
@@ -1325,7 +1325,7 @@ class Call:
         timeout: float | None = None,
         status_url: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Echo audio back to the caller (useful for testing)."""
         params: dict[str, Any] = {}
         if timeout is not None:
@@ -1348,7 +1348,7 @@ class Call:
         realm: str | None = None,
         max_triggers: int | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Bind a DTMF digit sequence to trigger a RELAY method."""
         params: dict[str, Any] = {
             "digits": digits,
@@ -1368,7 +1368,7 @@ class Call:
         *,
         realm: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Clear all digit bindings, optionally filtered by realm."""
         params: dict[str, Any] = {}
         if realm is not None:
@@ -1384,7 +1384,7 @@ class Call:
         self,
         action: dict[str, Any],
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Start or stop live transcription on the call."""
         params: dict[str, Any] = {"action": action}
         params.update(kwargs)
@@ -1396,7 +1396,7 @@ class Call:
         *,
         status_url: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Start or stop live translation on the call."""
         params: dict[str, Any] = {"action": action}
         if status_url is not None:
@@ -1414,7 +1414,7 @@ class Call:
         *,
         status_url: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Join a video/audio room."""
         params: dict[str, Any] = {"name": name}
         if status_url is not None:
@@ -1422,7 +1422,7 @@ class Call:
         params.update(kwargs)
         return await self._execute("join_room", params)
 
-    async def leave_room(self, **kwargs: Any) -> dict:
+    async def leave_room(self, **kwargs: Any) -> dict[str, Any]:
         """Leave the current room."""
         return await self._execute("leave_room", kwargs or None)
 
@@ -1490,7 +1490,7 @@ class Call:
         post_prompt: dict[str, Any] | None = None,
         post_prompt_url: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Connect to an Amazon Bedrock AI agent."""
         params: dict[str, Any] = {}
         if prompt is not None:
@@ -1516,7 +1516,7 @@ class Call:
         reset: dict[str, Any] | None = None,
         global_data: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Send a message to an active AI agent session."""
         params: dict[str, Any] = {}
         if message_text is not None:
@@ -1536,7 +1536,7 @@ class Call:
         timeout: str | None = None,
         prompt: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Put an AI agent session on hold."""
         params: dict[str, Any] = {}
         if timeout is not None:
@@ -1551,7 +1551,7 @@ class Call:
         *,
         prompt: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Resume an AI agent session from hold."""
         params: dict[str, Any] = {}
         if prompt is not None:
@@ -1568,7 +1568,7 @@ class Call:
         *,
         event: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Send a custom user-defined event."""
         params: dict[str, Any] = {}
         if event is not None:
@@ -1587,7 +1587,7 @@ class Call:
         control_id: str | None = None,
         status_url: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Place the call in a queue."""
         cid = control_id or str(uuid.uuid4())
         params: dict[str, Any] = {
@@ -1607,7 +1607,7 @@ class Call:
         queue_id: str | None = None,
         status_url: str | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Remove the call from a queue."""
         cid = control_id or str(uuid.uuid4())
         params: dict[str, Any] = {

--- a/signalwire/signalwire/relay/client.py
+++ b/signalwire/signalwire/relay/client.py
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
     # not exported on the top-level package for mypy.
     from websockets.asyncio.client import ClientConnection
 
+    from .event import RelayEvent
+
 from signalwire.core.logging_config import get_logger
 
 from .call import Call
@@ -159,7 +161,7 @@ class RelayClient:
 
         # Internal state
         self._ws: ClientConnection | None = None
-        self._pending: dict[str, asyncio.Future[dict]] = {}
+        self._pending: dict[str, asyncio.Future[dict[str, Any]]] = {}
         # Track the method for each pending request (for code-checking decisions)
         self._pending_methods: dict[str, str] = {}
         self._calls: dict[str, Call] = {}
@@ -174,8 +176,8 @@ class RelayClient:
         self._connected = False
         self._closing = False
         self._reconnect_delay = RECONNECT_MIN_DELAY
-        self._recv_task: asyncio.Task | None = None
-        self._ping_task: asyncio.Task | None = None
+        self._recv_task: asyncio.Task[None] | None = None
+        self._ping_task: asyncio.Task[None] | None = None
         # Strong references to fire-and-forget background tasks (queued sends,
         # inbound call/message handler dispatch, ws close). asyncio only keeps
         # a weak reference to a running task, so without this the task could be
@@ -200,7 +202,9 @@ class RelayClient:
         # Track consecutive client ping failures for exponential backoff
         self._ping_failures: int = 0
         # Queue for requests made while disconnected/reconnecting
-        self._execute_queue: list[tuple[dict, asyncio.Future[dict]]] = []
+        self._execute_queue: list[
+            tuple[dict[str, Any], asyncio.Future[dict[str, Any]]]
+        ] = []
 
     def __del__(self) -> None:
         _active_clients.discard(id(self))
@@ -371,7 +375,7 @@ class RelayClient:
     # Public RPC interface
     # ------------------------------------------------------------------
 
-    async def execute(self, method: str, params: dict[str, Any]) -> dict:
+    async def execute(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         """Send a JSON-RPC request and await the response.
 
         For calling methods, ``method`` is the full name (e.g.
@@ -457,7 +461,7 @@ class RelayClient:
         media: list[str] | None = None,
         tags: list[str] | None = None,
         region: str | None = None,
-        on_completed: Callable | None = None,
+        on_completed: Callable[[RelayEvent], Any] | None = None,
     ) -> Message:
         """Send an outbound SMS/MMS message.
 
@@ -619,7 +623,9 @@ class RelayClient:
     # Internal: send / receive
     # ------------------------------------------------------------------
 
-    async def _send_request(self, method: str, params: dict[str, Any]) -> dict:
+    async def _send_request(
+        self, method: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
         """Send a JSON-RPC 2.0 request and return the result.
 
         If not connected, queues the request for later delivery.
@@ -634,7 +640,7 @@ class RelayClient:
         }
 
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[dict] = loop.create_future()
+        future: asyncio.Future[dict[str, Any]] = loop.create_future()
         self._pending[req_id] = future
         self._pending_methods[req_id] = method
 
@@ -679,7 +685,9 @@ class RelayClient:
             )
             self._spawn_bg(self._safe_send(raw, future))
 
-    async def _safe_send(self, raw: str, future: asyncio.Future) -> None:
+    async def _safe_send(
+        self, raw: str, future: asyncio.Future[dict[str, Any]]
+    ) -> None:
         """Send a queued message, rejecting its future on failure."""
         try:
             if self._ws:

--- a/signalwire/signalwire/relay/message.py
+++ b/signalwire/signalwire/relay/message.py
@@ -72,7 +72,7 @@ class Message:
             asyncio.get_event_loop().create_future()
         )
         self._on_completed: Callable[[RelayEvent], Any] | None = None
-        self._listeners: list[Callable] = []
+        self._listeners: list[Callable[[RelayEvent], Any]] = []
 
     @property
     def is_done(self) -> bool:
@@ -86,7 +86,7 @@ class Message:
             return self._done.result()
         return None
 
-    def on(self, handler: Callable) -> None:
+    def on(self, handler: Callable[[RelayEvent], Any]) -> None:
         """Register an event listener for state changes on this message."""
         self._listeners.append(handler)
 

--- a/signalwire/signalwire/rest/namespaces/phone_numbers.py
+++ b/signalwire/signalwire/rest/namespaces/phone_numbers.py
@@ -48,12 +48,15 @@ class PhoneNumbersResource(CrudResource):
         Your backend returns an SWML document per call. The server
         auto-creates a ``swml_webhook`` Fabric resource keyed off this URL.
         """
-        return cast(dict, self.update(
-            resource_id,
-            call_handler=PhoneCallHandler.RELAY_SCRIPT.value,
-            call_relay_script_url=url,
-            **extra,
-        ))
+        return cast(
+            dict,
+            self.update(
+                resource_id,
+                call_handler=PhoneCallHandler.RELAY_SCRIPT.value,
+                call_relay_script_url=url,
+                **extra,
+            ),
+        )
 
     def set_cxml_webhook(
         self,
@@ -85,21 +88,27 @@ class PhoneNumbersResource(CrudResource):
         self, resource_id: str, application_id: str, **extra
     ) -> dict:
         """Route inbound calls to an existing cXML application by ID."""
-        return cast(dict, self.update(
-            resource_id,
-            call_handler=PhoneCallHandler.LAML_APPLICATION.value,
-            call_laml_application_id=application_id,
-            **extra,
-        ))
+        return cast(
+            dict,
+            self.update(
+                resource_id,
+                call_handler=PhoneCallHandler.LAML_APPLICATION.value,
+                call_laml_application_id=application_id,
+                **extra,
+            ),
+        )
 
     def set_ai_agent(self, resource_id: str, agent_id: str, **extra) -> dict:
         """Route inbound calls to an AI Agent Fabric resource by ID."""
-        return cast(dict, self.update(
-            resource_id,
-            call_handler=PhoneCallHandler.AI_AGENT.value,
-            call_ai_agent_id=agent_id,
-            **extra,
-        ))
+        return cast(
+            dict,
+            self.update(
+                resource_id,
+                call_handler=PhoneCallHandler.AI_AGENT.value,
+                call_ai_agent_id=agent_id,
+                **extra,
+            ),
+        )
 
     def set_call_flow(
         self,
@@ -124,12 +133,15 @@ class PhoneNumbersResource(CrudResource):
 
     def set_relay_application(self, resource_id: str, name: str, **extra) -> dict:
         """Route inbound calls to a named RELAY application."""
-        return cast(dict, self.update(
-            resource_id,
-            call_handler=PhoneCallHandler.RELAY_APPLICATION.value,
-            call_relay_application=name,
-            **extra,
-        ))
+        return cast(
+            dict,
+            self.update(
+                resource_id,
+                call_handler=PhoneCallHandler.RELAY_APPLICATION.value,
+                call_relay_application=name,
+                **extra,
+            ),
+        )
 
     def set_relay_topic(
         self,

--- a/signalwire/signalwire/rest/namespaces/phone_numbers.py
+++ b/signalwire/signalwire/rest/namespaces/phone_numbers.py
@@ -9,6 +9,8 @@ See LICENSE file in the project root for full license information.
 Phone Numbers namespace — list, search, purchase, get, update, release, bind.
 """
 
+from typing import cast
+
 from .._base import CrudResource
 from ..call_handler import PhoneCallHandler
 
@@ -46,12 +48,12 @@ class PhoneNumbersResource(CrudResource):
         Your backend returns an SWML document per call. The server
         auto-creates a ``swml_webhook`` Fabric resource keyed off this URL.
         """
-        return self.update(
+        return cast(dict, self.update(
             resource_id,
             call_handler=PhoneCallHandler.RELAY_SCRIPT.value,
             call_relay_script_url=url,
             **extra,
-        )
+        ))
 
     def set_cxml_webhook(
         self,
@@ -77,27 +79,27 @@ class PhoneNumbersResource(CrudResource):
         if status_callback_url is not None:
             body["call_status_callback_url"] = status_callback_url
         body.update(extra)
-        return self.update(resource_id, **body)
+        return cast(dict, self.update(resource_id, **body))
 
     def set_cxml_application(
         self, resource_id: str, application_id: str, **extra
     ) -> dict:
         """Route inbound calls to an existing cXML application by ID."""
-        return self.update(
+        return cast(dict, self.update(
             resource_id,
             call_handler=PhoneCallHandler.LAML_APPLICATION.value,
             call_laml_application_id=application_id,
             **extra,
-        )
+        ))
 
     def set_ai_agent(self, resource_id: str, agent_id: str, **extra) -> dict:
         """Route inbound calls to an AI Agent Fabric resource by ID."""
-        return self.update(
+        return cast(dict, self.update(
             resource_id,
             call_handler=PhoneCallHandler.AI_AGENT.value,
             call_ai_agent_id=agent_id,
             **extra,
-        )
+        ))
 
     def set_call_flow(
         self,
@@ -118,16 +120,16 @@ class PhoneNumbersResource(CrudResource):
         if version is not None:
             body["call_flow_version"] = version
         body.update(extra)
-        return self.update(resource_id, **body)
+        return cast(dict, self.update(resource_id, **body))
 
     def set_relay_application(self, resource_id: str, name: str, **extra) -> dict:
         """Route inbound calls to a named RELAY application."""
-        return self.update(
+        return cast(dict, self.update(
             resource_id,
             call_handler=PhoneCallHandler.RELAY_APPLICATION.value,
             call_relay_application=name,
             **extra,
-        )
+        ))
 
     def set_relay_topic(
         self,
@@ -144,4 +146,4 @@ class PhoneNumbersResource(CrudResource):
         if status_callback_url is not None:
             body["call_relay_topic_status_callback_url"] = status_callback_url
         body.update(extra)
-        return self.update(resource_id, **body)
+        return cast(dict, self.update(resource_id, **body))

--- a/signalwire/signalwire/search/__init__.py
+++ b/signalwire/signalwire/search/__init__.py
@@ -51,7 +51,7 @@ except ImportError:
     _MISSING_DEPS.append("nltk")
 
 
-def _check_search_dependencies():
+def _check_search_dependencies() -> None:
     """Check if search dependencies are available and provide helpful error message"""
     if not _SEARCH_AVAILABLE:
         missing = ", ".join(_MISSING_DEPS)

--- a/signalwire/signalwire/search/document_processor.py
+++ b/signalwire/signalwire/search/document_processor.py
@@ -9,7 +9,7 @@ See LICENSE file in the project root for full license information.
 
 import re
 import json
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, cast
 from pathlib import Path
 
 # Document processing imports
@@ -257,7 +257,7 @@ class DocumentProcessor:
             return self._extract_powerpoint(file_path)
         return json.dumps({"error": f"Unsupported file type: {file_type}"})
 
-    def _extract_pdf(self, file_path: str):
+    def _extract_pdf(self, file_path: str) -> Any:
         """Extract text from PDF files"""
         if not pdfplumber:
             return json.dumps({"error": "pdfplumber not available for PDF processing"})
@@ -275,7 +275,7 @@ class DocumentProcessor:
         except Exception as e:
             return json.dumps({"error": f"Error processing PDF: {e}"})
 
-    def _extract_docx(self, file_path: str):
+    def _extract_docx(self, file_path: str) -> Any:
         """Extract text from DOCX files"""
         if DocxDocument is None:
             return json.dumps(
@@ -288,7 +288,7 @@ class DocumentProcessor:
         except Exception as e:
             return json.dumps({"error": f"Error processing DOCX: {e}"})
 
-    def _extract_text(self, file_path: str):
+    def _extract_text(self, file_path: str) -> str:
         """Extract text from plain text files"""
         try:
             with open(  # noqa: PTH123  # tests patch builtins.open; Path.open() would bypass the mock seam
@@ -298,7 +298,7 @@ class DocumentProcessor:
         except Exception as e:
             return json.dumps({"error": f"Error processing TXT: {e}"})
 
-    def _extract_html(self, file_path: str):
+    def _extract_html(self, file_path: str) -> str:
         """Extract text from HTML files"""
         if BeautifulSoup is None:
             return json.dumps(
@@ -310,11 +310,12 @@ class DocumentProcessor:
                 file_path, encoding="utf-8"
             ) as file:
                 soup = BeautifulSoup(file, "html.parser")
-                return soup.get_text(separator="\n")
+                # bs4 is untyped (ignore_missing_imports); get_text() returns str.
+                return cast(str, soup.get_text(separator="\n"))
         except Exception as e:
             return json.dumps({"error": f"Error processing HTML: {e}"})
 
-    def _extract_markdown(self, file_path: str):
+    def _extract_markdown(self, file_path: str) -> str:
         """Extract text from Markdown files"""
         try:
             with open(  # noqa: PTH123  # tests patch builtins.open; Path.open() would bypass the mock seam
@@ -324,13 +325,13 @@ class DocumentProcessor:
                 if markdown is not None and BeautifulSoup is not None:
                     html = markdown.markdown(content)
                     soup = BeautifulSoup(html, "html.parser")
-                    return soup.get_text(separator="\n")
+                    return cast(str, soup.get_text(separator="\n"))
                 # Fallback to raw markdown
                 return content
         except Exception as e:
             return json.dumps({"error": f"Error processing Markdown: {e}"})
 
-    def _extract_rtf(self, file_path: str):
+    def _extract_rtf(self, file_path: str) -> str:
         """Extract text from RTF files"""
         if not rtf_to_text:
             return json.dumps({"error": "striprtf not available for RTF processing"})
@@ -339,11 +340,12 @@ class DocumentProcessor:
             with open(  # noqa: PTH123  # tests patch builtins.open; Path.open() would bypass the mock seam
                 file_path, encoding="utf-8"
             ) as file:
-                return rtf_to_text(file.read())
+                # striprtf is untyped; rtf_to_text() returns the extracted str.
+                return cast(str, rtf_to_text(file.read()))
         except Exception as e:
             return json.dumps({"error": f"Error processing RTF: {e}"})
 
-    def _extract_excel(self, file_path: str):
+    def _extract_excel(self, file_path: str) -> str:
         """Extract text from Excel files"""
         if not load_workbook:
             return json.dumps({"error": "openpyxl not available for Excel processing"})
@@ -359,7 +361,7 @@ class DocumentProcessor:
         except Exception as e:
             return json.dumps({"error": f"Error processing Excel: {e}"})
 
-    def _extract_powerpoint(self, file_path: str):
+    def _extract_powerpoint(self, file_path: str) -> Any:
         """Extract text from PowerPoint files"""
         if not Presentation:
             return json.dumps(
@@ -503,7 +505,7 @@ class DocumentProcessor:
         current_code_langs: list[str] = []
         current_has_code = False
 
-        def flush():
+        def flush() -> None:
             nonlocal current_lines, current_start_line, current_end_line
             nonlocal \
                 current_size, \
@@ -608,7 +610,7 @@ class DocumentProcessor:
             "has_code": False,
         }
 
-    def _leaf_md_block(self, tok, lines: list[str]) -> dict[str, Any]:
+    def _leaf_md_block(self, tok: Any, lines: list[str]) -> dict[str, Any]:
         """Turn a leaf (fence, code_block, hr, html_block) token into a block."""
         start, end = tok.map
         source_lines = lines[start:end]

--- a/signalwire/signalwire/search/index_builder.py
+++ b/signalwire/signalwire/search/index_builder.py
@@ -161,7 +161,7 @@ class IndexBuilder:
 
         return metadata_dict, metadata_text
 
-    def _load_model(self):
+    def _load_model(self) -> None:
         """Load embedding model (lazy loading)"""
         if self.model is None:
             if not SentenceTransformer:
@@ -187,7 +187,7 @@ class IndexBuilder:
         languages: list[str] | None = None,
         tags: list[str] | None = None,
         overwrite: bool = False,
-    ):
+    ) -> None:
         """
         Build complete search index from multiple sources (files and directories)
 
@@ -321,7 +321,7 @@ class IndexBuilder:
         exclude_patterns: list[str] | None = None,
         languages: list[str] | None = None,
         tags: list[str] | None = None,
-    ):
+    ) -> None:
         """
         Build complete search index from a single directory
 
@@ -599,7 +599,7 @@ class IndexBuilder:
         languages: list[str],
         sources_info: list[str],
         file_types: list[str],
-    ):
+    ) -> None:
         """Create SQLite database with all data"""
 
         # Remove existing file
@@ -822,7 +822,7 @@ class IndexBuilder:
         collection_name: str,
         languages: list[str],
         overwrite: bool = False,
-    ):
+    ) -> None:
         """
         Store chunks in pgvector backend
 

--- a/signalwire/signalwire/search/pgvector_backend.py
+++ b/signalwire/signalwire/search/pgvector_backend.py
@@ -64,7 +64,7 @@ class PgVectorBackend:
         self.conn: Any = None
         self._connect()
 
-    def _connect(self):
+    def _connect(self) -> None:
         """Establish database connection"""
         try:
             self.conn = psycopg2.connect(self.connection_string)
@@ -81,12 +81,12 @@ class PgVectorBackend:
                 logger.error(f"Failed to connect to database: {e}")
             raise
 
-    def _ensure_connection(self):
+    def _ensure_connection(self) -> None:
         """Ensure database connection is active"""
         if self.conn is None or self.conn.closed:
             self._connect()
 
-    def create_schema(self, collection_name: str, embedding_dim: int = 768):
+    def create_schema(self, collection_name: str, embedding_dim: int = 768) -> None:
         """
         Create database schema for a collection
 
@@ -232,7 +232,7 @@ class PgVectorBackend:
 
     def store_chunks(
         self, chunks: list[dict[str, Any]], collection_name: str, config: dict[str, Any]
-    ):
+    ) -> None:
         """
         Store document chunks in the database
 
@@ -427,7 +427,7 @@ class PgVectorBackend:
             )
             return [row[0] for row in cursor.fetchall()]
 
-    def delete_collection(self, collection_name: str):
+    def delete_collection(self, collection_name: str) -> None:
         """Delete a collection and its data"""
         self._ensure_connection()
 
@@ -448,7 +448,7 @@ class PgVectorBackend:
             self.conn.commit()
             logger.info(f"Deleted collection '{collection_name}'")
 
-    def close(self):
+    def close(self) -> None:
         """Close database connection"""
         if self.conn and not self.conn.closed:
             self.conn.close()
@@ -480,7 +480,7 @@ class PgVectorSearchBackend:
         self._connect()
         self.config = self._load_config()
 
-    def _connect(self):
+    def _connect(self) -> None:
         """Establish database connection.
 
         Autocommit is enabled because this backend is read-only — all methods
@@ -498,7 +498,7 @@ class PgVectorSearchBackend:
             logger.error(f"Failed to connect to database: {e}")
             raise
 
-    def _ensure_connection(self):
+    def _ensure_connection(self) -> None:
         """Ensure database connection is active"""
         if self.conn is None or self.conn.closed:
             self._connect()
@@ -1145,7 +1145,7 @@ class PgVectorSearchBackend:
         backend.close()
         return stats
 
-    def close(self):
+    def close(self) -> None:
         """Close database connection"""
         if self.conn and not self.conn.closed:
             self.conn.close()

--- a/signalwire/signalwire/search/query_processor.py
+++ b/signalwire/signalwire/search/query_processor.py
@@ -190,7 +190,7 @@ def detect_language(text: str) -> str:
     return "en"
 
 
-def load_spacy_model(language: str):
+def load_spacy_model(language: str) -> Any:
     """
     Load spaCy model for the given language
     Returns None if spaCy is not available or model not found
@@ -236,7 +236,7 @@ _MAX_MODEL_CACHE_SIZE = 5
 _model_lock = threading.Lock()
 
 
-def set_global_model(model):
+def set_global_model(model: Any) -> None:
     """Legacy function - adds model to cache instead of setting globally"""
     if model:
         # Try to get model name from various attributes
@@ -257,7 +257,7 @@ def set_global_model(model):
             logger.info(f"Model added to cache: {model_name}")
 
 
-def _get_cached_model(model_name: str | None = None):
+def _get_cached_model(model_name: str | None = None) -> Any:
     """Get or create cached sentence transformer model
 
     Args:
@@ -303,7 +303,9 @@ def _get_cached_model(model_name: str | None = None):
             return None
 
 
-def vectorize_query(query: str, model=None, model_name: str | None = None):
+def vectorize_query(
+    query: str, model: Any = None, model_name: str | None = None
+) -> Any:
     """
     Vectorize query using sentence transformers
     Returns numpy array of embeddings
@@ -354,7 +356,7 @@ stopwords_language_map = {
 
 
 # Function to ensure NLTK resources are downloaded
-def ensure_nltk_resources():
+def ensure_nltk_resources() -> None:
     """Download required NLTK resources if not already present"""
     resources = [
         "punkt",
@@ -399,7 +401,7 @@ pos_mapping = {
 }
 
 
-def get_wordnet_pos(spacy_pos):
+def get_wordnet_pos(spacy_pos: Any) -> Any:
     """Map spaCy POS tags to WordNet POS tags."""
     return pos_mapping.get(spacy_pos, wn.NOUN)
 

--- a/signalwire/signalwire/search/search_engine.py
+++ b/signalwire/signalwire/search/search_engine.py
@@ -42,7 +42,7 @@ class SearchEngine:
         index_path: str | None = None,
         connection_string: str | None = None,
         collection_name: str | None = None,
-        model=None,
+        model: Any = None,
     ):
         """
         Initialize search engine
@@ -610,8 +610,8 @@ class SearchEngine:
 
     def _merge_results(
         self,
-        vector_results: list[dict],
-        keyword_results: list[dict],
+        vector_results: list[dict[str, Any]],
+        keyword_results: list[dict[str, Any]],
         vector_weight: float | None = None,
         keyword_weight: float | None = None,
     ) -> list[dict[str, Any]]:
@@ -662,7 +662,7 @@ class SearchEngine:
         return sorted(combined.values(), key=lambda x: x["score"], reverse=True)
 
     def _filter_by_tags(
-        self, results: list[dict], required_tags: list[str]
+        self, results: list[dict[str, Any]], required_tags: list[str]
     ) -> list[dict[str, Any]]:
         """Filter results by required tags"""
         filtered = []
@@ -1302,10 +1302,10 @@ class SearchEngine:
 
     def _add_vector_scores_to_candidates(
         self,
-        candidates: dict[str, dict],
+        candidates: dict[str, dict[str, Any]],
         query_vector: NDArray,
         similarity_threshold: float,
-    ):
+    ) -> None:
         """Add vector similarity scores to existing candidates"""
         if not candidates or not np:
             return
@@ -1362,7 +1362,7 @@ class SearchEngine:
                 conn.close()
 
     def _calculate_combined_score(
-        self, candidate: dict, similarity_threshold: float
+        self, candidate: dict[str, Any], similarity_threshold: float
     ) -> float:
         """Calculate final score using max-signal-wins approach.
 
@@ -1391,7 +1391,9 @@ class SearchEngine:
         boost = agreement_boost * (len(scores) - 1)
         return min(1.0, base + boost)
 
-    def _dedupe_by_content(self, results: list[dict]) -> list[dict]:
+    def _dedupe_by_content(
+        self, results: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         """Collapse exact/near-exact content duplicates, keeping the highest-scoring copy.
 
         Index quality varies: some source docs contain repeated boilerplate (footers,
@@ -1430,8 +1432,8 @@ class SearchEngine:
         return deduped
 
     def _apply_diversity_penalties(
-        self, results: list[dict], target_count: int
-    ) -> list[dict]:
+        self, results: list[dict[str, Any]], target_count: int
+    ) -> list[dict[str, Any]]:
         """Apply penalties to prevent single-file dominance while maintaining quality"""
         if not results:
             return results
@@ -1513,8 +1515,8 @@ class SearchEngine:
         return penalized_results
 
     def _apply_match_type_diversity(
-        self, results: list[dict], target_count: int
-    ) -> list[dict]:
+        self, results: list[dict[str, Any]], target_count: int
+    ) -> list[dict[str, Any]]:
         """Ensure diversity of match types in final results
 
         Ensures we have a mix of:

--- a/signalwire/signalwire/search/search_engine.py
+++ b/signalwire/signalwire/search/search_engine.py
@@ -1391,9 +1391,7 @@ class SearchEngine:
         boost = agreement_boost * (len(scores) - 1)
         return min(1.0, base + boost)
 
-    def _dedupe_by_content(
-        self, results: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+    def _dedupe_by_content(self, results: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Collapse exact/near-exact content duplicates, keeping the highest-scoring copy.
 
         Index quality varies: some source docs contain repeated boilerplate (footers,

--- a/signalwire/signalwire/search/search_engine.py
+++ b/signalwire/signalwire/search/search_engine.py
@@ -1373,8 +1373,9 @@ class SearchEngine:
         """
         agreement_boost = 0.1  # Boost per additional agreeing source
 
-        # Collect all available scores
-        scores = {}
+        # Collect all available scores. Typed dict[str, float] so the
+        # max()/arithmetic below yields a concrete float (candidate[...] is Any).
+        scores: dict[str, float] = {}
         if "vector_score" in candidate:
             scores["vector"] = candidate["vector_score"]
 

--- a/signalwire/signalwire/search/search_service.py
+++ b/signalwire/signalwire/search/search_service.py
@@ -138,7 +138,7 @@ class SearchService:
 
         self.search_engines: dict[str, SearchEngine] = {}
         self.model: Any = None
-        self._query_cache: dict[str, Any] = {}  # Simple query result cache
+        self._query_cache: dict[str, SearchResponse] = {}  # Simple query result cache
         self._cache_size = 100  # Max number of cached queries
 
         # Load security configuration with optional config file

--- a/signalwire/signalwire/search/search_service.py
+++ b/signalwire/signalwire/search/search_service.py
@@ -9,6 +9,7 @@ See LICENSE file in the project root for full license information.
 
 import hashlib
 import json
+from collections.abc import Awaitable, Callable
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -158,7 +159,7 @@ class SearchService:
 
         self._load_resources()
 
-    def _load_config(self, config_file: str | None):
+    def _load_config(self, config_file: str | None) -> None:
         """Load configuration from file if available"""
         # Initialize defaults
         self.indexes = {}
@@ -196,7 +197,7 @@ class SearchService:
             ):
                 self.indexes = service_config["indexes"]
 
-    def _setup_security(self):
+    def _setup_security(self) -> None:
         """Setup security middleware and authentication"""
         if not self.app:
             return
@@ -207,7 +208,9 @@ class SearchService:
 
         # Add security headers middleware
         @self.app.middleware("http")
-        async def add_security_headers(request: Request, call_next):
+        async def add_security_headers(
+            request: Request, call_next: Callable[[Request], Awaitable[Response]]
+        ) -> Response:
             response = await call_next(request)
 
             # Add security headers
@@ -220,7 +223,9 @@ class SearchService:
 
         # Add host validation middleware
         @self.app.middleware("http")
-        async def validate_host(request: Request, call_next):
+        async def validate_host(
+            request: Request, call_next: Callable[[Request], Awaitable[Response]]
+        ) -> Response:
             host = request.headers.get("host", "").split(":")[0]
             if host and not self.security.should_allow_host(host):
                 return Response(content="Invalid host", status_code=400)
@@ -255,7 +260,7 @@ class SearchService:
 
         return credentials.username
 
-    def _setup_routes(self):
+    def _setup_routes(self) -> None:
         """Setup FastAPI routes"""
         if not self.app:
             return
@@ -264,7 +269,7 @@ class SearchService:
         security = HTTPBasic() if HTTPBasic is not None else None
 
         # Create dependency for authenticated routes
-        def get_authenticated():
+        def get_authenticated() -> Any:
             if security:
                 return security
             return None
@@ -275,13 +280,13 @@ class SearchService:
             credentials: HTTPBasicCredentials | None = None
             if not security
             else Depends(security),  # noqa: B008  # FastAPI DI: Depends() in default is the intended idiom
-        ):
+        ) -> SearchResponse:
             if security:
                 self._get_current_username(credentials)
             return await self._handle_search(request)
 
         @self.app.get("/health")
-        async def health():
+        async def health() -> dict[str, Any]:
             return {
                 "status": "healthy",
                 "backend": self.backend,
@@ -300,7 +305,7 @@ class SearchService:
             credentials: HTTPBasicCredentials | None = None
             if not security
             else Depends(security),  # noqa: B008  # FastAPI DI: Depends() in default is the intended idiom
-        ):
+        ) -> dict[str, Any]:
             """Reload or add new index/collection"""
             if security:
                 self._get_current_username(credentials)
@@ -345,7 +350,7 @@ class SearchService:
                 )
                 return {"status": "reloaded", "index": index_name, "backend": "sqlite"}
 
-    def _load_resources(self):
+    def _load_resources(self) -> None:
         """Load embedding model and search indexes"""
         if self.backend == "pgvector":
             # For pgvector, we need to load models for query embeddings
@@ -583,7 +588,7 @@ class SearchService:
         port: int | None = None,
         ssl_cert: str | None = None,
         ssl_key: str | None = None,
-    ):
+    ) -> None:
         """
         Start the service with optional HTTPS support.
 
@@ -641,6 +646,6 @@ class SearchService:
                 "uvicorn not available. Cannot start HTTP service."
             ) from None
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop the service (placeholder for cleanup)"""
         pass

--- a/signalwire/signalwire/skills/api_ninjas_trivia/skill.py
+++ b/signalwire/signalwire/skills/api_ninjas_trivia/skill.py
@@ -12,9 +12,12 @@ A configurable skill for getting trivia questions from API Ninjas with customiza
 categories and multiple tool instances.
 """
 
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TYPE_CHECKING
 from signalwire.core import FunctionResult
 from signalwire.core.skill_base import SkillBase
+
+if TYPE_CHECKING:
+    from signalwire.core.agent_base import AgentBase
 
 
 class ApiNinjasTriviaSkill(SkillBase):
@@ -76,7 +79,7 @@ class ApiNinjasTriviaSkill(SkillBase):
         "sportsleisure": "Sports and Leisure",
     }
 
-    def __init__(self, agent, params: dict[str, Any] | None = None):
+    def __init__(self, agent: "AgentBase", params: dict[str, Any] | None = None):
         """
         Initialize the skill with configuration parameters.
 
@@ -99,7 +102,7 @@ class ApiNinjasTriviaSkill(SkillBase):
         # Validate configuration
         self._validate_config()
 
-    def _validate_config(self):
+    def _validate_config(self) -> None:
         """Validate the skill configuration."""
         # Validate API key
         if not self.api_key or not isinstance(self.api_key, str):

--- a/signalwire/signalwire/skills/claude_skills/skill.py
+++ b/signalwire/signalwire/skills/claude_skills/skill.py
@@ -10,6 +10,7 @@ See LICENSE file in the project root for full license information.
 import re
 import subprocess
 import fnmatch
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -441,7 +442,7 @@ class ClaudeSkillsSkill(SkillBase):
             Content with shell patterns replaced by command output
         """
 
-        def replace_command(match):
+        def replace_command(match: re.Match[str]) -> str:
             command = match.group(1)
             try:
                 result = subprocess.run(  # noqa: S602  # intentional feature: runs shell snippets authored in skill body files (developer-controlled, like Claude Skills), gated behind opt-in allow_shell_injection (default False) which logs a warning; shell=True is required to support pipes/redirection in authored commands; not reachable from end-user runtime input
@@ -465,7 +466,7 @@ class ClaudeSkillsSkill(SkillBase):
         return _SHELL_INJECTION_RE.sub(replace_command, content)
 
     def _substitute_variables(
-        self, content: str, skill_dir: Path, raw_data: dict | None = None
+        self, content: str, skill_dir: Path, raw_data: dict[str, Any] | None = None
     ) -> str:
         """
         Substitute variable placeholders in content.
@@ -503,7 +504,7 @@ class ClaudeSkillsSkill(SkillBase):
         positional = arguments.split() if arguments else []
 
         # Replace $ARGUMENTS[N] with positional args
-        def replace_indexed(match):
+        def replace_indexed(match: re.Match[str]) -> str:
             index = int(match.group(1))
             if index < len(positional):
                 return positional[index]
@@ -512,7 +513,7 @@ class ClaudeSkillsSkill(SkillBase):
         result = re.sub(r"\$ARGUMENTS\[(\d+)\]", replace_indexed, body)
 
         # Replace $N shorthand (must do after $ARGUMENTS to avoid conflicts)
-        def replace_shorthand(match):
+        def replace_shorthand(match: re.Match[str]) -> str:
             index = int(match.group(1))
             if index < len(positional):
                 return positional[index]
@@ -573,8 +574,12 @@ class ClaudeSkillsSkill(SkillBase):
             response_postfix = self.params.get("response_postfix", "")
 
             # Create handler that captures the skill and prefix/postfix
-            def make_handler(s, rprefix, rpostfix):
-                def handler(args, raw_data):
+            def make_handler(
+                s: dict[str, Any], rprefix: str, rpostfix: str
+            ) -> Callable[[dict[str, Any], dict[str, Any]], FunctionResult]:
+                def handler(
+                    args: dict[str, Any], raw_data: dict[str, Any]
+                ) -> FunctionResult:
                     section = args.get("section")
                     arguments = args.get("arguments", "")
 

--- a/signalwire/signalwire/skills/datasphere/skill.py
+++ b/signalwire/signalwire/skills/datasphere/skill.py
@@ -182,7 +182,9 @@ class DataSphereSkill(SkillBase):
             handler=self._search_knowledge_handler,
         )
 
-    def _search_knowledge_handler(self, args, raw_data):
+    def _search_knowledge_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handler for knowledge search tool"""
         query = args.get("query", "").strip()
 

--- a/signalwire/signalwire/skills/datetime/skill.py
+++ b/signalwire/signalwire/skills/datetime/skill.py
@@ -55,7 +55,9 @@ class DateTimeSkill(SkillBase):
             handler=self._get_date_handler,
         )
 
-    def _get_time_handler(self, args, raw_data):
+    def _get_time_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handler for get_current_time tool"""
         timezone_name = args.get("timezone", "UTC")
 
@@ -73,7 +75,9 @@ class DateTimeSkill(SkillBase):
         except Exception as e:
             return FunctionResult(f"Error getting time: {e!s}")
 
-    def _get_date_handler(self, args, raw_data):
+    def _get_date_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handler for get_current_date tool"""
         timezone_name = args.get("timezone", "UTC")
 

--- a/signalwire/signalwire/skills/google_maps/skill.py
+++ b/signalwire/signalwire/skills/google_maps/skill.py
@@ -62,7 +62,7 @@ _WORD_TO_NUM = {
 }
 
 
-def _normalize_spoken_numbers(text):
+def _normalize_spoken_numbers(text: str) -> str:
     """Convert spoken number words to digits for address lookups.
 
     Speech-to-text often transcribes street numbers as words:
@@ -129,7 +129,7 @@ def _normalize_spoken_numbers(text):
     return " ".join(result)
 
 
-def _debug_json(label, data):
+def _debug_json(label: str, data: Any) -> None:
     """Log a JSON payload at DEBUG level with pretty formatting."""
     logger.debug(f"{label}:\n{json.dumps(data, indent=2, default=str)}")
 
@@ -138,7 +138,12 @@ class GoogleMapsClient:
     def __init__(self, api_key):
         self.api_key = api_key
 
-    def validate_address(self, input_text, bias_lat=None, bias_lng=None):
+    def validate_address(
+        self,
+        input_text: str,
+        bias_lat: float | None = None,
+        bias_lng: float | None = None,
+    ) -> dict[str, Any] | None:
         """Validate and geocode an address or business name.
 
         When bias_lat/bias_lng are provided (destination search with known pickup):
@@ -191,7 +196,9 @@ class GoogleMapsClient:
             logger.error(f"Address validation error: {e}")
             return None
 
-    def _nearby_search(self, keyword, lat, lng):
+    def _nearby_search(
+        self, keyword: str, lat: float, lng: float
+    ) -> dict[str, Any] | None:
         """Find the closest matching business using Nearby Search with rankby=distance.
 
         Only returns results whose name actually contains the search keyword,
@@ -269,7 +276,12 @@ class GoogleMapsClient:
             "business_name": name,
         }
 
-    def _autocomplete_search(self, input_text, bias_lat=None, bias_lng=None):
+    def _autocomplete_search(
+        self,
+        input_text: str,
+        bias_lat: float | None = None,
+        bias_lng: float | None = None,
+    ) -> dict[str, Any] | None:
         """Validate address using Places Autocomplete + Place Details.
 
         Returns: {"address": str, "lat": float, "lng": float} or None
@@ -307,7 +319,7 @@ class GoogleMapsClient:
         logger.debug(f"Selected prediction: place_id={place_id}")
         return self._get_place_details(place_id)
 
-    def _get_place_details(self, place_id):
+    def _get_place_details(self, place_id: str) -> dict[str, Any] | None:
         """Get full address and coordinates from a place_id.
 
         Returns: {"address": str, "lat": float, "lng": float} or None
@@ -537,7 +549,9 @@ class GoogleMapsSkill(SkillBase):
             handler=self._compute_route_handler,
         )
 
-    def _lookup_address_handler(self, args, raw_data):
+    def _lookup_address_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handler for lookup_address tool"""
         address = args.get("address", "").strip()
         if not address:
@@ -563,7 +577,9 @@ class GoogleMapsSkill(SkillBase):
 
         return FunctionResult("\n".join(parts))
 
-    def _compute_route_handler(self, args, raw_data):
+    def _compute_route_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handler for compute_route tool"""
         origin_lat = args.get("origin_lat")
         origin_lng = args.get("origin_lng")

--- a/signalwire/signalwire/skills/info_gatherer/skill.py
+++ b/signalwire/signalwire/skills/info_gatherer/skill.py
@@ -189,7 +189,9 @@ class InfoGathererSkill(SkillBase):
     # Handlers
     # ------------------------------------------------------------------ #
 
-    def _handle_start_questions(self, args, raw_data):
+    def _handle_start_questions(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         state = self.get_skill_data(raw_data)
         questions = state.get("questions", [])
         question_index = state.get("question_index", 0)
@@ -209,7 +211,9 @@ class InfoGathererSkill(SkillBase):
         )
         return FunctionResult(instruction)
 
-    def _handle_submit_answer(self, args, raw_data):
+    def _handle_submit_answer(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         answer = args.get("answer", "")
         confirmed = args.get("confirmed_by_user", False)
         state = self.get_skill_data(raw_data)
@@ -301,7 +305,7 @@ class InfoGathererSkill(SkillBase):
         return instruction
 
     @staticmethod
-    def _validate_questions(questions):
+    def _validate_questions(questions: Any) -> None:
         if not questions:
             raise ValueError("At least one question is required")
         if not isinstance(questions, list):

--- a/signalwire/signalwire/skills/math/skill.py
+++ b/signalwire/signalwire/skills/math/skill.py
@@ -8,7 +8,7 @@ See LICENSE file in the project root for full license information.
 """
 
 import ast
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 from collections.abc import Callable
 
 from signalwire.core.skill_base import SkillBase
@@ -55,7 +55,7 @@ class MathSkill(SkillBase):
         ast.USub: lambda a: -a,
     }
 
-    def _safe_eval(self, node):
+    def _safe_eval(self, node: ast.AST) -> int | float:
         """Recursively evaluate an AST node, allowing only safe math operations."""
         if isinstance(node, ast.Expression):
             return self._safe_eval(node.body)
@@ -72,16 +72,20 @@ class MathSkill(SkillBase):
             # Cap exponent to prevent resource exhaustion
             if op_type is ast.Pow and isinstance(right, (int, float)) and right > 1000:
                 raise ValueError("Exponent too large (maximum is 1000)")
-            return self._SAFE_OPERATORS[op_type](left, right)
+            # _SAFE_OPERATORS values are Callable[..., Any]; arithmetic on
+            # int|float operands yields int|float.
+            return cast("int | float", self._SAFE_OPERATORS[op_type](left, right))
         if isinstance(node, ast.UnaryOp):
             op_type = type(node.op)
             if op_type not in self._SAFE_OPERATORS:
                 raise ValueError(f"Unsupported unary operator: {op_type.__name__}")
             operand = self._safe_eval(node.operand)
-            return self._SAFE_OPERATORS[op_type](operand)
+            return cast("int | float", self._SAFE_OPERATORS[op_type](operand))
         raise ValueError(f"Unsupported expression node: {type(node).__name__}")
 
-    def _calculate_handler(self, args, raw_data):
+    def _calculate_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handler for calculate tool"""
         expression = args.get("expression", "").strip()
 

--- a/signalwire/signalwire/skills/mcp_gateway/skill.py
+++ b/signalwire/signalwire/skills/mcp_gateway/skill.py
@@ -172,9 +172,7 @@ class MCPGatewaySkill(SkillBase):
 
         return True
 
-    def _make_request(
-        self, method: str, url: str, **kwargs: Any
-    ) -> requests.Response:
+    def _make_request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
         """Make HTTP request with appropriate authentication"""
         headers = kwargs.get("headers", {})
         if self.auth_token:
@@ -240,9 +238,7 @@ class MCPGatewaySkill(SkillBase):
             is_hangup_hook=True,
         )
 
-    def _register_mcp_tool(
-        self, service_name: str, tool_def: dict[str, Any]
-    ) -> None:
+    def _register_mcp_tool(self, service_name: str, tool_def: dict[str, Any]) -> None:
         """Register a single MCP tool as a SWAIG function"""
         tool_name = tool_def.get("name")
         if not tool_name:
@@ -275,9 +271,7 @@ class MCPGatewaySkill(SkillBase):
             swaig_params[prop_name] = param_def
 
         # Create handler function
-        def handler(
-            args: dict[str, Any], raw_data: dict[str, Any]
-        ) -> FunctionResult:
+        def handler(args: dict[str, Any], raw_data: dict[str, Any]) -> FunctionResult:
             return self._call_mcp_tool(service_name, tool_name, args, raw_data)
 
         # Register the SWAIG function. Forward the MCP tool's required-argument

--- a/signalwire/signalwire/skills/mcp_gateway/skill.py
+++ b/signalwire/signalwire/skills/mcp_gateway/skill.py
@@ -172,7 +172,9 @@ class MCPGatewaySkill(SkillBase):
 
         return True
 
-    def _make_request(self, method: str, url: str, **kwargs) -> requests.Response:
+    def _make_request(
+        self, method: str, url: str, **kwargs: Any
+    ) -> requests.Response:
         """Make HTTP request with appropriate authentication"""
         headers = kwargs.get("headers", {})
         if self.auth_token:
@@ -238,7 +240,9 @@ class MCPGatewaySkill(SkillBase):
             is_hangup_hook=True,
         )
 
-    def _register_mcp_tool(self, service_name: str, tool_def: dict[str, Any]):
+    def _register_mcp_tool(
+        self, service_name: str, tool_def: dict[str, Any]
+    ) -> None:
         """Register a single MCP tool as a SWAIG function"""
         tool_name = tool_def.get("name")
         if not tool_name:
@@ -271,7 +275,9 @@ class MCPGatewaySkill(SkillBase):
             swaig_params[prop_name] = param_def
 
         # Create handler function
-        def handler(args, raw_data):
+        def handler(
+            args: dict[str, Any], raw_data: dict[str, Any]
+        ) -> FunctionResult:
             return self._call_mcp_tool(service_name, tool_name, args, raw_data)
 
         # Register the SWAIG function. Forward the MCP tool's required-argument

--- a/signalwire/signalwire/skills/native_vector_search/skill.py
+++ b/signalwire/signalwire/skills/native_vector_search/skill.py
@@ -10,7 +10,10 @@ See LICENSE file in the project root for full license information.
 import contextlib
 import os
 import shutil
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from signalwire.core.agent_base import AgentBase
 from pathlib import Path
 
 from signalwire.core.skill_base import SkillBase
@@ -570,7 +573,9 @@ class NativeVectorSearchSkill(SkillBase):
                 ],
             )
 
-    def _search_handler(self, args, raw_data):
+    def _search_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handle search requests"""
 
         # Debug logging to see what arguments are being passed
@@ -814,7 +819,9 @@ class NativeVectorSearchSkill(SkillBase):
 
             return FunctionResult(user_msg)
 
-    def _search_remote(self, query: str, enhanced: dict | None, count: int) -> list:
+    def _search_remote(
+        self, query: str, enhanced: dict[str, Any] | None, count: int
+    ) -> list[dict[str, Any]]:
         """Perform search using remote search server"""
         try:
             import requests
@@ -887,7 +894,7 @@ class NativeVectorSearchSkill(SkillBase):
         # We'll handle this in register_tools after the agent is set
         return []
 
-    def _add_prompt_section(self, agent):
+    def _add_prompt_section(self, agent: "AgentBase") -> None:
         """Add prompt section to agent (called during skill loading)"""
         try:
             agent.prompt_add_section(

--- a/signalwire/signalwire/skills/play_background_file/skill.py
+++ b/signalwire/signalwire/skills/play_background_file/skill.py
@@ -12,9 +12,12 @@ A configurable skill for managing background file playback with custom tool name
 and multiple file collections. Supports both audio and video files.
 """
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from signalwire.core import FunctionResult
 from signalwire.core.skill_base import SkillBase
+
+if TYPE_CHECKING:
+    from signalwire.core.agent_base import AgentBase
 
 
 class PlayBackgroundFileSkill(SkillBase):
@@ -84,7 +87,7 @@ class PlayBackgroundFileSkill(SkillBase):
         )
         return schema
 
-    def __init__(self, agent, params: dict[str, Any] | None = None):
+    def __init__(self, agent: "AgentBase", params: dict[str, Any] | None = None):
         """
         Initialize the skill with configuration parameters.
 
@@ -103,7 +106,7 @@ class PlayBackgroundFileSkill(SkillBase):
         # Validate configuration
         self._validate_config()
 
-    def _validate_config(self):
+    def _validate_config(self) -> None:
         """Validate the skill configuration."""
         if not isinstance(self.files, list) or len(self.files) == 0:
             raise ValueError("files parameter must be a non-empty list")

--- a/signalwire/signalwire/skills/registry.py
+++ b/signalwire/signalwire/skills/registry.py
@@ -23,7 +23,7 @@ from signalwire.core.logging_config import get_logger
 class SkillRegistry:
     """Global registry for on-demand skill loading"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._skills: dict[str, type[SkillBase]] = {}
         self._external_paths: list[Path] = []  # Additional paths to search for skills
         self._entry_points_loaded = False

--- a/signalwire/signalwire/skills/spider/skill.py
+++ b/signalwire/signalwire/skills/spider/skill.py
@@ -11,7 +11,7 @@ Spider skill for fast web scraping with SignalWire AI Agents.
 
 import re
 import collections
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 from urllib.parse import urljoin, urlparse
 import requests
 from lxml import html
@@ -179,7 +179,7 @@ class SpiderSkill(SkillBase):
         self.session.headers.update(self.headers)
 
         # Cache for responses (bounded OrderedDict for LRU-style eviction)
-        self._cache: collections.OrderedDict[str, Any] | None = (
+        self._cache: collections.OrderedDict[str, requests.Response] | None = (
             collections.OrderedDict() if self.cache_enabled else None
         )
         self._cache_max_size = 100
@@ -311,8 +311,9 @@ class SpiderSkill(SkillBase):
                 for elem in tree.xpath(xpath):
                     elem.drop_tree()
 
-            # Extract text
-            text = tree.text_content()
+            # Extract text. lxml has no type stubs, so text_content() is Any;
+            # it returns the element's concatenated text as a str.
+            text = cast(str, tree.text_content())
 
             # Clean whitespace if requested
             if self.clean_text:

--- a/signalwire/signalwire/skills/weather_api/skill.py
+++ b/signalwire/signalwire/skills/weather_api/skill.py
@@ -12,9 +12,12 @@ A configurable skill for getting weather information from WeatherAPI.com with cu
 temperature units and TTS-friendly responses.
 """
 
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TYPE_CHECKING
 from signalwire.core import FunctionResult
 from signalwire.core.skill_base import SkillBase
+
+if TYPE_CHECKING:
+    from signalwire.core.agent_base import AgentBase
 
 
 class WeatherApiSkill(SkillBase):
@@ -72,7 +75,7 @@ class WeatherApiSkill(SkillBase):
         )
         return schema
 
-    def __init__(self, agent, params: dict[str, Any] | None = None):
+    def __init__(self, agent: "AgentBase", params: dict[str, Any] | None = None):
         """
         Initialize the skill with configuration parameters.
 
@@ -93,7 +96,7 @@ class WeatherApiSkill(SkillBase):
         # Validate configuration
         self._validate_config()
 
-    def _validate_config(self):
+    def _validate_config(self) -> None:
         """Validate the skill configuration."""
         # Validate API key
         if not self.api_key or not isinstance(self.api_key, str):

--- a/signalwire/signalwire/skills/web_search/skill.py
+++ b/signalwire/signalwire/skills/web_search/skill.py
@@ -34,9 +34,7 @@ class GoogleSearchScraper:
             }
         )
 
-    def search_google(
-        self, query: str, num_results: int = 5
-    ) -> list[dict[str, Any]]:
+    def search_google(self, query: str, num_results: int = 5) -> list[dict[str, Any]]:
         """Search Google using Custom Search JSON API"""
         url = "https://www.googleapis.com/customsearch/v1"
 

--- a/signalwire/signalwire/skills/web_search/skill.py
+++ b/signalwire/signalwire/skills/web_search/skill.py
@@ -34,7 +34,9 @@ class GoogleSearchScraper:
             }
         )
 
-    def search_google(self, query: str, num_results: int = 5) -> list:
+    def search_google(
+        self, query: str, num_results: int = 5
+    ) -> list[dict[str, Any]]:
         """Search Google using Custom Search JSON API"""
         url = "https://www.googleapis.com/customsearch/v1"
 
@@ -556,7 +558,7 @@ class GoogleSearchScraper:
         return metrics
 
     def _format_snippet_results(
-        self, query: str, search_results: list, num_results: int
+        self, query: str, search_results: list[dict[str, Any]], num_results: int
     ) -> str:
         """Format Google CSE snippets without fetching the underlying pages.
 
@@ -627,7 +629,7 @@ class GoogleSearchScraper:
         if snippets_only:
             return self._format_snippet_results(query, search_results, num_results)
 
-        def _scrape_one(result):
+        def _scrape_one(result: dict[str, Any]) -> dict[str, Any] | None:
             """Fetch + score one candidate. Returns enriched dict or None."""
             if time.monotonic() >= deadline_at:
                 return None
@@ -872,7 +874,9 @@ class WebSearchSkill(SkillBase):
             handler=self._web_search_handler,
         )
 
-    def _web_search_handler(self, args, raw_data):
+    def _web_search_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handler for web search tool with quality filtering"""
         query = args.get("query", "").strip()
 

--- a/signalwire/signalwire/skills/web_search/skill_improved.py
+++ b/signalwire/signalwire/skills/web_search/skill_improved.py
@@ -34,9 +34,7 @@ class GoogleSearchScraper:
             }
         )
 
-    def search_google(
-        self, query: str, num_results: int = 5
-    ) -> list[dict[str, Any]]:
+    def search_google(self, query: str, num_results: int = 5) -> list[dict[str, Any]]:
         """Search Google using Custom Search JSON API"""
         url = "https://www.googleapis.com/customsearch/v1"
 

--- a/signalwire/signalwire/skills/web_search/skill_improved.py
+++ b/signalwire/signalwire/skills/web_search/skill_improved.py
@@ -34,7 +34,9 @@ class GoogleSearchScraper:
             }
         )
 
-    def search_google(self, query: str, num_results: int = 5) -> list:
+    def search_google(
+        self, query: str, num_results: int = 5
+    ) -> list[dict[str, Any]]:
         """Search Google using Custom Search JSON API"""
         url = "https://www.googleapis.com/customsearch/v1"
 
@@ -498,7 +500,9 @@ class WebSearchSkill(SkillBase):
             handler=self._web_search_handler,
         )
 
-    def _web_search_handler(self, args, raw_data):
+    def _web_search_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handler for web search tool with quality filtering"""
         query = args.get("query", "").strip()
 

--- a/signalwire/signalwire/skills/web_search/skill_original.py
+++ b/signalwire/signalwire/skills/web_search/skill_original.py
@@ -32,7 +32,9 @@ class GoogleSearchScraper:
             }
         )
 
-    def search_google(self, query: str, num_results: int = 5) -> list:
+    def search_google(
+        self, query: str, num_results: int = 5
+    ) -> list[dict[str, Any]]:
         """Search Google using Custom Search JSON API"""
         url = "https://www.googleapis.com/customsearch/v1"
 
@@ -231,7 +233,9 @@ class WebSearchSkill(SkillBase):
             handler=self._web_search_handler,
         )
 
-    def _web_search_handler(self, args, raw_data):
+    def _web_search_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> FunctionResult:
         """Handler for web search tool"""
         query = args.get("query", "").strip()
 

--- a/signalwire/signalwire/skills/web_search/skill_original.py
+++ b/signalwire/signalwire/skills/web_search/skill_original.py
@@ -32,9 +32,7 @@ class GoogleSearchScraper:
             }
         )
 
-    def search_google(
-        self, query: str, num_results: int = 5
-    ) -> list[dict[str, Any]]:
+    def search_google(self, query: str, num_results: int = 5) -> list[dict[str, Any]]:
         """Search Google using Custom Search JSON API"""
         url = "https://www.googleapis.com/customsearch/v1"
 

--- a/signalwire/signalwire/skills/wikipedia_search/skill.py
+++ b/signalwire/signalwire/skills/wikipedia_search/skill.py
@@ -13,8 +13,11 @@ Provides Wikipedia search capabilities using the Wikipedia API.
 
 import requests
 from urllib.parse import quote
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TYPE_CHECKING
 from signalwire.core.skill_base import SkillBase
+
+if TYPE_CHECKING:
+    from signalwire.core.function_result import FunctionResult
 
 
 class WikipediaSearchSkill(SkillBase):
@@ -102,7 +105,9 @@ class WikipediaSearchSkill(SkillBase):
             handler=self._search_wiki_handler,
         )
 
-    def _search_wiki_handler(self, args, raw_data):
+    def _search_wiki_handler(
+        self, args: dict[str, Any], raw_data: dict[str, Any]
+    ) -> "FunctionResult":
         """Handler for search_wiki tool"""
         from signalwire.core.function_result import FunctionResult
 
@@ -185,7 +190,7 @@ class WikipediaSearchSkill(SkillBase):
         except Exception as e:
             return f"Error searching Wikipedia: {e!s}"
 
-    def get_prompt_sections(self) -> list:
+    def get_prompt_sections(self) -> list[dict[str, Any]]:
         """
         Return additional context for the agent prompt.
 
@@ -204,7 +209,7 @@ class WikipediaSearchSkill(SkillBase):
             }
         ]
 
-    def get_hints(self) -> list:
+    def get_hints(self) -> list[str]:
         """
         Return speech recognition hints for better accuracy.
 

--- a/signalwire/signalwire/utils/__init__.py
+++ b/signalwire/signalwire/utils/__init__.py
@@ -7,6 +7,8 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
+from typing import cast
+
 from .schema_utils import SchemaUtils
 from .url_validator import validate_url
 from signalwire.core.logging_config import get_execution_mode
@@ -19,7 +21,9 @@ def is_serverless_mode() -> bool:
     Returns:
         bool: True if in serverless mode, False if in server mode
     """
-    return get_execution_mode() != "server"
+    # get_execution_mode() is currently untyped (-> Any), so the comparison
+    # leaks Any; the equality is a genuine bool. Narrow it explicitly.
+    return cast(str, get_execution_mode()) != "server"
 
 
 __all__ = ["SchemaUtils", "get_execution_mode", "is_serverless_mode", "validate_url"]

--- a/signalwire/signalwire/utils/schema_utils.py
+++ b/signalwire/signalwire/utils/schema_utils.py
@@ -15,7 +15,7 @@ Uses jsonschema-rs for full JSON Schema validation with type checking.
 import os
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import jsonschema_rs
 
@@ -196,7 +196,9 @@ class SchemaUtils:
                 # locale encoding (cp1252) breaks on non-ASCII chars in the
                 # schema file.
                 with Path(self.schema_path).open("r", encoding="utf-8") as f:
-                    schema = json.load(f)
+                    # json.load() is typed -> Any; the SWML schema file is a
+                    # JSON object, so narrow it to the declared dict return.
+                    schema = cast(dict[str, Any], json.load(f))
                 self.log.debug(
                     "schema_loaded_successfully",
                     path=self.schema_path,
@@ -276,7 +278,9 @@ class SchemaUtils:
         if verb_name in self.verbs:
             verb_def = self.verbs[verb_name]["definition"]
             if "properties" in verb_def and verb_name in verb_def["properties"]:
-                return verb_def["properties"][verb_name]
+                # verb_def is built from the parsed schema (dict[str, Any]); the
+                # subscript leaks Any. Narrow to the declared dict return.
+                return cast(dict[str, Any], verb_def["properties"][verb_name])
         return {}
 
     def get_verb_required_properties(self, verb_name: str) -> list[str]:
@@ -293,7 +297,9 @@ class SchemaUtils:
             verb_def = self.verbs[verb_name]["definition"]
             if "properties" in verb_def and verb_name in verb_def["properties"]:
                 verb_props = verb_def["properties"][verb_name]
-                return verb_props.get("required", [])
+                # verb_props is Any (parsed schema); "required" is a JSON array
+                # of property-name strings.
+                return cast(list[str], verb_props.get("required", []))
         return []
 
     def validate_verb(
@@ -444,7 +450,9 @@ class SchemaUtils:
         """
         properties = self.get_verb_properties(verb_name)
         if "properties" in properties:
-            return properties["properties"]
+            # properties is dict[str, Any]; the nested "properties" map is a
+            # JSON object of param-name -> definition.
+            return cast(dict[str, Any], properties["properties"])
         return {}
 
     def generate_method_signature(self, verb_name: str) -> str:

--- a/signalwire/signalwire/web/web_service.py
+++ b/signalwire/signalwire/web/web_service.py
@@ -9,6 +9,7 @@ See LICENSE file in the project root for full license information.
 
 import os
 import mimetypes
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, Optional, TYPE_CHECKING
 
@@ -49,8 +50,8 @@ class WebService:
         basic_auth: tuple[str, str] | None = None,
         config_file: str | None = None,
         enable_directory_browsing: bool = False,
-        allowed_extensions: list | None = None,
-        blocked_extensions: list | None = None,
+        allowed_extensions: list[str] | None = None,
+        blocked_extensions: list[str] | None = None,
         max_file_size: int = 100 * 1024 * 1024,  # 100MB default
         enable_cors: bool = True,
     ):
@@ -122,7 +123,7 @@ class WebService:
             self.app = None
             logger.warning("FastAPI not available. HTTP service will not be available.")
 
-    def _load_config(self, config_file: str | None):
+    def _load_config(self, config_file: str | None) -> None:
         """Load configuration from file if available"""
         # Initialize defaults
         self.directories = {}
@@ -167,7 +168,7 @@ class WebService:
             if "blocked_extensions" in service_config:
                 self.blocked_extensions = service_config["blocked_extensions"]
 
-    def _setup_security(self):
+    def _setup_security(self) -> None:
         """Setup security middleware and authentication"""
         if not self.app:
             return
@@ -178,7 +179,10 @@ class WebService:
 
         # Add security headers middleware
         @self.app.middleware("http")
-        async def add_security_headers(request: Request, call_next):
+        async def add_security_headers(
+            request: "Request",
+            call_next: "Callable[[Request], Awaitable[Response]]",
+        ) -> "Response":
             response = await call_next(request)
 
             # Add security headers
@@ -196,7 +200,10 @@ class WebService:
 
         # Add host validation middleware
         @self.app.middleware("http")
-        async def validate_host(request: Request, call_next):
+        async def validate_host(
+            request: "Request",
+            call_next: "Callable[[Request], Awaitable[Response]]",
+        ) -> "Response":
             host = request.headers.get("host", "").split(":")[0]
             if host and not self.security.should_allow_host(host):
                 return Response(content="Invalid host", status_code=400)
@@ -323,7 +330,7 @@ class WebService:
         </html>
         """
 
-    def _setup_routes(self):
+    def _setup_routes(self) -> None:
         """Setup FastAPI routes"""
         if not self.app:
             return
@@ -332,7 +339,7 @@ class WebService:
         security = HTTPBasic() if HTTPBasic is not None else None
 
         @self.app.get("/health")
-        async def health():
+        async def health() -> dict[str, Any]:
             return {
                 "status": "healthy",
                 "directories": list(self.directories.keys()),
@@ -342,7 +349,7 @@ class WebService:
             }
 
         @self.app.get("/")
-        async def root():
+        async def root():  # noqa: ANN202  # FastAPI derives the response model from this handler's return annotation; a Response|dict union is not a valid Pydantic field, so it must stay unannotated.
             """Root endpoint showing available directories"""
             html = """
             <!DOCTYPE html>
@@ -378,7 +385,7 @@ class WebService:
                 return HTMLResponse(content=html)
             return {"directories": list(self.directories.keys())}
 
-    def _mount_directories(self):
+    def _mount_directories(self) -> None:
         """Mount static file directories"""
         if not self.app or StaticFiles is None:
             return
@@ -407,13 +414,13 @@ class WebService:
             @self.app.get(f"{route}/{{file_path:path}}")
             async def serve_file(
                 file_path: str,
-                request: Request,
+                request: "Request",
                 credentials: Optional["HTTPBasicCredentials"] = (
                     None if not security else Depends(security)  # noqa: B008  # FastAPI DI: Depends() in default is the intended idiom
                 ),
-                route=route,
-                directory=directory,
-            ):
+                route: str = route,
+                directory: str = directory,
+            ):  # noqa: ANN202  # FastAPI derives the response model from this return annotation; a multi-Response union is not a valid Pydantic field, so it must stay unannotated.
                 """Serve files with security checks"""
                 if security:
                     self._get_current_username(credentials)
@@ -537,7 +544,7 @@ class WebService:
         port: int | None = None,
         ssl_cert: str | None = None,
         ssl_key: str | None = None,
-    ):
+    ) -> None:
         """
         Start the service with optional HTTPS support
 
@@ -600,6 +607,6 @@ class WebService:
                 "uvicorn not available. Cannot start HTTP service."
             ) from None
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop the service (placeholder for cleanup)"""
         pass

--- a/signalwire/signalwire/web/web_service.py
+++ b/signalwire/signalwire/web/web_service.py
@@ -349,7 +349,7 @@ class WebService:
             }
 
         @self.app.get("/")
-        async def root():  # noqa: ANN202  # FastAPI derives the response model from this handler's return annotation; a Response|dict union is not a valid Pydantic field, so it must stay unannotated.
+        async def root():
             """Root endpoint showing available directories"""
             html = """
             <!DOCTYPE html>
@@ -420,7 +420,7 @@ class WebService:
                 ),
                 route: str = route,
                 directory: str = directory,
-            ):  # noqa: ANN202  # FastAPI derives the response model from this return annotation; a multi-Response union is not a valid Pydantic field, so it must stay unannotated.
+            ):
                 """Serve files with security checks"""
                 if security:
                     self._get_current_username(credentials)


### PR DESCRIPTION
## Type-annotation hardening for the Python reference SDK

Three drift-aware commits that tighten type annotations on the source-of-truth Python SDK without enabling `--strict` in the gate and without re-drifting any of the 9 ports. `mypy --strict signalwire/signalwire` findings drop **1394 → 856** (no-untyped-def 674→392, no-untyped-call 493→355, type-arg 137→46, **no-any-return 45→0**). The existing mypy gate (`check_untyped_defs`, no `disallow_untyped_defs`) stays green throughout, and the full pytest suite stays green.

The intentional `_HostTyped` mixin-host `Any`-subclass artifact (9 `attr-defined` + 8 `misc` under `--strict`) was left untouched as instructed.

---

### Commit 1 — `fix(types): annotate no-any-return leaks` (real-signal slice)

All **45** `mypy --strict` `no-any-return` findings triaged and made honest (concrete return + narrowed leak), not silenced. Result: `no-any-return` 45 → 0.

**Fixed — genuine concrete return, body was leaking `Any`:**

| Leak source | Fix | Files |
|---|---|---|
| `json.loads()` / `requests.json()` / dict-subscript `Any` | `cast` to the already-declared concrete return | schema_utils (4), webhook_exec, service_loader, gateway_service, mcp_manager (2), skill_base (`get_skill_data`) |
| `yaml.dump()` (no stubs → `Any`) | `cast(str, …)` | swml_renderer (2), pom.to_yaml |
| mixin-host `Any` attrs (`_session_manager`, `_prompt_manager`, `skill_manager`, `pom`) | narrowed **at the call site** to the host method's real return; `_HostTyped` base untouched | state_mixin (2), skill_mixin (2), prompt_mixin (8), prompt/manager (2) |
| local dict/attr stayed `Any` | typed the local/attr instead of casting | search_engine (`scores: dict[str, float]`), search_service (`_query_cache: dict[str, SearchResponse]`), prompt manager (`_prompt_text: str \| None`), spider (`_cache: OrderedDict[str, Response]`) |
| loop var bound to an `Any`-annotated name | renamed the loop var off `path: Any` | swml_service `_find_schema_path` |
| `to_field = request_body[...]` (`dict[str, Any]` value) | `cast(str, …)` | swml_service `extract_sip_username` |
| `json.load(...).get("name", "")` | `str(...)` coercion | dokku |

**Left dynamic on purpose:** none. Every `no-any-return` resolved to a concrete honest type.

**One genuine semantic fix:** `SkillBase.define_tool` is declared `-> None` but was `return`ing the delegate `agent.define_tool(...)` (which is fluent `-> AgentBase`). Now it calls without returning — honoring the declared `None` contract and removing the `Any` propagation.

---

### Commit 2 — `chore(types): drift-free annotation pass`

~**337 return annotations** plus matching parameter and generic-argument types across the non-REST surface where the type is unambiguous from the code: `cli`, `mcp_gateway`, `prefabs`, `agents`, `search`, `relay`, `livewire`, `web`, `skills`, `pom`.

- `void` methods → `-> None`; obvious leaf types (`dict[str, Any]`, `list[str]`, `Callable[..., Any]`, `asyncio.Task[None]`, …) read off the body/callers.
- Skill contract methods matched to `SkillBase`; tool handlers to `(args: dict[str, Any], raw_data: dict[str, Any]) -> FunctionResult`.
- A few returns that newly leaked `Any` from untyped third-party libs (bs4.get_text, striprtf, the math AST operator table) were kept honest with a narrowing `cast`, so `mypy --strict` `no-any-return` stays at 0.
- Symbols whose precise type could **not** be determined from the code were left unannotated (e.g. `registry.add_skill_to_schema`, two `google_maps` methods — annotating them surfaced pre-existing latent `None`-key / int-vs-str issues that are out of scope for a type-only pass).

**Caught by the test suite (not the gate):** two FastAPI route handlers in `web_service` (`root`, `serve_file`) must stay return-unannotated — FastAPI derives the response model from the handler's return annotation, and a multi-`Response` union is not a valid Pydantic field (`FastAPIError` at route registration). Reverted those two; kept the rest.

**Verification:**
- mypy gate (default config): `Success: no issues found in 176 source files`.
- Full pytest suite: **5768 passed**, 9 skipped (plus the one pre-existing failure noted below).
- Oracle (`porting-sdk/python_signatures.json`) regenerated via `scripts/enumerate_python_signatures.py`; **DRIFT clean (drift=0) vs all 9 ports**: go, typescript, java, php, ruby, perl, rust, cpp, dotnet. **No port needs re-drift.**

---

### Commit 3 — TypeScript-authoritative drifters — **SKIPPED (empty set)**

Per the brief, this commit applies only annotations that *would* cause drift **and** where TypeScript already declares the same concrete type (TS authoritative). I scanned every symbol (returns + params) for "ref currently `any`, TS declares a **portable** concrete type, ≥1 other port conflicts." **No symbol qualified**, so the commit was skipped. The drift-causing annotations all fall into the report table below — in every case TS either uses a TS-specific generated/`class:` type (so it disagrees with the genuine Python type) or is itself `any`/ambiguous.

---

### REPORT TABLE — drift-causing annotations NOT applied (for human decision)

#### A. REST namespace return types (195 symbols)

The natural annotation for every `rest.namespaces.*` / `rest._base.*` resource method is **`dict[str, Any]`** (the HTTP layer parses the JSON body to a dict; `{}` on 204). This would drift:

| Conflicting port | Their return type | # symbols | TS resolves? |
|---|---|---|---|
| **rust** | `class:signalwire.value.Value` (generic JSON-value wrapper) | 194 | n/a |
| **typescript** | `class:…types.generated.<Name>Response` (per-endpoint generated model) | 131 | **No — TS uses its own generated class, not `dict`** |
| **typescript** | `union<class:CallLeg, class:FabricDeviceLeg>` etc. | 40 | No |

TS does not declare `dict[str, Any]` for any of these — it declares concrete generated response models (a TS idiom), and rust uses its own `Value` wrapper. So neither is authoritative for the portable `dict` type. **Decision needed:** either (a) accept `dict[str, Any]` on the Python reference and re-drift rust + typescript (this is the bulk of the remaining `no-untyped-def`), or (b) leave these returns loose. Examples: `CrudResource.{create,get,list,update,delete}`, `AddressesResource.create`, `CallingNamespace.{play,record,dial,…}`, `PhoneNumbersResource.set_*`.

#### B. Individual scalar/param mismatches

| Symbol | Proposed Python type | Conflicting port(s) → their type | Why TS didn't resolve it |
|---|---|---|---|
| `rest._base.SignalWireRestError.__init__(status_code)` | `int` (HTTP status) | (none — go/java/php already `int`) | TS declares `float` (TS `number`→float), which is wrong for Python. The correct `int` is **drift-free** and is just a clean follow-up annotation, not a TS-authoritative drift. |
| `rest._base.SignalWireRestError.__init__(body)` | `str \| dict[str, Any]` | go/cpp → `string` | TS = `union<string, class:SignalWireErrorBody>` (TS-generated body model) — disagrees with the portable type. |
| `core.function_result.FunctionResult.execute_swml(swml_content)` | genuinely loose: `str \| dict[str, Any] \| <SWML SDK obj>` | rust → `class:Value` | The 3rd accepted form is a duck-typed SWML SDK object (`.to_dict()`); no clean portable type. TS = `union<string, dict, class:__type>` — ambiguous. |
| `core.mixins.tool_mixin.ToolMixin.on_function_call` (return) | overridable hook; true type unclear from base | java/cpp → `FunctionResult`; php/rust/dotnet → `optional<FunctionResult>` | TS = `union<void, dict, …>` — ambiguous; not authoritative. |
| `core.mixins.web_mixin.WebMixin.run` (return) | `None \| ServerlessResponse` | java/php/cpp/dotnet → `void` | TS = `union<void, class:ServerlessResponse>` (TS class) — not a portable type. |
| `core.logging_config.get_execution_mode` (return) | `str` | (none — ports already `string`) | TS declares `tuple<string, union<…>>` which is wrong for Python (returns a single `str`). The correct `str` annotation is **drift-free** — a clean follow-up, not a TS-authoritative drift. |

> The two "(none)" rows (`status_code → int`, `get_execution_mode → str`): the *correct* Python annotation is drift-free and could simply be added in a follow-up commit-2-style pass. They surfaced here only because the scan started from TS's (wrong-for-Python) type. NOT blocked on any port re-drift.

---

### Pre-existing, unrelated test failure (not introduced here)

`tests/test_examples.py::TestBedrockExamples::test_bedrock_agents_load[bedrock_agent_run.py]` fails with `cannot import name 'run_agent' from 'signalwire'`. Root cause: `examples/bedrock_agent_run.py` imports `run_agent`, which is **not defined or exported anywhere** in the package. This predates this branch, is unrelated to type annotations, and is left for a separate fix.

### Ports needing re-drift

**None** for what is applied here. Commits 1 and 2 are drift-clean against all 9 ports; commit 3 was skipped. The deferred REST-return annotations (report §A) *would* require rust + typescript re-drift **if** a human elects to apply them later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
