### PR TITLE
Fix set_prompt_pom: build a PromptObjectModel from the section list

### DIFF
--- a/signalwire/signalwire/core/agent/prompt/manager.py
+++ b/signalwire/signalwire/core/agent/prompt/manager.py
@@ -11,8 +11,10 @@ Prompt management functionality for AgentBase.
 
 from typing import Any, cast
 import inspect
+import json
 
 from signalwire.core.logging_config import get_logger
+from signalwire.pom import PromptObjectModel
 
 logger = get_logger(__name__)
 
@@ -124,7 +126,14 @@ class PromptManager:
             ValueError: If use_pom is False
         """
         if self.agent._use_pom:
-            self.agent.pom = pom
+            # The renderer treats self.agent.pom as a PromptObjectModel (it calls
+            # .to_dict()), so storing a bare list crashes at render time. Build the
+            # model from the section list; pass through anything already a POM.
+            self.agent.pom = (
+                PromptObjectModel.from_json(json.dumps(pom))
+                if isinstance(pom, list)
+                else pom
+            )
         else:
             raise ValueError("use_pom must be True to use set_prompt_pom")
 

--- a/tests/unit/core/test_agent_base.py
+++ b/tests/unit/core/test_agent_base.py
@@ -137,13 +137,15 @@ class TestAgentBasePromptMethods:
             self.agent._prompt_manager.set_prompt_pom([{"title": "X", "body": "y"}])
 
     def test_set_prompt_pom_succeeds_when_use_pom_true(self):
-        """set_prompt_pom assigns the POM list when use_pom is True."""
+        """set_prompt_pom builds a PromptObjectModel from the section list when use_pom is True."""
+        from signalwire.pom import PromptObjectModel
         with pytest.MonkeyPatch().context() as m:
             m.setattr("signalwire.core.agent_base.uvicorn", Mock())
             agent = AgentBase("pom_agent", use_pom=True, schema_validation=False)
         sections = [{"title": "Greeting", "body": "Hello"}]
         agent._prompt_manager.set_prompt_pom(sections)
-        assert agent.pom == sections
+        assert isinstance(agent.pom, PromptObjectModel)
+        assert agent.pom.to_dict() == sections
 
 
 class TestAgentBaseConfigurationMethods:

--- a/tests/unit/core/test_agent_base.py
+++ b/tests/unit/core/test_agent_base.py
@@ -138,13 +138,16 @@ class TestAgentBasePromptMethods:
             self.agent._prompt_manager.set_prompt_pom([{"title": "X", "body": "y"}])
 
     def test_set_prompt_pom_succeeds_when_use_pom_true(self) -> None:
-        """set_prompt_pom assigns the POM list when use_pom is True."""
+        """set_prompt_pom builds a PromptObjectModel from the section list when use_pom is True."""
+        from signalwire.pom import PromptObjectModel
+
         with pytest.MonkeyPatch().context() as m:
             m.setattr("signalwire.core.agent_base.uvicorn", Mock())
             agent = AgentBase("pom_agent", use_pom=True, schema_validation=False)
         sections = [{"title": "Greeting", "body": "Hello"}]
         agent._prompt_manager.set_prompt_pom(sections)
-        assert agent.pom == sections  # type: ignore[comparison-overlap]  # pom holds the raw list at runtime
+        assert isinstance(agent.pom, PromptObjectModel)
+        assert agent.pom.to_dict() == sections
 
 
 class TestAgentBaseConfigurationMethods:


### PR DESCRIPTION
## Problem
`set_prompt_pom(pom: List[Dict[str, Any]])` stored the raw list (`self.agent.pom = pom`), but the prompt renderer (`PromptManager._process_prompt_sections`) calls `self.agent.pom.to_dict()`. So the documented `List[Dict]` input crashed at render time:

```
AttributeError: 'list' object has no attribute 'to_dict'
```

Prompts built incrementally with `prompt_add_section` were unaffected — they mutate the existing `PromptObjectModel` — which is why the bundled examples never tripped it. `set_prompt_pom` is the only path that overwrites `pom` with a list.

## Fix
Convert the list to a `PromptObjectModel` (via `from_json`) before storing; pass through anything already a POM object. One file (`core/agent/prompt/manager.py`): two imports + the conversion.

## Verified
- `set_prompt_pom([...])` now renders `prompt:{pom}` (previously crashed).
- Coexists with `contexts` → `prompt:{pom, contexts}`.
- Re-setting with a new list replaces cleanly (no accumulation across calls).