### PR TITLE
fmt: format _validate_history (set_history commit left it unformatted)

### DIFF
--- a/signalwire/signalwire/core/contexts.py
+++ b/signalwire/signalwire/core/contexts.py
@@ -32,9 +32,7 @@ HISTORY_MODES = ("keep", "default", "hide")
 
 def _validate_history(mode: str) -> str:
     if mode not in HISTORY_MODES:
-        raise ValueError(
-            f"history must be one of {HISTORY_MODES}, got {mode!r}"
-        )
+        raise ValueError(f"history must be one of {HISTORY_MODES}, got {mode!r}")
     return mode
 
 


### PR DESCRIPTION
The set_history commit (883aa1d) left `_validate_history`'s `raise ValueError(...)` wrapped across 3 lines; `ruff format` collapses it to one line (81 chars < 88 limit). This has kept the FMT gate red on main and on every open PR's merge preview (including wave2 #48 — which is why #48's FMT failed on a contexts.py that was clean on its own branch but inherits main's set_history code via the PR merge ref).

One-line formatting fix, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)