### PR TITLE
feat(rest): Projects CRUD resource (projects management, #54)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "signalwire-sdk"
-version = "3.0.2"
+version = "3.1.0"
 description = "SignalWire SDK"
 authors = [
     {name = "SignalWire Team", email = "info@signalwire.com"}

--- a/signalwire/signalwire/__init__.py
+++ b/signalwire/signalwire/__init__.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 configure_logging()
 
-__version__ = "3.0.2"
+__version__ = "3.1.0"
 
 # Import core classes for easier access.
 # These imports are intentionally placed after configure_logging() so the SDK's

--- a/signalwire/signalwire/agent_server.py
+++ b/signalwire/signalwire/agent_server.py
@@ -68,7 +68,7 @@ class AgentServer:
         self.app = FastAPI(
             title="SignalWire AI Agents",
             description="Hosted SignalWire AI Agents",
-            version="3.0.2",
+            version="3.1.0",
             redirect_slashes=False,
             docs_url=None,
             redoc_url=None,

--- a/signalwire/signalwire/rest/namespaces/_client_tree_generated.py
+++ b/signalwire/signalwire/rest/namespaces/_client_tree_generated.py
@@ -46,6 +46,9 @@ from .message_resources_generated import (
 from .project_resources_generated import (
     ProjectTokens,
 )
+from .projects_resources_generated import (
+    Projects,
+)
 from .pubsub_resources_generated import (
     PubSub,
 )
@@ -161,6 +164,7 @@ class _GeneratedResourceTree:
         self.mfa = Mfa(http)
         self.number_groups = NumberGroups(http)
         self.phone_numbers = PhoneNumbers(http)
+        self.projects = Projects(http)
         self.pubsub = PubSub(http)
         self.queues = Queues(http)
         self.recordings = Recordings(http)

--- a/signalwire/signalwire/rest/namespaces/projects_resources_generated.py
+++ b/signalwire/signalwire/rest/namespaces/projects_resources_generated.py
@@ -1,0 +1,92 @@
+# AUTO-GENERATED from porting-sdk/rest-apis/projects/openapi.yaml — DO NOT EDIT.
+# Regenerate: python3 porting-sdk/scripts/generate_python_rest_types.py
+#
+# One typed CRUD subclass per full-CRUD resource: closed typed create/update params
+# (explicit spec fields) + an ``extras`` escape hatch and a ``**_reserved_kw`` tail for
+# unknown / reserved-word wire fields, bound to the resource's spec types.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+from collections.abc import Mapping
+
+from .._base import CrudResource
+
+if TYPE_CHECKING:
+    from .projects_types_generated import (
+        Project,
+        ProjectCreate,
+        ProjectList,
+        ProjectUpdate,
+        ProjectWithSigningKey,
+    )
+
+
+class Projects(
+    CrudResource["ProjectList", "Project", "ProjectCreate", "ProjectUpdate"]
+):
+    """Typed resource for ``/projects`` (generated)."""
+
+    def __init__(self, http: Any) -> None:
+        super().__init__(http, "/api/projects")
+
+    def create(  # type: ignore[override]
+        self,
+        *,
+        name: str,
+        protect_recordings: bool | None = None,
+        protect_message_media: bool | None = None,
+        protect_fax_media: bool | None = None,
+        force_https_requests: bool | None = None,
+        extras: Mapping[str, Any] | None = None,
+        **_reserved_kw: Any,
+    ) -> Project:
+        body: dict[str, Any] = {
+            k: v
+            for k, v in {
+                "name": name,
+                "protect_recordings": protect_recordings,
+                "protect_message_media": protect_message_media,
+                "protect_fax_media": protect_fax_media,
+                "force_https_requests": force_https_requests,
+            }.items()
+            if v is not None
+        }
+        if extras:
+            body.update(extras)
+        body.update(_reserved_kw)
+        return cast("Project", self._http.post(self._base_path, body=body))
+
+    def update(
+        self,
+        id: str,
+        /,
+        *,
+        name: str | None = None,
+        protect_recordings: bool | None = None,
+        protect_message_media: bool | None = None,
+        protect_fax_media: bool | None = None,
+        force_https_requests: bool | None = None,
+        extras: Mapping[str, Any] | None = None,
+        **_reserved_kw: Any,
+    ) -> Project:
+        body: dict[str, Any] = {
+            k: v
+            for k, v in {
+                "name": name,
+                "protect_recordings": protect_recordings,
+                "protect_message_media": protect_message_media,
+                "protect_fax_media": protect_fax_media,
+                "force_https_requests": force_https_requests,
+            }.items()
+            if v is not None
+        }
+        if extras:
+            body.update(extras)
+        body.update(_reserved_kw)
+        return cast("Project", self._http.patch(self._path(id), body=body))
+
+    def rotate_signing_key(self, id: str) -> ProjectWithSigningKey:
+        return cast(
+            "ProjectWithSigningKey",
+            self._http.post(self._path(id, "signing-key", "rotate")),
+        )

--- a/signalwire/signalwire/rest/namespaces/projects_types_generated.py
+++ b/signalwire/signalwire/rest/namespaces/projects_types_generated.py
@@ -1,0 +1,122 @@
+# AUTO-GENERATED from porting-sdk/rest-apis/projects/openapi.yaml — DO NOT EDIT.
+# Regenerate: python3 porting-sdk/scripts/generate_python_rest_types.py
+#
+# One TypedDict per components/schemas entry + per-operation Request/Response
+# aliases. TypedDicts are STATIC-ONLY: at runtime each is a plain dict, so a
+# differently-shaped server response is returned unchanged and never raises.
+from __future__ import annotations
+from typing import Any, Literal, TypeAlias, TypedDict
+
+
+class Project(TypedDict, total=False):
+    """A project or subproject within the caller's project tree.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    id: str
+    name: str
+    parent_project_id: str | None
+    subproject: bool
+    region_preference: str
+    protect_recordings: bool
+    protect_message_media: bool
+    protect_fax_media: bool
+    force_https_requests: bool
+    created_at: str
+    updated_at: str
+
+
+ProjectWithSigningKey: TypeAlias = "dict[str, Any]"
+
+
+class ProjectCreate(TypedDict, total=False):
+    """Request body for creating a subproject.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    name: str
+    protect_recordings: bool
+    protect_message_media: bool
+    protect_fax_media: bool
+    force_https_requests: bool
+
+
+ProjectUpdate: TypeAlias = "ProjectCreate"
+
+
+class ProjectList(TypedDict, total=False):
+    """A page of projects.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    links: dict[str, Any]
+    data: list[Project]
+
+
+class ProjectStatusCode422(TypedDict, total=False):
+    """The request contains invalid parameters or violates a business rule. See errors for details.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    errors: list[Types_StatusCodes_RestApiErrorItem]
+
+
+class Types_StatusCodes_RestApiErrorItem(TypedDict, total=False):
+    """Details about a specific error.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    type: str
+    code: str
+    message: str
+    attribute: str | None
+    url: str
+
+
+class Types_StatusCodes_StatusCode401(TypedDict, total=False):
+    """Access is unauthorized.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    error: Literal["Unauthorized"]
+
+
+class Types_StatusCodes_StatusCode403(TypedDict, total=False):
+    """The API token lacks the required `Management` scope.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    error: Literal["Forbidden"]
+
+
+class Types_StatusCodes_StatusCode404(TypedDict, total=False):
+    """The server cannot find the requested resource.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    error: Literal["Not Found"]
+
+
+ListProjectsResponse: TypeAlias = "ProjectList"
+CreateSubprojectRequest: TypeAlias = "ProjectCreate"
+CreateSubprojectResponse: TypeAlias = "ProjectWithSigningKey"
+GetProjectResponse: TypeAlias = "Project"
+UpdateProjectRequest: TypeAlias = "ProjectUpdate"
+UpdateProjectResponse: TypeAlias = "Project"
+RotateSigningKeyResponse: TypeAlias = "ProjectWithSigningKey"

--- a/tests/unit/rest/projects_generated_test.py
+++ b/tests/unit/rest/projects_generated_test.py
@@ -1,0 +1,120 @@
+"""AUTO-GENERATED REST wire tests for the `projects` namespace — DO NOT EDIT.
+Regenerate: python3 porting-sdk/scripts/generate_python_rest_types.py
+
+Each route the SDK implements (captured from the real client by python_route_registry,
+joined to the spec operationId) gets a SUCCESS test (call it, assert method/path/route on
+the mock journal) and an ERROR test (arm a 5xx, assert SignalWireRestError). The assertion
+oracle is the spec operationId — independent of the resource generator — so these catch
+SDK-vs-contract drift, not just a generator self-snapshot. Full-mock harness fixtures.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from signalwire.rest._base import SignalWireRestError
+
+if TYPE_CHECKING:
+    from signalwire.rest.client import RestClient
+
+    from .conftest import _MockHarness
+
+
+class TestProjectsWire:
+    def test_projects_create(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        signalwire_client.projects.create(name="x")
+        last = mock.last_request()
+        assert last.method == "POST"
+        assert last.matched_route == "projects.create_subproject"
+
+    def test_projects_create_error(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        mock.push_scenario("projects.create_subproject", 500, {"error": "x"})
+        with pytest.raises(SignalWireRestError) as exc:
+            signalwire_client.projects.create(name="x")
+        assert exc.value.status_code == 500
+
+    def test_projects_delete(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        signalwire_client.projects.delete("test-id")
+        last = mock.last_request()
+        assert last.method == "DELETE"
+        assert last.matched_route == "projects.delete_subproject"
+
+    def test_projects_delete_error(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        mock.push_scenario("projects.delete_subproject", 500, {"error": "x"})
+        with pytest.raises(SignalWireRestError) as exc:
+            signalwire_client.projects.delete("test-id")
+        assert exc.value.status_code == 500
+
+    def test_projects_get(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        signalwire_client.projects.get("test-id")
+        last = mock.last_request()
+        assert last.method == "GET"
+        assert last.matched_route == "projects.get_project"
+
+    def test_projects_get_error(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        mock.push_scenario("projects.get_project", 500, {"error": "x"})
+        with pytest.raises(SignalWireRestError) as exc:
+            signalwire_client.projects.get("test-id")
+        assert exc.value.status_code == 500
+
+    def test_projects_list(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        signalwire_client.projects.list()
+        last = mock.last_request()
+        assert last.method == "GET"
+        assert last.matched_route == "projects.list_projects"
+
+    def test_projects_list_error(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        mock.push_scenario("projects.list_projects", 500, {"error": "x"})
+        with pytest.raises(SignalWireRestError) as exc:
+            signalwire_client.projects.list()
+        assert exc.value.status_code == 500
+
+    def test_projects_rotate_signing_key(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        signalwire_client.projects.rotate_signing_key("test-id")
+        last = mock.last_request()
+        assert last.method == "POST"
+        assert last.matched_route == "projects.rotate_signing_key"
+
+    def test_projects_rotate_signing_key_error(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        mock.push_scenario("projects.rotate_signing_key", 500, {"error": "x"})
+        with pytest.raises(SignalWireRestError) as exc:
+            signalwire_client.projects.rotate_signing_key("test-id")
+        assert exc.value.status_code == 500
+
+    def test_projects_update(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        signalwire_client.projects.update("test-id")
+        last = mock.last_request()
+        assert last.method == "PATCH"
+        assert last.matched_route == "projects.update_project"
+
+    def test_projects_update_error(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        mock.push_scenario("projects.update_project", 500, {"error": "x"})
+        with pytest.raises(SignalWireRestError) as exc:
+            signalwire_client.projects.update("test-id")
+        assert exc.value.status_code == 500


### PR DESCRIPTION
## Summary

Generates the **plural `Projects`** REST resource (`client.projects`) into the Python reference — the full-CRUD projects/subprojects management resource over `/api/projects` (`list` / `get` / `create` / `update` / `delete`). Emitted by `generate_python_rest_types.py` from porting-sdk's `rest-apis/projects/openapi.yaml` `x-sdk-resource` markup.

### Plural `Projects` vs singular `project`
- **`client.projects`** (this PR) — full CRUD over any project/subproject in the caller's tree, at `/api/projects`. New.
- **`client.project.tokens`** (pre-existing, untouched) — token management on the single authenticated project, at `/api/project` (no ID). Distinct API, distinct namespace. The two are NOT merged.

### `rotate_signing_key`
The one sub-resource RPC beyond base CRUD: `client.projects.rotate_signing_key(id)` → `POST /api/projects/{id}/signing-key/rotate`.

## Generated / changed files
All generated (`# AUTO-GENERATED … DO NOT EDIT`):
- `signalwire/rest/namespaces/projects_types_generated.py` — 17 types
- `signalwire/rest/namespaces/projects_resources_generated.py` — `Projects(CrudResource)` + `rotate_signing_key`
- `signalwire/rest/namespaces/_client_tree_generated.py` — wired `self.projects = Projects(http)`
- `tests/unit/rest/projects_generated_test.py` — 6 routes × (success + error) = **12 wire tests** over the shared `mock_signalwire`

Version bumped **3.0.2 → 3.1.0** (minor — new public surface) in `pyproject.toml`, `signalwire/__init__.py`, `agent_server.py`.

## Gates
Full `run-ci.sh` is **GREEN**. GEN-FRESH reproduces projects from specs; SPEC-PARITY treats projects as canonical (0 gaps); REST-COVERAGE + TEST pass over the shared mock; DRIFT / SEMVER-DIFF / TYPECHECK / LINT / FMT pass.

## Dependency — coordinated merge
Depends on **porting-sdk `feat/projects-canonical`** (commit `29254d3`), which:
- flips `SPEC_NAMES` to include `projects` (makes the 6 routes canonical + mock-served), and
- carries the regenerated oracle `python_signatures.json` / `python_surface.json` with the new `Projects.*` members.

This PR **must merge as part of that coordinated set** — the reference is the oracle the 9 other ports match, so the oracle commit and this impl land together. Do NOT merge standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
