### PR TITLE
feat(rest): Messages send/redact resource (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [3.2.0] - 2026-07-14
+
+### New Features
+- REST: added the `client.messages` resource for the native messaging API
+  (`/api/messaging`): `create` sends an SMS/MMS message
+  (`POST /api/messaging/messages`) and `update` redacts a previously sent
+  message's body (`PATCH /api/messaging/messages/{message_id}`). This is the
+  plural send/redact resource, distinct from the singular message *logs*
+  reachable via `client.logs.messages`.
+
+## [3.1.0] - 2026-07-14
+
+### New Features
+- REST: added the `client.projects` CRUD resource for the project-management
+  API (`/api/projects`), including `rotate_signing_key`.
+
 ## [3.0.2] - 2026-07-11
 
 - REST: `ReadResource.paginate()` wires the `PaginatedIterator` into every list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "signalwire-sdk"
-version = "3.1.0"
+version = "3.2.0"
 description = "SignalWire SDK"
 authors = [
     {name = "SignalWire Team", email = "info@signalwire.com"}

--- a/signalwire/signalwire/__init__.py
+++ b/signalwire/signalwire/__init__.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 configure_logging()
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 # Import core classes for easier access.
 # These imports are intentionally placed after configure_logging() so the SDK's

--- a/signalwire/signalwire/agent_server.py
+++ b/signalwire/signalwire/agent_server.py
@@ -68,7 +68,7 @@ class AgentServer:
         self.app = FastAPI(
             title="SignalWire AI Agents",
             description="Hosted SignalWire AI Agents",
-            version="3.1.0",
+            version="3.2.0",
             redirect_slashes=False,
             docs_url=None,
             redoc_url=None,

--- a/signalwire/signalwire/rest/namespaces/_client_tree_generated.py
+++ b/signalwire/signalwire/rest/namespaces/_client_tree_generated.py
@@ -43,6 +43,9 @@ from .logs_resources_generated import (
 from .message_resources_generated import (
     MessageLogs,
 )
+from .messages_resources_generated import (
+    Messages,
+)
 from .project_resources_generated import (
     ProjectTokens,
 )
@@ -161,6 +164,7 @@ class _GeneratedResourceTree:
         self.chat = Chat(http)
         self.imported_numbers = ImportedNumbers(http)
         self.lookup = Lookup(http)
+        self.messages = Messages(http)
         self.mfa = Mfa(http)
         self.number_groups = NumberGroups(http)
         self.phone_numbers = PhoneNumbers(http)

--- a/signalwire/signalwire/rest/namespaces/messages_resources_generated.py
+++ b/signalwire/signalwire/rest/namespaces/messages_resources_generated.py
@@ -1,0 +1,71 @@
+# AUTO-GENERATED from porting-sdk/rest-apis/messages/openapi.yaml — DO NOT EDIT.
+# Regenerate: python3 porting-sdk/scripts/generate_python_rest_types.py
+#
+# One typed CRUD subclass per full-CRUD resource: closed typed create/update params
+# (explicit spec fields) + an ``extras`` escape hatch and a ``**_reserved_kw`` tail for
+# unknown / reserved-word wire fields, bound to the resource's spec types.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+from collections.abc import Mapping
+
+from .._base import BaseResource
+
+if TYPE_CHECKING:
+    from .messages_types_generated import (
+        Message,
+    )
+
+
+class Messages(BaseResource):
+    """Typed resource for ``/messages`` (generated)."""
+
+    def __init__(self, http: Any) -> None:
+        super().__init__(http, "/api/messaging/messages")
+
+    def create(
+        self,
+        *,
+        to: str,
+        from_: str,
+        body: str | None = None,
+        media: list[str] | None = None,
+        send_as_mms: bool | None = None,
+        status_callback: str | None = None,
+        custom_variables: dict[str, str] | None = None,
+        extras: Mapping[str, Any] | None = None,
+        **_reserved_kw: Any,
+    ) -> Message:
+        body_: dict[str, Any] = {
+            k: v
+            for k, v in {
+                "to": to,
+                "from": from_,
+                "body": body,
+                "media": media,
+                "send_as_mms": send_as_mms,
+                "status_callback": status_callback,
+                "custom_variables": custom_variables,
+            }.items()
+            if v is not None
+        }
+        if extras:
+            body_.update(extras)
+        body_.update(_reserved_kw)
+        return cast("Message", self._http.post(self._base_path, body=body_))
+
+    def update(
+        self,
+        message_id: str,
+        *,
+        body: str,
+        extras: Mapping[str, Any] | None = None,
+        **_reserved_kw: Any,
+    ) -> Message:
+        body_: dict[str, Any] = {
+            k: v for k, v in {"body": body}.items() if v is not None
+        }
+        if extras:
+            body_.update(extras)
+        body_.update(_reserved_kw)
+        return cast("Message", self._http.patch(self._path(message_id), body=body_))

--- a/signalwire/signalwire/rest/namespaces/messages_types_generated.py
+++ b/signalwire/signalwire/rest/namespaces/messages_types_generated.py
@@ -1,0 +1,145 @@
+# AUTO-GENERATED from porting-sdk/rest-apis/messages/openapi.yaml — DO NOT EDIT.
+# Regenerate: python3 porting-sdk/scripts/generate_python_rest_types.py
+#
+# One TypedDict per components/schemas entry + per-operation Request/Response
+# aliases. TypedDicts are STATIC-ONLY: at runtime each is a plain dict, so a
+# differently-shaped server response is returned unchanged and never raises.
+from __future__ import annotations
+from typing import Literal, TypeAlias, TypedDict
+
+
+class CreateMessageRequest(TypedDict, total=False):
+    """Request body for sending a new SMS or MMS message.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    to: str
+    # non-identifier field 'from': str
+    body: str
+    media: list[str]
+    send_as_mms: bool
+    status_callback: str
+    custom_variables: dict[str, str]
+
+
+class UpdateMessageRequest(TypedDict, total=False):
+    """Request body for redacting the body of a previously sent message. Only `body` may be updated, and it must be an empty string.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    body: str
+
+
+class Message(TypedDict, total=False):
+    """A message record. Returned by the create and update endpoints.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    id: uuid
+    # non-identifier field 'from': str
+    to: str
+    body: str
+    status: MessageStatus
+    direction: MessageDirection
+    kind: MessageKind
+    media: list[str]
+    number_of_segments: int
+    error_code: str | None
+    error_message: str | None
+    created_at: str
+    project_id: uuid
+    status_callback_url: str | None
+    message_uri: str
+
+
+MessageStatus: TypeAlias = "Literal['queued', 'initiated', 'sent', 'delivered', 'undelivered', 'failed', 'read']"
+
+MessageDirection: TypeAlias = "Literal['inbound', 'outbound']"
+
+MessageKind: TypeAlias = "Literal['sms', 'mms']"
+
+
+class MessagesCreateStatusCode422(TypedDict, total=False):
+    """The request contains invalid parameters. See errors for details.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    errors: list[Types_StatusCodes_RestApiErrorItem]
+
+
+class MessagesUpdateStatusCode422(TypedDict, total=False):
+    """The request contains invalid parameters. See errors for details.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    errors: list[Types_StatusCodes_RestApiErrorItem]
+
+
+class Types_StatusCodes_RestApiErrorItem(TypedDict, total=False):
+    """Details about a specific error.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    type: str
+    code: str
+    message: str
+    attribute: str | None
+    url: str
+
+
+class Types_StatusCodes_StatusCode400(TypedDict, total=False):
+    """The request is invalid.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    error: Literal["Bad Request"]
+
+
+class Types_StatusCodes_StatusCode401(TypedDict, total=False):
+    """Access is unauthorized.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    error: Literal["Unauthorized"]
+
+
+class Types_StatusCodes_StatusCode404(TypedDict, total=False):
+    """The server cannot find the requested resource.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    error: Literal["Not Found"]
+
+
+class Types_StatusCodes_StatusCode500(TypedDict, total=False):
+    """An internal server error occurred.
+
+    Open shape: extra server keys are permitted and partial payloads are valid;
+    not validated at runtime (a TypedDict is a plain ``dict``).
+    """
+
+    error: Literal["Internal Server Error"]
+
+
+uuid: TypeAlias = "str"
+
+CreateMessageResponse: TypeAlias = "Message"
+UpdateMessageResponse: TypeAlias = "Message"

--- a/tests/unit/rest/messages_generated_test.py
+++ b/tests/unit/rest/messages_generated_test.py
@@ -1,0 +1,56 @@
+"""AUTO-GENERATED REST wire tests for the `messages` namespace — DO NOT EDIT.
+Regenerate: python3 porting-sdk/scripts/generate_python_rest_types.py
+
+Each route the SDK implements (captured from the real client by python_route_registry,
+joined to the spec operationId) gets a SUCCESS test (call it, assert method/path/route on
+the mock journal) and an ERROR test (arm a 5xx, assert SignalWireRestError). The assertion
+oracle is the spec operationId — independent of the resource generator — so these catch
+SDK-vs-contract drift, not just a generator self-snapshot. Full-mock harness fixtures.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from signalwire.rest._base import SignalWireRestError
+
+if TYPE_CHECKING:
+    from signalwire.rest.client import RestClient
+
+    from .conftest import _MockHarness
+
+
+class TestMessagesWire:
+    def test_messages_create(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        signalwire_client.messages.create(to="x", from_="x")
+        last = mock.last_request()
+        assert last.method == "POST"
+        assert last.matched_route == "messages.create_message"
+
+    def test_messages_create_error(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        mock.push_scenario("messages.create_message", 500, {"error": "x"})
+        with pytest.raises(SignalWireRestError) as exc:
+            signalwire_client.messages.create(to="x", from_="x")
+        assert exc.value.status_code == 500
+
+    def test_messages_update(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        signalwire_client.messages.update("test-id", body="x")
+        last = mock.last_request()
+        assert last.method == "PATCH"
+        assert last.matched_route == "messages.update_message"
+
+    def test_messages_update_error(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        mock.push_scenario("messages.update_message", 500, {"error": "x"})
+        with pytest.raises(SignalWireRestError) as exc:
+            signalwire_client.messages.update("test-id", body="x")
+        assert exc.value.status_code == 500


### PR DESCRIPTION
## Messages send/redact resource (`client.messages`)

Adds the native messaging REST resource for the `/api/messaging` send/redact
API, generated from the porting-sdk `messages` spec.

| method | route | purpose |
|---|---|---|
| `client.messages.create(...)` | `POST /api/messaging/messages` | send an SMS/MMS message |
| `client.messages.update(message_id, body="")` | `PATCH /api/messaging/messages/{message_id}` | redact a message body |

`Messages` is a **`BaseResource`** with only `create` + `update` (no
list/get/delete) — a used-once subset of CRUD, per the spec's `x-sdk-resource`
markup (`base: BaseResource`, `methods: {create, update}`).

### Plural `messages` (send/redact) vs singular `message` (logs)

This is **distinct** from the existing singular *message logs* resource: the
message-logs spec routes to `client.logs.messages` (via `namespace: logs`).
This PR adds a brand-new flat `client.messages` for the send/redact API. No
message-logs code is touched; the two share the `/api/messaging` URL prefix but
are separate resources.

### Files (all generator output)
- `messages_types_generated.py`, `messages_resources_generated.py`
- `_client_tree_generated.py` — wires `client.messages`
- `tests/unit/rest/messages_generated_test.py` — 4 wire tests
  (create + update, each success + error) over the shared mock, no transport patching

### Version
Bumped **3.1.0 → 3.2.0** (new public minor surface) across `pyproject.toml`,
`signalwire/signalwire/__init__.py`, `agent_server.py`, and `CHANGELOG.md`.

### Dependency — coordinated merge
Depends on **porting-sdk `feat/messages-canonical`** (adds `messages` to
`SPEC_NAMES`, the spec markup + mock routes, and the regenerated oracle
`python_signatures.json` / `python_surface.json`). Merge porting-sdk's branch
first, or merge together — the oracle commit there is what the downstream ports
drift against.

That porting-sdk branch also carries a **generator fix**: a create/update body
field literally named `body` (the redact body) collided with the emitter's
hardcoded local `body` dict variable (mypy no-redef + union-attr). Fixed with a
collision-free body-var name (`body_` when a param is named `body`);
non-`body` resources emit byte-identically.

### Gates
Full `run-ci.sh` GREEN: LINT, TYPECHECK (mypy), GEN-FRESH, SIGNATURES, DRIFT,
SEMVER-DIFF, SPEC-PARITY (messages implemented, 0 gaps), REST-COVERAGE
(2/2 messages routes success+error), TEST, FMT, and all doc/surface gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
