### PR TITLE
fix(env): unify datasphere examples/docs to SIGNALWIRE_API_TOKEN (plan 4.4)

### DIFF
--- a/examples/datasphere_serverless_env_demo.py
+++ b/examples/datasphere_serverless_env_demo.py
@@ -17,7 +17,7 @@ from environment variables, showing best practices for production deployment.
 Required Environment Variables:
 - SIGNALWIRE_SPACE_NAME: Your SignalWire space name
 - SIGNALWIRE_PROJECT_ID: Your SignalWire project ID  
-- SIGNALWIRE_TOKEN: Your SignalWire authentication token
+- SIGNALWIRE_API_TOKEN: Your SignalWire authentication token
 - DATASPHERE_DOCUMENT_ID: The DataSphere document ID to search
 
 Optional Environment Variables:
@@ -29,7 +29,7 @@ Optional Environment Variables:
 Usage:
     export SIGNALWIRE_SPACE_NAME="your-space"
     export SIGNALWIRE_PROJECT_ID="your-project-id"
-    export SIGNALWIRE_TOKEN="your-token"
+    export SIGNALWIRE_API_TOKEN="your-token"
     export DATASPHERE_DOCUMENT_ID="your-document-id"
     python examples/datasphere_serverless_env_demo.py
 """
@@ -46,7 +46,7 @@ def get_required_env_var(name: str) -> str:
         print("\nRequired environment variables:")
         print("- SIGNALWIRE_SPACE_NAME: Your SignalWire space name")
         print("- SIGNALWIRE_PROJECT_ID: Your SignalWire project ID")
-        print("- SIGNALWIRE_TOKEN: Your SignalWire authentication token")
+        print("- SIGNALWIRE_API_TOKEN: Your SignalWire authentication token")
         print("- DATASPHERE_DOCUMENT_ID: The DataSphere document ID to search")
         print("\nOptional environment variables:")
         print("- DATASPHERE_COUNT: Number of search results (default: 3)")
@@ -70,7 +70,7 @@ def main():
     print("Loading configuration from environment variables...")
     space_name = get_required_env_var('SIGNALWIRE_SPACE_NAME')
     project_id = get_required_env_var('SIGNALWIRE_PROJECT_ID')
-    token = get_required_env_var('SIGNALWIRE_TOKEN')
+    token = get_required_env_var('SIGNALWIRE_API_TOKEN')
     document_id = get_required_env_var('DATASPHERE_DOCUMENT_ID')
     
     # Get optional environment variables with defaults

--- a/examples/datasphere_webhook_env_demo.py
+++ b/examples/datasphere_webhook_env_demo.py
@@ -17,7 +17,7 @@ from environment variables, showing the difference between webhook and serverles
 Required Environment Variables:
 - SIGNALWIRE_SPACE_NAME: Your SignalWire space name
 - SIGNALWIRE_PROJECT_ID: Your SignalWire project ID  
-- SIGNALWIRE_TOKEN: Your SignalWire authentication token
+- SIGNALWIRE_API_TOKEN: Your SignalWire authentication token
 - DATASPHERE_DOCUMENT_ID: The DataSphere document ID to search
 
 Optional Environment Variables:
@@ -29,7 +29,7 @@ Optional Environment Variables:
 Usage:
     export SIGNALWIRE_SPACE_NAME="your-space"
     export SIGNALWIRE_PROJECT_ID="your-project-id"
-    export SIGNALWIRE_TOKEN="your-token"
+    export SIGNALWIRE_API_TOKEN="your-token"
     export DATASPHERE_DOCUMENT_ID="your-document-id"
     python examples/datasphere_webhook_env_demo.py
 """
@@ -46,7 +46,7 @@ def get_required_env_var(name: str) -> str:
         print("\nRequired environment variables:")
         print("- SIGNALWIRE_SPACE_NAME: Your SignalWire space name")
         print("- SIGNALWIRE_PROJECT_ID: Your SignalWire project ID")
-        print("- SIGNALWIRE_TOKEN: Your SignalWire authentication token")
+        print("- SIGNALWIRE_API_TOKEN: Your SignalWire authentication token")
         print("- DATASPHERE_DOCUMENT_ID: The DataSphere document ID to search")
         print("\nOptional environment variables:")
         print("- DATASPHERE_COUNT: Number of search results (default: 3)")
@@ -70,7 +70,7 @@ def main():
     print("Loading configuration from environment variables...")
     space_name = get_required_env_var('SIGNALWIRE_SPACE_NAME')
     project_id = get_required_env_var('SIGNALWIRE_PROJECT_ID')
-    token = get_required_env_var('SIGNALWIRE_TOKEN')
+    token = get_required_env_var('SIGNALWIRE_API_TOKEN')
     document_id = get_required_env_var('DATASPHERE_DOCUMENT_ID')
     
     # Get optional environment variables with defaults

--- a/man/sw-agent-init.1
+++ b/man/sw-agent-init.1
@@ -138,7 +138,7 @@ variables:
 .IP \(bu 2
 .B SIGNALWIRE_PROJECT_ID
 .IP \(bu 2
-.B SIGNALWIRE_TOKEN
+.B SIGNALWIRE_API_TOKEN
 .PP
 If found, they are offered as defaults. Otherwise, you can enter them
 manually or skip and configure later.
@@ -378,7 +378,7 @@ SignalWire space name. If set, used as default in interactive mode.
 .B SIGNALWIRE_PROJECT_ID
 SignalWire project ID. If set, used as default in interactive mode.
 .TP
-.B SIGNALWIRE_TOKEN
+.B SIGNALWIRE_API_TOKEN
 SignalWire API token. If set, used as default in interactive mode.
 .SH EXIT STATUS
 .TP


### PR DESCRIPTION
Plan item 4.4 — unify the token env var to the canonical `SIGNALWIRE_API_TOKEN` fleet-wide.

The datasphere env-demo examples (+ the sw-agent-init man page) referenced the inconsistent `SIGNALWIRE_TOKEN`, while the SDK's REST/RELAY clients and every other port read `SIGNALWIRE_API_TOKEN`. This aligns the examples/docs to the canonical name (outright rename, matching the fleet decision — no back-compat alias, since these are example/doc references, not a runtime env read that needs a fallback). DOC-ENV verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
