### PR TITLE
fix(env): unify token env var to SIGNALWIRE_API_TOKEN (plan 4.4)

### DIFF
--- a/docs/cloud_functions_guide.md
+++ b/docs/cloud_functions_guide.md
@@ -62,7 +62,7 @@ Set these environment variables for your function:
 ```bash
 # SignalWire credentials
 export SIGNALWIRE_PROJECT_ID="your-project-id"
-export SIGNALWIRE_TOKEN="your-token"
+export SIGNALWIRE_API_TOKEN="your-token"
 
 # Agent configuration
 export AGENT_USERNAME="your-username"
@@ -172,7 +172,7 @@ Set these in your Azure Function App settings:
 ```bash
 # SignalWire credentials
 SIGNALWIRE_PROJECT_ID="your-project-id"
-SIGNALWIRE_TOKEN="your-token"
+SIGNALWIRE_API_TOKEN="your-token"
 
 # Agent configuration
 AGENT_USERNAME="your-username"

--- a/signalwire/signalwire/cli/dokku.py
+++ b/signalwire/signalwire/cli/dokku.py
@@ -144,7 +144,7 @@ ENV_EXAMPLE_TEMPLATE = """# SignalWire Agent Configuration
 # SignalWire Credentials (required for WebRTC calling)
 SIGNALWIRE_SPACE_NAME=your-space
 SIGNALWIRE_PROJECT_ID=your-project-id
-SIGNALWIRE_TOKEN=your-api-token
+SIGNALWIRE_API_TOKEN=your-api-token
 
 # Public URL for SWML callbacks (required for WebRTC calling)
 # This should be your publicly accessible URL (e.g., ngrok, dokku domain)
@@ -381,7 +381,7 @@ def setup_swml_handler():
     """Set up SWML handler on startup."""
     sw_host = get_signalwire_host()
     project = os.getenv("SIGNALWIRE_PROJECT_ID", "")
-    token = os.getenv("SIGNALWIRE_TOKEN", "")
+    token = os.getenv("SIGNALWIRE_API_TOKEN", "")
     agent_name = os.getenv("AGENT_NAME", "{agent_slug}")
     proxy_url = os.getenv("SWML_PROXY_URL_BASE", os.getenv("APP_URL", ""))
     auth_user = os.getenv("SWML_BASIC_AUTH_USER", "signalwire")
@@ -478,7 +478,7 @@ def get_token():
     """Get a guest token for WebRTC calls."""
     sw_host = get_signalwire_host()
     project = os.getenv("SIGNALWIRE_PROJECT_ID", "")
-    token = os.getenv("SIGNALWIRE_TOKEN", "")
+    token = os.getenv("SIGNALWIRE_API_TOKEN", "")
 
     if not all([sw_host, project, token]):
         return JSONResponse({{"error": "SignalWire credentials not configured"}}, status_code=500)
@@ -1315,7 +1315,7 @@ APP_JSON_TEMPLATE = """{{
       "description": "SignalWire project ID",
       "required": true
     }},
-    "SIGNALWIRE_TOKEN": {{
+    "SIGNALWIRE_API_TOKEN": {{
       "description": "SignalWire API token",
       "required": true
     }},

--- a/signalwire/signalwire/cli/init_project.py
+++ b/signalwire/signalwire/cli/init_project.py
@@ -133,7 +133,7 @@ def get_env_credentials() -> dict[str, str]:
     return {
         "space": os.environ.get("SIGNALWIRE_SPACE_NAME", ""),
         "project": os.environ.get("SIGNALWIRE_PROJECT_ID", ""),
-        "token": os.environ.get("SIGNALWIRE_TOKEN", ""),
+        "token": os.environ.get("SIGNALWIRE_API_TOKEN", ""),
     }
 
 
@@ -192,7 +192,7 @@ Thumbs.db
 TEMPLATE_ENV_EXAMPLE = """# SignalWire Credentials
 SIGNALWIRE_SPACE_NAME=your-space
 SIGNALWIRE_PROJECT_ID=your-project-id
-SIGNALWIRE_TOKEN=your-api-token
+SIGNALWIRE_API_TOKEN=your-api-token
 
 # Agent Server Configuration
 HOST=0.0.0.0
@@ -1719,7 +1719,7 @@ Edit `.env` to configure:
 |----------|-------------|
 | `SIGNALWIRE_SPACE_NAME` | Your SignalWire space name |
 | `SIGNALWIRE_PROJECT_ID` | Your SignalWire project ID |
-| `SIGNALWIRE_TOKEN` | Your SignalWire API token |
+| `SIGNALWIRE_API_TOKEN` | Your SignalWire API token |
 | `HOST` | Server host (default: 0.0.0.0) |
 | `PORT` | Server port (default: 5000) |
 
@@ -2317,7 +2317,7 @@ Set your phone number's SWML URL to the endpoint URL shown after deployment.
         env_content = f"""# SignalWire Credentials
 SIGNALWIRE_SPACE_NAME={self.credentials.get("space", "")}
 SIGNALWIRE_PROJECT_ID={self.credentials.get("project", "")}
-SIGNALWIRE_TOKEN={self.credentials.get("token", "")}
+SIGNALWIRE_API_TOKEN={self.credentials.get("token", "")}
 
 # Agent Server Configuration
 HOST=0.0.0.0

--- a/signalwire/signalwire/skills/datasphere/skill.py
+++ b/signalwire/signalwire/skills/datasphere/skill.py
@@ -51,7 +51,7 @@ class DataSphereSkill(SkillBase):
                     "description": "SignalWire API token",
                     "required": True,
                     "hidden": True,
-                    "env_var": "SIGNALWIRE_TOKEN",
+                    "env_var": "SIGNALWIRE_API_TOKEN",
                 },
                 "document_id": {
                     "type": "string",

--- a/signalwire/signalwire/skills/datasphere_serverless/skill.py
+++ b/signalwire/signalwire/skills/datasphere_serverless/skill.py
@@ -55,7 +55,7 @@ class DataSphereServerlessSkill(SkillBase):
                     "description": "SignalWire API token",
                     "required": True,
                     "hidden": True,
-                    "env_var": "SIGNALWIRE_TOKEN",
+                    "env_var": "SIGNALWIRE_API_TOKEN",
                 },
                 "document_id": {
                     "type": "string",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def mock_env_vars() -> Iterator[dict[str, str]]:
     """Mock environment variables for testing"""
     env_vars = {
         "SIGNALWIRE_PROJECT_ID": "test-project-id",
-        "SIGNALWIRE_TOKEN": "test-token",
+        "SIGNALWIRE_API_TOKEN": "test-token",
         "SIGNALWIRE_SPACE": "test.signalwire.com",
         "OPENAI_API_KEY": "test-openai-key",
         "TEST_ENV_VAR": "test-value"

--- a/tests/unit/cli/test_init_project.py
+++ b/tests/unit/cli/test_init_project.py
@@ -207,7 +207,7 @@ class TestGetEnvCredentials:
     @patch.dict(os.environ, {
         'SIGNALWIRE_SPACE_NAME': 'myspace',
         'SIGNALWIRE_PROJECT_ID': 'proj123',
-        'SIGNALWIRE_TOKEN': 'tok456',
+        'SIGNALWIRE_API_TOKEN': 'tok456',
     })
     def test_returns_env_values(self) -> None:
         creds = get_env_credentials()
@@ -218,7 +218,9 @@ class TestGetEnvCredentials:
     @patch.dict(os.environ, {}, clear=True)
     def test_returns_empty_when_unset(self) -> None:
         # Remove any env vars that might be set
-        for key in ['SIGNALWIRE_SPACE_NAME', 'SIGNALWIRE_PROJECT_ID', 'SIGNALWIRE_TOKEN']:
+        for key in [
+            'SIGNALWIRE_SPACE_NAME', 'SIGNALWIRE_PROJECT_ID', 'SIGNALWIRE_API_TOKEN',
+        ]:
             os.environ.pop(key, None)
         creds = get_env_credentials()
         assert creds['space'] == ''

--- a/tests/unit/skills/test_datasphere_serverless_skill.py
+++ b/tests/unit/skills/test_datasphere_serverless_skill.py
@@ -100,7 +100,7 @@ class TestDataSphereServerlessSkillParameterSchema:
         assert schema["token"]["type"] == "string"
         assert schema["token"]["required"] is True
         assert schema["token"]["hidden"] is True
-        assert schema["token"]["env_var"] == "SIGNALWIRE_TOKEN"
+        assert schema["token"]["env_var"] == "SIGNALWIRE_API_TOKEN"
 
     def test_schema_includes_document_id(self) -> None:
         """Test document_id parameter is defined"""

--- a/tests/unit/skills/test_datasphere_skill.py
+++ b/tests/unit/skills/test_datasphere_skill.py
@@ -132,7 +132,7 @@ class TestGetParameterSchema:
 
     def test_token_env_var(self) -> None:
         schema = DataSphereSkill.get_parameter_schema()
-        assert schema["token"].get("env_var") == "SIGNALWIRE_TOKEN"
+        assert schema["token"].get("env_var") == "SIGNALWIRE_API_TOKEN"
 
     def test_count_defaults(self) -> None:
         schema = DataSphereSkill.get_parameter_schema()


### PR DESCRIPTION
## Plan 4.4 — env-var naming unification

Standardizes the token environment variable on the canonical **`SIGNALWIRE_API_TOKEN`** (already used by the REST + RELAY clients) and removes the divergent `SIGNALWIRE_TOKEN` **outright** (no back-compat alias, per decision).

### Changed
- **`cli/init_project.py`** — `get_env_credentials()` reads `SIGNALWIRE_API_TOKEN`; generated `.env` scaffolding + doc table emit it.
- **`cli/dokku.py`** — the generated dokku app's runtime reads + `.env`/`app.json` templates use `SIGNALWIRE_API_TOKEN`.
- **`skills/datasphere/skill.py`** + **`datasphere_serverless/skill.py`** — declared `env_var` metadata → `SIGNALWIRE_API_TOKEN`.
- **`docs/cloud_functions_guide.md`** — the two `export …` examples.
- Tests updated to the canonical name (conftest fixture + init_project + both datasphere skill tests).

### Verified
- `606 passed` (full CLI + datasphere skill suites).
- `doc_env.py --port python` → **clean**.
- Zero `SIGNALWIRE_TOKEN` remaining anywhere in the repo.

Once merged, the oracle regen + DOC-ENV enforce the single name; the 9 ports pick it up on their next re-drift (any port still reading `SIGNALWIRE_TOKEN` will surface in DOC-ENV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
