### PR TITLE
Wave-3: ReadResource.paginate() + doc/API-truth gate burns

### DIFF
--- a/ACCESSOR_TRUTH_ALLOW.md
+++ b/ACCESSOR_TRUTH_ALLOW.md
@@ -1,0 +1,7 @@
+# ACCESSOR_TRUTH_ALLOW.md — methods excused from ACCESSOR-TRUTH
+
+Each entry: `- <method> — reason (approver, date)`. Only for a backtick `foo()`
+that is NOT an SDK-surface claim (an illustrative identifier example, a
+deliberately-shown other-language name, etc.). Never to hide a real doc lie.
+
+- get_params — illustrative naming example in docs/search_overview.md ("Programming identifiers: `set_params()` vs `get_params()`"), teaching semantic-vs-exact matching — not a claim the SDK exposes get_params(). (mjerris, 2026-07-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.0.2] - 2026-07-11
+
+- REST: `ReadResource.paginate()` wires the `PaginatedIterator` into every list
+  resource so callers can page through all results (follows `links.next`).
+- Docs: corrected env-var names and documented previously-undocumented knobs
+  (including the proxy/SSRF trust toggles);
+  fixed stale skill/namespace counts and phantom method references.
+
 ## [3.0.1] - 2026-04-12
 
 - Update install instructions and PyPI URLs to use `signalwire-sdk`

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -2702,7 +2702,6 @@ my-prefab-agents/
 - `set_state(call_id, data)` 
 - `update_state(call_id, data)`
 - `clear_state(call_id)`
-- `cleanup_expired_state()`
 
 ### SIP Routing Methods
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1126,7 +1126,21 @@ Key environment variables:
 - `SWML_SSL_CERT_PATH`: Path to SSL certificate
 - `SWML_SSL_KEY_PATH`: Path to SSL key
 - `SWML_DOMAIN`: Domain name for the service
-- `SWML_SCHEMA_PATH`: Optional path to override the schema.json location
+
+Proxy / request-trust knobs (all default OFF — enable only behind a trusted proxy):
+- `SWML_TRUST_PROXY_HEADERS`: trust `X-Forwarded-*` host/proto headers (`1`/`true`/`yes`)
+- `SWML_TRUST_REMOTE_USER`: trust the `REMOTE_USER` CGI header for auth
+- `SWML_ALLOW_PRIVATE_URLS`: allow webhook/target URLs that resolve to private IPs
+  (off by default to block SSRF)
+- `SWML_PROXY_DEBUG`: verbose proxy-header resolution logging
+
+Other knobs:
+- `SWML_SKIP_SCHEMA_VALIDATION`: skip SWML schema validation (`1`) — for debugging only
+- `SIGNALWIRE_LOG_FORMAT`: log renderer, `console` (default) or `json`
+- `SIGNALWIRE_SPACE_NAME`: default space name used by `sw-agent-init` scaffolding
+
+The schema.json location is overridden via the `schema_path=` constructor argument
+of `AgentBase` / `SWMLService` (not an environment variable).
 
 ## Request Flow
 

--- a/docs/sdk_features.md
+++ b/docs/sdk_features.md
@@ -481,7 +481,7 @@ The SDK handles auth automatically:
 | Dynamic config | Custom middleware | `set_dynamic_config_callback()` |
 | Post-call analytics | Parse raw webhook payload | `on_summary()` callback |
 | Health checks | Manual endpoints | Built-in `/health` and `/ready` |
-| Call recording | Manual SWML verb insertion | `enable_record_call()` |
+| Call recording | Manual SWML verb insertion | `record_call()` |
 | SSL/TLS | Manual cert configuration | Env var driven |
 
 The SDK turns what would be a multi-file infrastructure project into a single Python class. The SWML is correct by construction. The webhooks route themselves. The auth is automatic. The deployment is universal. The developer focuses on what the agent should *do*, not how to wire it together.

--- a/docs/web_service.md
+++ b/docs/web_service.md
@@ -94,12 +94,12 @@ service = WebService(
 ```bash
 # Basic authentication
 export SWML_BASIC_AUTH_USER="admin"
-export SWML_BASIC_AUTH_PASS="secretpassword"
+export SWML_BASIC_AUTH_PASSWORD="secretpassword"
 
 # SSL/HTTPS configuration
 export SWML_SSL_ENABLED=true
-export SWML_SSL_CERT="/path/to/cert.pem"
-export SWML_SSL_KEY="/path/to/key.pem"
+export SWML_SSL_CERT_PATH="/path/to/cert.pem"
+export SWML_SSL_KEY_PATH="/path/to/key.pem"
 
 # Security settings
 export SWML_ALLOWED_HOSTS="example.com,*.example.com"
@@ -145,7 +145,7 @@ Create a `web.json` or `swml_web.json` file:
 WebService implements HTTP Basic Authentication. Credentials can be set via:
 
 1. **Constructor**: `basic_auth=("username", "password")`
-2. **Environment**: `SWML_BASIC_AUTH_USER` and `SWML_BASIC_AUTH_PASS`
+2. **Environment**: `SWML_BASIC_AUTH_USER` and `SWML_BASIC_AUTH_PASSWORD`
 3. **Config file**: `security.basic_auth` section
 4. **Auto-generated**: If not specified, generates random credentials
 
@@ -187,16 +187,8 @@ WebService provides multiple ways to enable HTTPS:
 
 ```bash
 # Using file paths
-export SWML_SSL_CERT="/path/to/cert.pem"
-export SWML_SSL_KEY="/path/to/key.pem"
-
-# Or using inline PEM content
-export SWML_SSL_CERT_INLINE="-----BEGIN CERTIFICATE-----
-MIIDXTCCAkWgAwIBAgIJAKLdQVPy...
------END CERTIFICATE-----"
-export SWML_SSL_KEY_INLINE="-----BEGIN PRIVATE KEY-----
-MIIEvQIBADANBgkqhkiG9w0BAQE...
------END PRIVATE KEY-----"
+export SWML_SSL_CERT_PATH="/path/to/cert.pem"
+export SWML_SSL_KEY_PATH="/path/to/key.pem"
 ```
 
 ### Method 2: Direct Parameters
@@ -233,8 +225,8 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem \
     -days 365 -nodes -subj "/CN=localhost"
 
 # Use with WebService
-export SWML_SSL_CERT="cert.pem"
-export SWML_SSL_KEY="key.pem"
+export SWML_SSL_CERT_PATH="cert.pem"
+export SWML_SSL_KEY_PATH="key.pem"
 ```
 
 ## API Endpoints
@@ -473,8 +465,8 @@ After=network.target
 Type=simple
 User=www-data
 WorkingDirectory=/opt/signalwire
-Environment="SWML_SSL_CERT=/etc/ssl/certs/server.crt"
-Environment="SWML_SSL_KEY=/etc/ssl/private/server.key"
+Environment="SWML_SSL_CERT_PATH=/etc/ssl/certs/server.crt"
+Environment="SWML_SSL_KEY_PATH=/etc/ssl/private/server.key"
 ExecStart=/usr/bin/python3 -c "from signalwire import WebService; WebService(directories={'/': '/var/www/html'}).start()"
 Restart=always
 

--- a/one_sdk.md
+++ b/one_sdk.md
@@ -33,11 +33,11 @@ Every SDK generates identical SWML JSON. The `set_param("realtime", {"voice": "v
 
 ### Same Skills System
 
-All 18 skills exist in every SDK with the same names, same tool names, same parameter schemas. `add_skill("datetime")` works identically across all 7 languages.
+All 17 skills exist in every SDK with the same names, same tool names, same parameter schemas. `add_skill("datetime")` works identically across all 7 languages.
 
 ### Same REST Namespaces
 
-All 21 REST API namespaces (Fabric, Calling, PhoneNumbers, Datasphere, Video, Compat, etc.) exist in every SDK with the same method names and paths.
+All 20 REST API namespaces (Fabric, Calling, PhoneNumbers, Datasphere, Video, Compat, etc.) exist in every SDK with the same method names and paths.
 
 ### Platform-Native Idioms
 
@@ -165,7 +165,7 @@ The One SDK doc says: "Consistency is maintained through shared design documents
 - **PORTING_GUIDE.md** — The master specification (1200+ lines)
 - **CHECKLIST_TEMPLATE.md** — Every feature as a checkbox
 - **SWAIG_FUNCTION_RESULT_REFERENCE.md** — Exact JSON for all 40+ actions
-- **SKILLS_MANIFEST.md** — All 18 skills with exact specs
+- **SKILLS_MANIFEST.md** — All 17 skills with exact specs
 - **RELAY_IMPLEMENTATION_GUIDE.md** — Wire protocol reference
 - **rest-apis/*.yaml** — OpenAPI specs for all REST namespaces
 - **schema.json** — SWML verb schema (the source of truth for verbs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ all = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/signalwire/signalwire-agents"
+Homepage = "https://github.com/signalwire/signalwire-python"
 
 [project.scripts]
 swaig-test = "signalwire.cli.swaig_test_wrapper:main"

--- a/signalwire/signalwire/rest/_base.py
+++ b/signalwire/signalwire/rest/_base.py
@@ -14,6 +14,7 @@ from typing import Any, Generic, TypeVar, cast
 
 import requests
 from signalwire.core.logging_config import get_logger
+from signalwire.rest._pagination import PaginatedIterator
 
 logger = get_logger("rest_client")
 
@@ -134,6 +135,24 @@ class ReadResource(BaseResource, Generic[TList, TItem]):
 
     def list(self, **params: Any) -> TList:
         return cast(TList, self._http.get(self._base_path, params=params or None))
+
+    def paginate(self, **params: Any) -> PaginatedIterator:
+        """Iterate every item across all pages of this resource's list endpoint.
+
+        ``list()`` returns a single raw page (the server's first response). For
+        endpoints that paginate on the wire (a ``links.next`` / ``page_token`` in
+        the response), ``paginate()`` follows those links and yields each item:
+
+            for address in client.fabric.addresses.paginate():
+                ...
+
+        Wires the resource layer to the tested ``PaginatedIterator`` (which walks
+        ``resp["data"]`` and follows ``resp["links"]["next"]``), so callers no
+        longer hand-construct the path + token loop.
+        """
+        return PaginatedIterator(
+            self._http, self._base_path, params=params or None, data_key="data"
+        )
 
     def get(self, resource_id: str) -> TItem:
         return cast(TItem, self._http.get(self._path(resource_id)))

--- a/signalwire/signalwire/rest/_pagination.py
+++ b/signalwire/signalwire/rest/_pagination.py
@@ -9,9 +9,13 @@ See LICENSE file in the project root for full license information.
 Pagination support for list endpoints that return paged results.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from ._base import HttpClient
+if TYPE_CHECKING:
+    # Type-only import: _base imports this module (ReadResource.paginate), so a
+    # runtime `from ._base import HttpClient` would be a circular import. HttpClient
+    # is used here purely as an annotation, so guard it under TYPE_CHECKING.
+    from ._base import HttpClient
 
 
 class PaginatedIterator:
@@ -24,7 +28,7 @@ class PaginatedIterator:
 
     def __init__(
         self,
-        http: HttpClient,
+        http: "HttpClient",
         path: str,
         params: dict[str, Any] | None = None,
         data_key: str = "data",

--- a/tests/unit/rest/test_pagination_mock.py
+++ b/tests/unit/rest/test_pagination_mock.py
@@ -147,3 +147,32 @@ class TestPaginatedIterator:
         else:
             stopped = False
         assert stopped, "expected StopIteration on second __next__()"
+
+    def test_resource_paginate_walks_all_pages(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        """ReadResource.paginate() wires the resource layer to PaginatedIterator:
+        a caller pages through every item without hand-constructing the path/token
+        loop. Two mock pages (first carries links.next), collected in order."""
+        from signalwire.rest._base import ReadResource
+
+        _push_scenario(
+            mock, _FABRIC_ADDRESSES_ENDPOINT_ID, status=200,
+            response={
+                "data": [{"id": "r-1"}, {"id": "r-2"}],
+                "links": {"next": f"{_FABRIC_ADDRESSES_PATH}?cursor=page2"},
+            },
+        )
+        _push_scenario(
+            mock, _FABRIC_ADDRESSES_ENDPOINT_ID, status=200,
+            response={"data": [{"id": "r-3"}], "links": {}},
+        )
+
+        resource: ReadResource[Any, Any] = ReadResource(
+            signalwire_client._http, _FABRIC_ADDRESSES_PATH
+        )
+        collected = [item["id"] for item in resource.paginate()]
+        assert collected == ["r-1", "r-2", "r-3"]
+        gets = [e for e in mock.journal if e.path == _FABRIC_ADDRESSES_PATH]
+        assert len(gets) == 2, f"expected 2 paginated GETs, got {len(gets)}"
+        assert gets[1].query_params.get("cursor") == ["page2"]


### PR DESCRIPTION
Wave-3 on the Python reference: adds `ReadResource.paginate()` (the new oracle symbol every port adopts) and burns the Wave-3 doc/API-truth gate findings.

## Changes
- **feat(rest): `ReadResource.paginate(**params) -> PaginatedIterator`** — wires the existing `PaginatedIterator` into a lazy, cursor-following `paginate()` on the read-resource base. This is the reference symbol the 9 ports mirror; the porting-sdk oracle records it per-subclass.
- **docs(env): DOC-ENV** — documented the previously-hidden SDK env knobs (incl. security toggles) where the code reads them.
- **docs: counts** — 18→17 skills, 21→20 namespaces (Twilio-compat excised matrix-wide).
- **docs: ACCESSOR-TRUTH** — corrected phantom method references.
- **chore: META-CONSISTENT** — package-metadata fixes.

## Lockstep
Part of the Wave-3 lockstep set. **Merge order: this PR FIRST**, then porting-sdk feat/wave3 (its audit-checklist validates the oracle against signalwire-python@main, so the paginate impl must land here first), then the 9 port PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
