### PR TITLE
docs: reconcile widened doc-gate perimeter (DOC-ENV + ACCESSOR-TRUTH)

### DIFF
--- a/signalwire/signalwire/skills/math/README.md
+++ b/signalwire/signalwire/skills/math/README.md
@@ -116,8 +116,9 @@ The calculate tool accepts one parameter:
 - Uses regex pattern matching for character validation
 
 ### Safe Evaluation
-- Uses Python's `eval()` with restricted builtins (empty `__builtins__`)
-- No access to system functions or imports
+- Parses the expression to an AST (`ast.parse(..., mode="eval")`) and walks it with a restricted evaluator that only permits numeric constants and a fixed set of arithmetic operators (`+`, `-`, `*`, `/`, `%`, `**`, unary `+`/`-`)
+- Never calls Python's built-in `eval`, so there is no access to names, attributes, calls, system functions, or imports
+- Caps the exponent to prevent resource exhaustion
 - Cannot execute arbitrary code
 
 ### Error Handling

--- a/tutorial/fred/tutorial/appendix-docker-deployment.md
+++ b/tutorial/fred/tutorial/appendix-docker-deployment.md
@@ -286,24 +286,28 @@ ENTRYPOINT ["python", "fred.py"]
 
 ### 2. Secrets Management
 
-Never hardcode credentials. Use Docker secrets or environment files:
+Never hardcode credentials. Keep them out of the compose file by loading an
+environment file that is not committed to source control:
 
 ```yaml
-# docker-compose with secrets
+# docker-compose using an env file for secrets
 version: '3.8'
-
-secrets:
-  fred_password:
-    file: ./secrets/fred_password.txt
 
 services:
   fred:
     # ... other config ...
-    secrets:
-      - fred_password
-    environment:
-      - SWML_BASIC_AUTH_PASSWORD_FILE=/run/secrets/fred_password
+    env_file:
+      - ./secrets/fred.env   # not committed; holds SWML_BASIC_AUTH_PASSWORD=...
 ```
+
+```bash
+# ./secrets/fred.env
+SWML_BASIC_AUTH_USER=fred
+SWML_BASIC_AUTH_PASSWORD=your-secure-password
+```
+
+The SDK reads `SWML_BASIC_AUTH_USER` / `SWML_BASIC_AUTH_PASSWORD` directly from
+the process environment.
 
 ### 3. Reverse Proxy Setup
 

--- a/tutorial/multi_agents/README.md
+++ b/tutorial/multi_agents/README.md
@@ -179,8 +179,8 @@ python agent.py
 | `SWML_SSL_CERT_PATH` | Path to SSL certificate | None |
 | `SWML_SSL_KEY_PATH` | Path to SSL private key | None |
 | `SWML_DOMAIN` | Domain for SSL | None |
-| `SWML_AUTH_USER` | Basic auth username | Auto-generated |
-| `SWML_AUTH_PASS` | Basic auth password | Auto-generated |
+| `SWML_BASIC_AUTH_USER` | Basic auth username | Auto-generated |
+| `SWML_BASIC_AUTH_PASSWORD` | Basic auth password | Auto-generated |
 | `PYTORCH_DISABLE_AVX512` | Disable AVX512 for compatibility | `0` |
 
 ### Code Examples

--- a/tutorial/multi_agents/lesson3_multi_agent_systems.md
+++ b/tutorial/multi_agents/lesson3_multi_agent_systems.md
@@ -364,8 +364,8 @@ Look for these in the logs:
 **Authentication:**
 ```bash
 # Set custom credentials
-export SWML_AUTH_USER=myuser
-export SWML_AUTH_PASS=mypassword
+export SWML_BASIC_AUTH_USER=myuser
+export SWML_BASIC_AUTH_PASSWORD=mypassword
 
 # Or let the system generate them (check logs)
 ```

--- a/tutorial/multi_agents/lesson4_advanced_features.md
+++ b/tutorial/multi_agents/lesson4_advanced_features.md
@@ -315,7 +315,7 @@ class DebugAgent(AgentBase):
 server = AgentServer(log_level="debug")
 
 # Or via environment variable
-export SWML_LOG_LEVEL=debug
+export SIGNALWIRE_LOG_LEVEL=debug
 
 # Available levels:
 # - debug: Detailed information for debugging
@@ -373,9 +373,9 @@ def debug_state(self, args, raw_data):
 
 ```bash
 # Core configuration
-export SWML_AUTH_USER=produser
-export SWML_AUTH_PASS=strongpassword
-export SWML_LOG_LEVEL=info
+export SWML_BASIC_AUTH_USER=produser
+export SWML_BASIC_AUTH_PASSWORD=strongpassword
+export SIGNALWIRE_LOG_LEVEL=info
 
 # SSL configuration
 export SWML_SSL_ENABLED=true
@@ -427,7 +427,7 @@ After=network.target
 Type=simple
 User=agent
 WorkingDirectory=/opt/signalwire-agent
-Environment="SWML_LOG_LEVEL=info"
+Environment="SIGNALWIRE_LOG_LEVEL=info"
 Environment="SWML_SSL_ENABLED=true"
 ExecStart=/usr/bin/python3 /opt/signalwire-agent/agent.py
 Restart=always


### PR DESCRIPTION
## Why

porting-sdk #99 widens the doc-gate perimeter — `accessor_truth.py` + `doc_env.py` now scan **all** tracked markdown (not just `docs/**`). That surfaces real pre-existing doc drift the narrow perimeter missed. #99 can't land green until this port's findings are reconciled.

All changes here are **docs-only**. No SDK code changed.

## DOC-ENV findings → fixes (finding → truth-in-source → fix)

| Doc claim | Truth in source | Fix |
|---|---|---|
| `SWML_AUTH_USER` | `auth_mixin.py`/`security_config.py` read `SWML_BASIC_AUTH_USER` | renamed to `SWML_BASIC_AUTH_USER` |
| `SWML_AUTH_PASS` | code reads `SWML_BASIC_AUTH_PASSWORD` | renamed to `SWML_BASIC_AUTH_PASSWORD` |
| `SWML_LOG_LEVEL` | `logging_config.py` reads `SIGNALWIRE_LOG_LEVEL` | renamed to `SIGNALWIRE_LOG_LEVEL` |
| `SWML_BASIC_AUTH_PASSWORD_FILE` | SDK reads no `*_FILE` var — it reads `SWML_BASIC_AUTH_PASSWORD` directly | removed; docker tutorial reworked to an `env_file` pattern using the real var |

## ACCESSOR-TRUTH finding → fix

| Doc claim | Truth in source | Fix |
|---|---|---|
| math skill README: "Uses Python's `eval()` with restricted builtins" | `skills/math/skill.py` never calls `eval()`; it does `ast.parse(mode="eval")` + a restricted `_safe_eval` AST walker | rewrote the "Safe Evaluation" section to describe the real AST-based evaluator (stale doc was also a security misdescription) |

## Flagged — NOT fixed, NOT allowlisted (needs a human decision)

`SWML_SCHEMA_PATH` and `SWML_SCHEMA_MCP_DEBUG` still trip DOC-ENV. **Both are real and correctly documented** — `mcp/swml-schema-search/swml_schema_mcp.py` reads them (schema-path override + debug-logging toggle), and the doc that names them lives right beside that script (`mcp/swml-schema-search/README.md`).

The mismatch is a **perimeter artifact**: the gate's code perimeter is `signalwire/signalwire/**/*.py` (shippable SDK surface) and deliberately excludes the standalone `mcp/` tool, while its doc perimeter is all tracked markdown. Docs and code are both correct.

Per RULES.md (no autonomous allowlisting) I did not add a `DOC_ENV_ALLOW.md` entry or widen the gate to go green. Candidate resolutions for a maintainer to pick:
- allowlist the two vars in `DOC_ENV_ALLOW.md` (they are legitimately doc+code correct, just outside the code perimeter), or
- extend the python code perimeter to include `mcp/**/*.py` in `doc_env.py` (treats the MCP tool as documentable surface).

## Verification

- `accessor_truth.py --port python` → **clean (exit 0)**
- `doc_env.py --port python` → only the two flagged MCP vars remain (the perimeter artifact above)
- docs-only; python test suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
