### PR TITLE
fix(agent): type _multilingual as Optional so the None initializer checks

### DIFF
--- a/signalwire/signalwire/core/mixins/ai_config_mixin.py
+++ b/signalwire/signalwire/core/mixins/ai_config_mixin.py
@@ -22,6 +22,8 @@ class AIConfigMixin(_HostTyped):
     Mixin class containing all AI configuration methods for AgentBase
     """
 
+    _multilingual: dict[str, Any] | None = None
+
     def add_hint(self, hint: str) -> "AgentBase":
         """
         Add a simple string hint to help the AI agent understand certain words better


### PR DESCRIPTION
`set_multilingual()` assigns `_multilingual` a `dict[str, Any]`, so mypy infers that as its type and rejects `self._multilingual = None` in `AgentBase.__init__` (`agent_base.py:289`) — the TYPECHECK gate is currently red on `main` because of it.

Fix: declare `_multilingual: dict[str, Any] | None = None` explicitly on `AIConfigMixin` (the class that owns `set_multilingual`), so both the `None` default and the dict assignment type-check.

- Type-only change; no runtime behavior change.
- Whole-repo mypy after the fix: **0 findings** (176 files).
- Touches the multilingual feature added in 3a44d2e.