### PR TITLE
feat(rest): RequestOptions envelope — timeout/retries/abort (plan 4.2)

### DIFF
--- a/scripts/doc_wire_runner.py
+++ b/scripts/doc_wire_runner.py
@@ -22,15 +22,21 @@ from __future__ import annotations
 import os
 import sys
 
-from signalwire.rest import RestClient
+from signalwire.rest import RequestOptions, RestClient
 from signalwire.rest._base import HttpClient
 
 
 def _client(base_url: str) -> RestClient:
     original_init = HttpClient.__init__
 
-    def _patched_init(self: HttpClient, project: str, token: str, host: str) -> None:
-        original_init(self, project, token, host)
+    def _patched_init(
+        self: HttpClient,
+        project: str,
+        token: str,
+        host: str,
+        request_options: RequestOptions | None = None,
+    ) -> None:
+        original_init(self, project, token, host, request_options=request_options)
         self._base_url = base_url
 
     HttpClient.__init__ = _patched_init  # type: ignore[method-assign]

--- a/signalwire/signalwire/rest/__init__.py
+++ b/signalwire/signalwire/rest/__init__.py
@@ -11,10 +11,12 @@ SignalWire REST API client module.
 
 from .client import RestClient
 from ._base import SignalWireRestError, SignalWireRestTransportError
+from ._request_options import RequestOptions
 from .namespaces.relay_rest_types_generated import PhoneCallHandler
 
 __all__ = [
     "PhoneCallHandler",
+    "RequestOptions",
     "RestClient",
     "SignalWireRestError",
     "SignalWireRestTransportError",

--- a/signalwire/signalwire/rest/_base.py
+++ b/signalwire/signalwire/rest/_base.py
@@ -9,12 +9,18 @@ See LICENSE file in the project root for full license information.
 HTTP client infrastructure and base resource classes for the REST client.
 """
 
+import time
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Generic, TypeVar, cast
 
 import requests
 from signalwire.core.logging_config import get_logger
 from signalwire.rest._pagination import PaginatedIterator
+from signalwire.rest._request_options import (
+    RequestOptions,
+    resolve,
+    status_is_retryable,
+)
 
 logger = get_logger("rest_client")
 
@@ -86,8 +92,15 @@ class SignalWireRestTransportError(SignalWireRestError):
 class HttpClient:
     """Thin wrapper around requests.Session with Basic Auth and JSON handling."""
 
-    def __init__(self, project: str, token: str, host: str) -> None:
+    def __init__(
+        self,
+        project: str,
+        token: str,
+        host: str,
+        request_options: RequestOptions | None = None,
+    ) -> None:
         self._base_url = f"https://{host}"
+        self._request_options = request_options
         self._session = requests.Session()
         self._session.auth = (project, token)
         self._session.headers.update(
@@ -99,49 +112,120 @@ class HttpClient:
         )
         logger.debug("HttpClient initialized", host=host, project=project[:8] + "...")
 
+    def _sleep(self, seconds: float) -> None:
+        """Backoff sleep between retries. A seam so tests can drive the retry
+        loop without wall-clock delay (the mock proves attempt ORDERING, not
+        real time)."""
+        if seconds > 0:
+            time.sleep(seconds)
+
+    def _retry_after_seconds(self, resp: requests.Response) -> float | None:
+        """Parse a ``Retry-After`` header (delta-seconds form) if present."""
+        value = resp.headers.get("Retry-After")
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None  # HTTP-date form: fall back to computed backoff
+
     def _request(
         self,
         method: str,
         path: str,
         body: Any = None,
         params: dict[str, Any] | None = None,
+        request_options: RequestOptions | None = None,
     ) -> Any:
         url = self._base_url + path
+        opts = resolve(self._request_options, request_options)
         logger.debug("REST request", method=method, path=path)
-        try:
-            resp = self._session.request(method, url, json=body, params=params)
-        except requests.RequestException as exc:
-            # Transport failure (connection refused / DNS / reset / TLS): the request
-            # never produced a response. Wrap in the typed error family so a caller
-            # catching SignalWireRestError handles it too, instead of a bare
-            # requests.ConnectionError leaking out.
-            raise SignalWireRestTransportError(str(exc), path, method) from exc
-        if not resp.ok:
-            try:
-                err_body: Any = resp.json()
-            except Exception:
-                err_body = resp.text
-            raise SignalWireRestError(resp.status_code, err_body, path, method)
-        if resp.status_code == 204 or not resp.content:
-            return {}
-        return resp.json()
 
-    def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
-        return self._request("GET", path, params=params)
+        # total attempts = retries + 1; retry on a retryable status (idempotency-
+        # aware) or a transport error, honoring Retry-After then exponential
+        # backoff. abort_signal is checked cooperatively before every attempt.
+        attempt = 0
+        while True:
+            attempt += 1
+            if opts.abort_signal is not None and opts.abort_signal.is_set():
+                # Cancelled before this attempt — surface as the transport-error
+                # family (no response was produced), not a bare exception.
+                raise SignalWireRestTransportError(
+                    "request cancelled by abort_signal", path, method
+                )
+
+            try:
+                resp = self._session.request(
+                    method, url, json=body, params=params, timeout=opts.timeout
+                )
+            except requests.RequestException as exc:
+                # Transport failure (connection refused / DNS / reset / TLS /
+                # timeout): the request never produced a response. Retry if
+                # attempts remain, else wrap in the typed error family so a caller
+                # catching SignalWireRestError handles it too.
+                if attempt <= opts.retries:
+                    self._sleep(opts.retry_backoff * 2 ** (attempt - 1))
+                    continue
+                raise SignalWireRestTransportError(str(exc), path, method) from exc
+
+            if not resp.ok:
+                if attempt <= opts.retries and status_is_retryable(
+                    method, resp.status_code, opts
+                ):
+                    delay = self._retry_after_seconds(resp)
+                    if delay is None:
+                        delay = opts.retry_backoff * 2 ** (attempt - 1)
+                    self._sleep(delay)
+                    continue
+                try:
+                    err_body: Any = resp.json()
+                except Exception:
+                    err_body = resp.text
+                raise SignalWireRestError(resp.status_code, err_body, path, method)
+
+            if resp.status_code == 204 or not resp.content:
+                return {}
+            return resp.json()
+
+    def get(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        request_options: RequestOptions | None = None,
+    ) -> Any:
+        return self._request(
+            "GET", path, params=params, request_options=request_options
+        )
 
     def post(
-        self, path: str, body: Any = None, params: dict[str, Any] | None = None
+        self,
+        path: str,
+        body: Any = None,
+        params: dict[str, Any] | None = None,
+        request_options: RequestOptions | None = None,
     ) -> Any:
-        return self._request("POST", path, body=body, params=params)
+        return self._request(
+            "POST", path, body=body, params=params, request_options=request_options
+        )
 
-    def put(self, path: str, body: Any = None) -> Any:
-        return self._request("PUT", path, body=body)
+    def put(
+        self,
+        path: str,
+        body: Any = None,
+        request_options: RequestOptions | None = None,
+    ) -> Any:
+        return self._request("PUT", path, body=body, request_options=request_options)
 
-    def patch(self, path: str, body: Any = None) -> Any:
-        return self._request("PATCH", path, body=body)
+    def patch(
+        self,
+        path: str,
+        body: Any = None,
+        request_options: RequestOptions | None = None,
+    ) -> Any:
+        return self._request("PATCH", path, body=body, request_options=request_options)
 
-    def delete(self, path: str) -> Any:
-        return self._request("DELETE", path)
+    def delete(self, path: str, request_options: RequestOptions | None = None) -> Any:
+        return self._request("DELETE", path, request_options=request_options)
 
 
 class BaseResource:

--- a/signalwire/signalwire/rest/_request_options.py
+++ b/signalwire/signalwire/rest/_request_options.py
@@ -10,7 +10,7 @@ cooperative cancellation. Supplied at two levels:
   that *shallow-overrides* the client default for that one call — an unset
   (``None``) field falls back to the client default, then the built-in default.
 
-The timeout + retry semantics are the oracle-pinned, wire-observable contract
+The timeout + retry semantics are the reference-pinned, wire-observable contract
 (the mock sees N attempts and honors the backoff ordering). ``abort_signal``
 fidelity is per-port idiom (see the cross-port design): every port exposes the
 field; how deeply the cancellation cuts is the language's business. In python a

--- a/signalwire/signalwire/rest/_request_options.py
+++ b/signalwire/signalwire/rest/_request_options.py
@@ -1,0 +1,159 @@
+"""RequestOptions — the REST request-options envelope (plan 4.2).
+
+A single value object controlling per-request transport behavior: timeout,
+retries (with an idempotency-aware retry policy + exponential backoff), and
+cooperative cancellation. Supplied at two levels:
+
+- **Client default**: ``RestClient(..., request_options=...)`` stored on the
+  ``HttpClient`` and applied to every request.
+- **Per-request override**: each verb accepts an optional ``request_options=``
+  that *shallow-overrides* the client default for that one call — an unset
+  (``None``) field falls back to the client default, then the built-in default.
+
+The timeout + retry semantics are the oracle-pinned, wire-observable contract
+(the mock sees N attempts and honors the backoff ordering). ``abort_signal``
+fidelity is per-port idiom (see the cross-port design): every port exposes the
+field; how deeply the cancellation cuts is the language's business. In python a
+sync client cannot interrupt an in-flight blocking socket read without a thread,
+so cancellation is checked cooperatively *between* attempts — the honest,
+portable minimum.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class _AbortSignal(Protocol):
+    """The cooperative-cancellation primitive: anything with ``is_set() -> bool``.
+
+    A ``threading.Event`` satisfies this directly. Checked before each attempt;
+    if set, the request raises rather than proceeding.
+    """
+
+    def is_set(self) -> bool: ...
+
+
+# The built-in defaults (the contract floor). ``None`` on a RequestOptions field
+# means "inherit"; these are what an unset field resolves to at apply-time.
+_DEFAULT_TIMEOUT = 30.0
+_DEFAULT_RETRIES = 0
+_DEFAULT_RETRY_ON_STATUS = frozenset({429, 500, 502, 503, 504})
+_DEFAULT_RETRY_BACKOFF = 0.5
+
+
+@dataclass(frozen=True)
+class RequestOptions:
+    """Per-request transport options. All fields optional; ``None`` = inherit.
+
+    Fields (defaults resolved at apply-time, so ``None`` genuinely means
+    "fall back to the client default, then the built-in"):
+
+    - ``timeout``: max wall-clock seconds per attempt; on exceed the request
+      raises the transport-error type. Built-in default ``30.0``.
+    - ``retries``: number of RETRY attempts (total attempts = ``retries + 1``)
+      on a retryable failure. Built-in default ``0`` (opt-in resilience — the
+      no-retry behavior stays the default; a caller opts into retries).
+    - ``retry_on_status``: HTTP statuses that trigger a retry for an idempotent
+      method. Built-in ``{429, 500, 502, 503, 504}``.
+    - ``retry_backoff``: base seconds for exponential backoff between retries
+      (``backoff * 2 ** (attempt - 1)``), honoring ``Retry-After`` when present.
+      Built-in ``0.5``.
+    - ``abort_signal``: a cooperative-cancellation object (``is_set()``); checked
+      before each attempt. Built-in ``None``.
+    """
+
+    timeout: float | None = None
+    retries: int | None = None
+    retry_on_status: frozenset[int] | None = None
+    retry_backoff: float | None = None
+    abort_signal: _AbortSignal | None = None
+
+    def merge(self, override: RequestOptions | None) -> RequestOptions:
+        """Return ``self`` with any set (non-``None``) field of ``override`` applied.
+
+        This is the per-request-over-client-default shallow merge: an unset field
+        on ``override`` leaves ``self``'s value intact.
+        """
+        if override is None:
+            return self
+        changes: dict[str, Any] = {
+            name: value
+            for name in (
+                "timeout",
+                "retries",
+                "retry_on_status",
+                "retry_backoff",
+                "abort_signal",
+            )
+            if (value := getattr(override, name)) is not None
+        }
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True)
+class _EffectiveOptions:
+    """A RequestOptions with every field resolved to a concrete value.
+
+    Produced by :func:`resolve` — no ``None`` remains, so the request loop reads
+    concrete values without re-checking defaults on every attempt.
+    """
+
+    timeout: float
+    retries: int
+    retry_on_status: frozenset[int]
+    retry_backoff: float
+    abort_signal: _AbortSignal | None
+
+
+def resolve(
+    client_default: RequestOptions | None,
+    per_request: RequestOptions | None,
+) -> _EffectiveOptions:
+    """Resolve the effective options: per-request over client-default over built-in.
+
+    ``None`` on any field inherits the next level down; the built-in defaults are
+    the floor. The result has every field concrete.
+    """
+    merged = (client_default or RequestOptions()).merge(per_request)
+    return _EffectiveOptions(
+        timeout=merged.timeout if merged.timeout is not None else _DEFAULT_TIMEOUT,
+        retries=merged.retries if merged.retries is not None else _DEFAULT_RETRIES,
+        retry_on_status=(
+            merged.retry_on_status
+            if merged.retry_on_status is not None
+            else _DEFAULT_RETRY_ON_STATUS
+        ),
+        retry_backoff=(
+            merged.retry_backoff
+            if merged.retry_backoff is not None
+            else _DEFAULT_RETRY_BACKOFF
+        ),
+        abort_signal=merged.abort_signal,
+    )
+
+
+# Methods with no server-side side effect — safe to retry on any retryable status.
+# POST/PATCH are excluded: they may create/mutate, so they retry ONLY on a
+# transport error or 429/503-with-Retry-After (never blindly on 500/502/504),
+# to avoid duplicate side effects. This asymmetry is part of the pinned contract.
+_IDEMPOTENT_METHODS = frozenset({"GET", "PUT", "DELETE", "HEAD", "OPTIONS"})
+
+
+def status_is_retryable(method: str, status: int, opts: _EffectiveOptions) -> bool:
+    """Whether an HTTP ``status`` for ``method`` should trigger a retry.
+
+    Idempotent methods (GET/PUT/DELETE) retry on the full ``retry_on_status``
+    set. Non-idempotent methods (POST/PATCH) retry only on 429/503 (the
+    Retry-After-bearing throttles), never on 500/502/504, to avoid replaying a
+    side effect that may have partially applied.
+    """
+    if status not in opts.retry_on_status:
+        return False
+    if method.upper() in _IDEMPOTENT_METHODS:
+        return True
+    # Non-idempotent: only the throttle statuses (which carry Retry-After and
+    # mean "the request was NOT processed, back off").
+    return status in (429, 503)

--- a/signalwire/signalwire/rest/client.py
+++ b/signalwire/signalwire/rest/client.py
@@ -12,6 +12,7 @@ RestClient — top-level REST client with namespaced sub-objects.
 import os
 
 from ._base import HttpClient
+from ._request_options import RequestOptions
 from .namespaces._client_tree_generated import _GeneratedResourceTree
 
 
@@ -44,6 +45,7 @@ class RestClient(_GeneratedResourceTree):
         project: str | None = None,
         token: str | None = None,
         host: str | None = None,
+        request_options: RequestOptions | None = None,
     ) -> None:
         project = project or os.environ.get("SIGNALWIRE_PROJECT_ID", "")
         token = token or os.environ.get("SIGNALWIRE_API_TOKEN", "")
@@ -57,7 +59,7 @@ class RestClient(_GeneratedResourceTree):
             )
 
         self._project = project
-        self._http = HttpClient(project, token, host)
+        self._http = HttpClient(project, token, host, request_options=request_options)
 
         # Generated resource tree (flat resources + namespace containers).
         self._wire_resources(self._http)

--- a/tests/unit/rest/conftest.py
+++ b/tests/unit/rest/conftest.py
@@ -70,6 +70,7 @@ import pytest
 import requests
 
 from signalwire.rest._base import HttpClient
+from signalwire.rest._request_options import RequestOptions
 from signalwire.rest.client import RestClient
 
 
@@ -113,7 +114,9 @@ _MOCK_AVAILABLE = _MOCK_PKG_DIR is not None
 class MockResponse:
     """Simulates a requests.Response — used by the legacy ``mock_session`` fixture."""
 
-    def __init__(self, status_code: int = 200, json_data: object = None, content: bytes = b"ok") -> None:
+    def __init__(
+        self, status_code: int = 200, json_data: object = None, content: bytes = b"ok"
+    ) -> None:
         self.status_code = status_code
         self._json = json_data if json_data is not None else {}
         self.content = content
@@ -255,14 +258,21 @@ class _SharedServer:
             if _MOCK_PKG_DIR:
                 existing = child_env.get("PYTHONPATH", "")
                 child_env["PYTHONPATH"] = (
-                    f"{_MOCK_PKG_DIR}{os.pathsep}{existing}" if existing else _MOCK_PKG_DIR
+                    f"{_MOCK_PKG_DIR}{os.pathsep}{existing}"
+                    if existing
+                    else _MOCK_PKG_DIR
                 )
             self._child = subprocess.Popen(  # noqa: S603  (spawns the local mock server, fixed argv)
                 [
-                    sys.executable, "-m", "mock_signalwire",
-                    "--host", "127.0.0.1",
-                    "--port", str(port),
-                    "--log-level", "error",
+                    sys.executable,
+                    "-m",
+                    "mock_signalwire",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    str(port),
+                    "--log-level",
+                    "error",
                 ],
                 env=child_env,
                 stdout=subprocess.DEVNULL,
@@ -360,7 +370,9 @@ class _MockHarness:
         entries = self._raw_journal()
         if not self.auth_header:
             return entries
-        return [e for e in entries if e.headers.get("authorization") == self.auth_header]
+        return [
+            e for e in entries if e.headers.get("authorization") == self.auth_header
+        ]
 
     def last_request(self) -> _JournalEntry:
         """Most recent journal entry for THIS client.  Raises if empty."""
@@ -431,7 +443,9 @@ def mock() -> _MockHarness:
 
 
 @pytest.fixture
-def signalwire_client(mock: _MockHarness, monkeypatch: pytest.MonkeyPatch) -> Iterator[RestClient]:
+def signalwire_client(
+    mock: _MockHarness, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[RestClient]:
     """A real ``RestClient`` whose HTTP transport hits the shared mock.
 
     Each client authenticates with the constant project ``test_proj`` and a
@@ -451,9 +465,9 @@ def signalwire_client(mock: _MockHarness, monkeypatch: pytest.MonkeyPatch) -> It
     to the ``RestClient`` class.
     """
     token = f"test_tok_{uuid.uuid4().hex[:12]}"
-    auth_header = "Basic " + base64.b64encode(
-        f"{_REST_PROJECT}:{token}".encode()
-    ).decode()
+    auth_header = (
+        "Basic " + base64.b64encode(f"{_REST_PROJECT}:{token}".encode()).decode()
+    )
 
     # Scope the harness view to this client's auth header.
     mock.project = _REST_PROJECT
@@ -461,8 +475,14 @@ def signalwire_client(mock: _MockHarness, monkeypatch: pytest.MonkeyPatch) -> It
 
     original_init = HttpClient.__init__
 
-    def _patched_init(self: HttpClient, *args: object, **kwargs: object) -> None:
-        original_init(self, *args, **kwargs)  # threads request_options through
+    def _patched_init(
+        self: HttpClient,
+        project: str,
+        token: str,
+        host: str,
+        request_options: RequestOptions | None = None,
+    ) -> None:
+        original_init(self, project, token, host, request_options=request_options)
         self._base_url = mock.url
 
     monkeypatch.setattr(HttpClient, "__init__", _patched_init)

--- a/tests/unit/rest/conftest.py
+++ b/tests/unit/rest/conftest.py
@@ -384,17 +384,36 @@ class _MockHarness:
         requests.post(f"{self.url}/__mock__/journal/reset", timeout=5)
         requests.post(f"{self.url}/__mock__/scenarios/reset", timeout=5)
 
-    def push_scenario(self, endpoint_id: str, status: int, response: Any) -> None:
+    def push_scenario(
+        self,
+        endpoint_id: str,
+        status: int,
+        response: Any,
+        headers: dict[str, str] | None = None,
+        delay_ms: int | None = None,
+    ) -> None:
         """Stage a consume-once response override for ``endpoint_id``.
 
         Scoped to THIS client's auth header (REST's session key is the
         ``Authorization`` header), so a concurrent test can't consume the
         override and a stale one can't bleed across tests.
+
+        Multiple pushes on the same endpoint are consumed FIFO — stage
+        ``503`` then let the request retry into the default ``200`` (or stage
+        ``503`` then ``200``) to exercise the retry contract over the real mock.
+        ``headers`` can carry ``Retry-After``; ``delay_ms`` arms a server-side
+        delay so a client's ``timeout`` fires (both proven on the wire, not
+        mock.patch).
         """
         url = f"{self.url}/__mock__/scenarios/{endpoint_id}"
         if self.auth_header:
             url = f"{url}?session_id={quote(self.auth_header, safe='')}"
-        resp = requests.post(url, json={"status": status, "response": response}, timeout=5)
+        payload: dict[str, Any] = {"status": status, "response": response}
+        if headers is not None:
+            payload["headers"] = headers
+        if delay_ms is not None:
+            payload["delay_ms"] = delay_ms
+        resp = requests.post(url, json=payload, timeout=5)
         resp.raise_for_status()
 
 
@@ -442,8 +461,8 @@ def signalwire_client(mock: _MockHarness, monkeypatch: pytest.MonkeyPatch) -> It
 
     original_init = HttpClient.__init__
 
-    def _patched_init(self: HttpClient, project: str, token: str, host: str) -> None:
-        original_init(self, project, token, host)
+    def _patched_init(self: HttpClient, *args: object, **kwargs: object) -> None:
+        original_init(self, *args, **kwargs)  # threads request_options through
         self._base_url = mock.url
 
     monkeypatch.setattr(HttpClient, "__init__", _patched_init)

--- a/tests/unit/rest/test_base.py
+++ b/tests/unit/rest/test_base.py
@@ -34,7 +34,7 @@ class TestHttpClient:
         result = http.get("/api/test", params={"page": 1})
         mock_session.request.assert_called_once_with(
             "GET", "https://test.signalwire.com/api/test",
-            json=None, params={"page": 1},
+            json=None, params={"page": 1}, timeout=30.0,
         )
         assert result == {"data": [1, 2]}
 
@@ -43,7 +43,7 @@ class TestHttpClient:
         result = http.post("/api/test", body={"name": "x"})
         mock_session.request.assert_called_once_with(
             "POST", "https://test.signalwire.com/api/test",
-            json={"name": "x"}, params=None,
+            json={"name": "x"}, params=None, timeout=30.0,
         )
         assert result == {"id": "abc"}
 
@@ -52,7 +52,7 @@ class TestHttpClient:
         result = http.put("/api/test/1", body={"name": "y"})
         mock_session.request.assert_called_once_with(
             "PUT", "https://test.signalwire.com/api/test/1",
-            json={"name": "y"}, params=None,
+            json={"name": "y"}, params=None, timeout=30.0,
         )
 
     def test_patch(self, http: HttpClient, mock_session: MagicMock) -> None:
@@ -60,7 +60,7 @@ class TestHttpClient:
         http.patch("/api/test/1", body={"name": "z"})
         mock_session.request.assert_called_once_with(
             "PATCH", "https://test.signalwire.com/api/test/1",
-            json={"name": "z"}, params=None,
+            json={"name": "z"}, params=None, timeout=30.0,
         )
 
     def test_delete(self, http: HttpClient, mock_session: MagicMock) -> None:
@@ -68,7 +68,7 @@ class TestHttpClient:
         result = http.delete("/api/test/1")
         mock_session.request.assert_called_once_with(
             "DELETE", "https://test.signalwire.com/api/test/1",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
         assert result == {}
 
@@ -106,7 +106,7 @@ class TestCrudResource:
         result = res.list(page=1)
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/items",
-            json=None, params={"page": 1},
+            json=None, params={"page": 1}, timeout=30.0,
         )
 
     def test_create(self, http: HttpClient, mock_session: MagicMock) -> None:
@@ -115,7 +115,7 @@ class TestCrudResource:
         result = res.create(name="test")
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/items",
-            json={"name": "test"}, params=None,
+            json={"name": "test"}, params=None, timeout=30.0,
         )
 
     def test_get(self, http: HttpClient, mock_session: MagicMock) -> None:
@@ -124,7 +124,7 @@ class TestCrudResource:
         result = res.get("abc")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/items/abc",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
     def test_update_patch(self, http: HttpClient, mock_session: MagicMock) -> None:
@@ -133,7 +133,7 @@ class TestCrudResource:
         res.update("abc", name="updated")
         mock_session.request.assert_called_with(
             "PATCH", "https://test.signalwire.com/api/items/abc",
-            json={"name": "updated"}, params=None,
+            json={"name": "updated"}, params=None, timeout=30.0,
         )
 
     def test_update_put(self, http: HttpClient, mock_session: MagicMock) -> None:
@@ -146,7 +146,7 @@ class TestCrudResource:
         res.update("abc", name="updated")
         mock_session.request.assert_called_with(
             "PUT", "https://test.signalwire.com/api/items/abc",
-            json={"name": "updated"}, params=None,
+            json={"name": "updated"}, params=None, timeout=30.0,
         )
 
     def test_delete(self, http: HttpClient, mock_session: MagicMock) -> None:
@@ -155,7 +155,7 @@ class TestCrudResource:
         res.delete("abc")
         mock_session.request.assert_called_with(
             "DELETE", "https://test.signalwire.com/api/items/abc",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
 
@@ -166,5 +166,5 @@ class TestCrudWithAddresses:
         res.list_addresses("abc")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/fabric/resources/ai_agents/abc/addresses",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )

--- a/tests/unit/rest/test_fabric.py
+++ b/tests/unit/rest/test_fabric.py
@@ -14,7 +14,7 @@ class TestFabricResources:
         client.fabric.ai_agents.list()
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/fabric/resources/ai_agents",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
     def test_ai_agents_create(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -27,7 +27,7 @@ class TestFabricResources:
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/fabric/resources/ai_agents",
             json={"name": "Support", "prompt": "You are helpful", "agent_id": "a1"},
-            params=None,
+            params=None, timeout=30.0,
         )
 
     def test_ai_agents_update_uses_patch(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -35,7 +35,7 @@ class TestFabricResources:
         client.fabric.ai_agents.update("id-1", name="Updated")
         mock_session.request.assert_called_with(
             "PATCH", "https://test.signalwire.com/api/fabric/resources/ai_agents/id-1",
-            json={"name": "Updated"}, params=None,
+            json={"name": "Updated"}, params=None, timeout=30.0,
         )
 
     def test_swml_scripts_update_uses_put(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -43,7 +43,7 @@ class TestFabricResources:
         client.fabric.swml_scripts.update("id-1", contents="{}")
         mock_session.request.assert_called_with(
             "PUT", "https://test.signalwire.com/api/fabric/resources/swml_scripts/id-1",
-            json={"contents": "{}"}, params=None,
+            json={"contents": "{}"}, params=None, timeout=30.0,
         )
 
     def test_list_addresses(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -51,7 +51,7 @@ class TestFabricResources:
         client.fabric.ai_agents.list_addresses("id-1")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/fabric/resources/ai_agents/id-1/addresses",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
 
@@ -61,7 +61,7 @@ class TestFabricCallFlows:
         client.fabric.call_flows.list_versions("cf-1")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/fabric/resources/call_flow/cf-1/versions",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
     def test_deploy_version(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -69,7 +69,7 @@ class TestFabricCallFlows:
         client.fabric.call_flows.deploy_version("cf-1", {"document_version": 2})
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/fabric/resources/call_flow/cf-1/versions",
-            json={"document_version": 2}, params=None,
+            json={"document_version": 2}, params=None, timeout=30.0,
         )
 
 
@@ -79,7 +79,7 @@ class TestFabricSubscribers:
         client.fabric.subscribers.list_sip_endpoints("sub-1")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/fabric/resources/subscribers/sub-1/sip_endpoints",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
     def test_create_sip_endpoint(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -89,7 +89,7 @@ class TestFabricSubscribers:
         )
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/fabric/resources/subscribers/sub-1/sip_endpoints",
-            json={"username": "user1", "password": "s3cret"}, params=None,
+            json={"username": "user1", "password": "s3cret"}, params=None, timeout=30.0,
         )
 
 
@@ -107,7 +107,7 @@ class TestGenericResources:
         )
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/fabric/resources/res-1/phone_routes",
-            json={"phone_route_id": "pr-1", "handler": "calling"}, params=None,
+            json={"phone_route_id": "pr-1", "handler": "calling"}, params=None, timeout=30.0,
         )
 
 
@@ -159,7 +159,7 @@ class TestFabricTokens:
         client.fabric.tokens.create_subscriber_token(reference="user@example.com")
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/fabric/subscribers/tokens",
-            json={"reference": "user@example.com"}, params=None,
+            json={"reference": "user@example.com"}, params=None, timeout=30.0,
         )
 
     def test_create_guest_token(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -167,7 +167,7 @@ class TestFabricTokens:
         client.fabric.tokens.create_guest_token(allowed_addresses=["addr-1"])
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/fabric/guests/tokens",
-            json={"allowed_addresses": ["addr-1"]}, params=None,
+            json={"allowed_addresses": ["addr-1"]}, params=None, timeout=30.0,
         )
 
 

--- a/tests/unit/rest/test_namespaces.py
+++ b/tests/unit/rest/test_namespaces.py
@@ -14,7 +14,7 @@ class TestPhoneNumbers:
         client.phone_numbers.search(area_code="512")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/relay/rest/phone_numbers/search",
-            json=None, params={"area_code": "512"},
+            json=None, params={"area_code": "512"}, timeout=30.0,
         )
 
     def test_update_uses_put(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -22,7 +22,7 @@ class TestPhoneNumbers:
         client.phone_numbers.update("pn-1", name="Main")
         mock_session.request.assert_called_with(
             "PUT", "https://test.signalwire.com/api/relay/rest/phone_numbers/pn-1",
-            json={"name": "Main"}, params=None,
+            json={"name": "Main"}, params=None, timeout=30.0,
         )
 
 
@@ -32,7 +32,7 @@ class TestQueues:
         client.queues.list_members("q-1")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/relay/rest/queues/q-1/members",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
     def test_get_next_member(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -40,7 +40,7 @@ class TestQueues:
         client.queues.get_next_member("q-1")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/relay/rest/queues/q-1/members/next",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
 
@@ -50,7 +50,7 @@ class TestNumberGroups:
         client.number_groups.add_membership("ng-1", phone_number_id="pn-1")
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/relay/rest/number_groups/ng-1/number_group_memberships",
-            json={"phone_number_id": "pn-1"}, params=None,
+            json={"phone_number_id": "pn-1"}, params=None, timeout=30.0,
         )
 
     def test_get_membership(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -58,7 +58,7 @@ class TestNumberGroups:
         client.number_groups.get_membership("mem-1")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/relay/rest/number_group_memberships/mem-1",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
 
@@ -68,7 +68,7 @@ class TestVerifiedCallers:
         client.verified_callers.redial_verification("vc-1")
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/relay/rest/verified_caller_ids/vc-1/verification",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
     def test_submit_verification(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -76,7 +76,7 @@ class TestVerifiedCallers:
         client.verified_callers.submit_verification("vc-1", verification_code="123456")
         mock_session.request.assert_called_with(
             "PUT", "https://test.signalwire.com/api/relay/rest/verified_caller_ids/vc-1/verification",
-            json={"verification_code": "123456"}, params=None,
+            json={"verification_code": "123456"}, params=None, timeout=30.0,
         )
 
 
@@ -86,7 +86,7 @@ class TestSipProfile:
         client.sip_profile.get()
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/relay/rest/sip_profile",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
 
@@ -96,7 +96,7 @@ class TestLookup:
         client.lookup.phone_number("+15551234567", include="carrier")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/relay/rest/lookup/phone_number/+15551234567",
-            json=None, params={"include": "carrier"},
+            json=None, params={"include": "carrier"}, timeout=30.0,
         )
 
 
@@ -106,7 +106,7 @@ class TestMfa:
         client.mfa.sms(to="+15551234567", from_="+15559876543")
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/relay/rest/mfa/sms",
-            json={"to": "+15551234567", "from": "+15559876543"}, params=None,
+            json={"to": "+15551234567", "from": "+15559876543"}, params=None, timeout=30.0,
         )
 
     def test_verify(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -114,7 +114,7 @@ class TestMfa:
         client.mfa.verify("mfa-1", token="123456")  # noqa: S106
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/relay/rest/mfa/mfa-1/verify",
-            json={"token": "123456"}, params=None,
+            json={"token": "123456"}, params=None, timeout=30.0,
         )
 
 
@@ -124,7 +124,7 @@ class TestDatasphere:
         client.datasphere.documents.search(query_string="billing")
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/datasphere/documents/search",
-            json={"query_string": "billing"}, params=None,
+            json={"query_string": "billing"}, params=None, timeout=30.0,
         )
 
     def test_list_chunks(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -132,7 +132,7 @@ class TestDatasphere:
         client.datasphere.documents.list_chunks("doc-1")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/datasphere/documents/doc-1/chunks",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
     def test_delete_chunk(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -140,7 +140,7 @@ class TestDatasphere:
         client.datasphere.documents.delete_chunk("doc-1", "chunk-1")
         mock_session.request.assert_called_with(
             "DELETE", "https://test.signalwire.com/api/datasphere/documents/doc-1/chunks/chunk-1",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
 
@@ -150,7 +150,7 @@ class TestVideo:
         client.video.rooms.create(name="standup")
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/video/rooms",
-            json={"name": "standup"}, params=None,
+            json={"name": "standup"}, params=None, timeout=30.0,
         )
 
     def test_room_tokens_create(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -158,7 +158,7 @@ class TestVideo:
         client.video.room_tokens.create(room_name="standup", user_name="alice")
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/video/room_tokens",
-            json={"room_name": "standup", "user_name": "alice"}, params=None,
+            json={"room_name": "standup", "user_name": "alice"}, params=None, timeout=30.0,
         )
 
     def test_session_members(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -166,7 +166,7 @@ class TestVideo:
         client.video.room_sessions.list_members("sess-1")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/video/room_sessions/sess-1/members",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
     def test_conference_streams(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -174,7 +174,7 @@ class TestVideo:
         client.video.conferences.create_stream("conf-1", url="rtmp://example.com/live")
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/video/conferences/conf-1/streams",
-            json={"url": "rtmp://example.com/live"}, params=None,
+            json={"url": "rtmp://example.com/live"}, params=None, timeout=30.0,
         )
 
 
@@ -184,7 +184,7 @@ class TestLogs:
         client.logs.voice.list_events("log-1")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/voice/logs/log-1/events",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
 
@@ -199,7 +199,7 @@ class TestRegistry:
         client.registry.brands.create(body)
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/relay/rest/registry/beta/brands",
-            json=body, params=None,
+            json=body, params=None, timeout=30.0,
         )
 
     def test_campaign_orders(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -207,7 +207,7 @@ class TestRegistry:
         client.registry.campaigns.list_orders("camp-1")
         mock_session.request.assert_called_with(
             "GET", "https://test.signalwire.com/api/relay/rest/registry/beta/campaigns/camp-1/orders",
-            json=None, params=None,
+            json=None, params=None, timeout=30.0,
         )
 
 
@@ -217,7 +217,7 @@ class TestProjectTokens:
         client.project.tokens.create(name="test-token", permissions=["calling"])
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/project/tokens",
-            json={"name": "test-token", "permissions": ["calling"]}, params=None,
+            json={"name": "test-token", "permissions": ["calling"]}, params=None, timeout=30.0,
         )
 
 
@@ -227,7 +227,7 @@ class TestPubSubChat:
         client.pubsub.create_token(ttl=60, channels={"room": {"read": True}})
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/pubsub/tokens",
-            json={"ttl": 60, "channels": {"room": {"read": True}}}, params=None,
+            json={"ttl": 60, "channels": {"room": {"read": True}}}, params=None, timeout=30.0,
         )
 
     def test_chat_token(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -235,5 +235,5 @@ class TestPubSubChat:
         client.chat.create_token(ttl=60, channels={"room": {"read": True}})
         mock_session.request.assert_called_with(
             "POST", "https://test.signalwire.com/api/chat/tokens",
-            json={"ttl": 60, "channels": {"room": {"read": True}}}, params=None,
+            json={"ttl": 60, "channels": {"room": {"read": True}}}, params=None, timeout=30.0,
         )

--- a/tests/unit/rest/test_phone_numbers.py
+++ b/tests/unit/rest/test_phone_numbers.py
@@ -25,14 +25,14 @@ class TestPhoneNumbersCrud:
         mock_session.request.return_value = MockResponse(200, {"data": []})
         client.phone_numbers.list()
         mock_session.request.assert_called_with(
-            "GET", BASE, json=None, params=None,
+            "GET", BASE, json=None, params=None, timeout=30.0,
         )
 
     def test_search(self, client: RestClient, mock_session: MagicMock) -> None:
         mock_session.request.return_value = MockResponse(200, {"data": []})
         client.phone_numbers.search(area_code="512")
         mock_session.request.assert_called_with(
-            "GET", f"{BASE}/search", json=None, params={"area_code": "512"},
+            "GET", f"{BASE}/search", json=None, params={"area_code": "512"}, timeout=30.0,
         )
 
     def test_update_uses_put(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -40,7 +40,7 @@ class TestPhoneNumbersCrud:
         mock_session.request.return_value = MockResponse(200, {})
         client.phone_numbers.update("pn-1", name="Main")
         mock_session.request.assert_called_with(
-            "PUT", f"{BASE}/pn-1", json={"name": "Main"}, params=None,
+            "PUT", f"{BASE}/pn-1", json={"name": "Main"}, params=None, timeout=30.0,
         )
 
 
@@ -90,7 +90,7 @@ class TestSetSwmlWebhook:
                 "call_handler": "relay_script",
                 "call_relay_script_url": "https://example.com/swml",
             },
-            params=None,
+            params=None, timeout=30.0,
         )
 
     def test_extra_kwargs_pass_through(self, client: RestClient, mock_session: MagicMock) -> None:
@@ -116,7 +116,7 @@ class TestSetCxmlWebhook:
                 "call_handler": "laml_webhooks",
                 "call_request_url": "https://example.com/voice.xml",
             },
-            params=None,
+            params=None, timeout=30.0,
         )
 
     def test_with_fallback_and_status(self, client: RestClient, mock_session: MagicMock) -> None:

--- a/tests/unit/rest/test_request_options.py
+++ b/tests/unit/rest/test_request_options.py
@@ -1,0 +1,202 @@
+"""RequestOptions envelope — behavioral contract over the real mock (plan 4.2).
+
+These drive a real ``RestClient`` through the real ``requests`` transport into
+the shared ``mock_signalwire`` and assert on the recorded journal — the same
+journal the REST-COVERAGE gate reads. Retry / timeout are wire-observable: the
+mock sees N attempts and honors the backoff ordering, so the contract is proven
+over the real mock, NOT mock.patch.
+
+Contract pinned here (the oracle):
+- ``retries``: a retryable failure is retried up to ``retries`` extra times; the
+  mock sees ``retries + 1`` attempts; the final success is returned.
+- idempotency asymmetry: GET/PUT/DELETE retry on the full ``retry_on_status``
+  set; POST/PATCH retry only on 429/503 (throttles), never 500/502/504.
+- ``timeout``: a server-side delay exceeding the timeout raises the transport
+  error family.
+- ``abort_signal``: set before a request raises the transport error family.
+- per-request options shallow-override the client default.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+
+from signalwire.rest import RequestOptions
+from signalwire.rest._base import SignalWireRestError, SignalWireRestTransportError
+
+if TYPE_CHECKING:
+    from signalwire.rest.client import RestClient
+
+    from .conftest import _MockHarness
+
+# A spec-derived endpoint the mock synthesizes a 200 for by default, and whose
+# scenario store we can override. Same one the pagination tests use.
+_ADDRESSES_ENDPOINT_ID = "fabric.list_fabric_addresses"
+
+
+def _addresses(client: RestClient, request_options: RequestOptions | None = None):
+    """Drive one GET /api/fabric/addresses through the real transport."""
+    return client._http.get("/api/fabric/addresses", request_options=request_options)
+
+
+class TestRetryContract:
+    """A retryable failure is retried; the mock sees every attempt."""
+
+    def test_get_retries_503_then_succeeds(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        # Arm a single 503; the default synthesized 200 follows it. With
+        # retries=1 the client retries the 503 into the 200 → 2 attempts.
+        mock.push_scenario(_ADDRESSES_ENDPOINT_ID, 503, {"errors": [{"code": "X"}]})
+        result = _addresses(
+            signalwire_client,
+            RequestOptions(retries=1, retry_backoff=0.0),  # no wall-clock delay
+        )
+        assert result is not None
+        gets = [
+            e
+            for e in mock.journal
+            if e.path == "/api/fabric/addresses" and e.method == "GET"
+        ]
+        assert len(gets) == 2, f"expected 2 attempts (503 then 200), got {len(gets)}"
+
+    def test_no_retries_by_default_raises_on_first_failure(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        # Default retries=0: the first non-2xx raises immediately (the original
+        # no-retry contract remains the default; retries are opt-in).
+        mock.push_scenario(_ADDRESSES_ENDPOINT_ID, 503, {"errors": [{"code": "X"}]})
+        with pytest.raises(SignalWireRestError) as exc:
+            _addresses(signalwire_client)
+        assert exc.value.status_code == 503
+        gets = [
+            e
+            for e in mock.journal
+            if e.path == "/api/fabric/addresses" and e.method == "GET"
+        ]
+        assert len(gets) == 1, "default must not retry"
+
+    def test_retries_exhausted_raises_last_error(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        # Two 503s + retries=1 => attempts = 2, both 503 => raise the 503.
+        mock.push_scenario(_ADDRESSES_ENDPOINT_ID, 503, {"errors": [{"code": "X"}]})
+        mock.push_scenario(_ADDRESSES_ENDPOINT_ID, 503, {"errors": [{"code": "X"}]})
+        with pytest.raises(SignalWireRestError) as exc:
+            _addresses(signalwire_client, RequestOptions(retries=1, retry_backoff=0.0))
+        assert exc.value.status_code == 503
+        gets = [
+            e
+            for e in mock.journal
+            if e.path == "/api/fabric/addresses" and e.method == "GET"
+        ]
+        assert len(gets) == 2, "retries=1 => exactly 2 attempts"
+
+
+class TestIdempotencyAsymmetry:
+    """POST/PATCH do not blindly retry 500/502/504; GET/PUT/DELETE do."""
+
+    _CREATE_ADDRESS_PATH = "/api/relay/rest/addresses"
+
+    def test_post_does_not_retry_500(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        # A real POST route; 500 is NOT retryable for a non-idempotent method
+        # even with retries armed → exactly one attempt, raise the 500.
+        mock.push_scenario("relay-rest.create_address", 500, {"error": "x"})
+        with pytest.raises(SignalWireRestError) as exc:
+            signalwire_client._http.post(
+                self._CREATE_ADDRESS_PATH,
+                body={"label": "x"},
+                request_options=RequestOptions(retries=2, retry_backoff=0.0),
+            )
+        assert exc.value.status_code == 500
+        posts = [
+            e
+            for e in mock.journal
+            if e.path == self._CREATE_ADDRESS_PATH and e.method == "POST"
+        ]
+        assert len(posts) == 1, "POST must not retry a 500 (side-effect safety)"
+
+    def test_post_does_retry_503(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        # 503 (throttle, carries Retry-After semantics) IS retryable even for a
+        # non-idempotent method → the 503 retries into the default 200.
+        mock.push_scenario("relay-rest.create_address", 503, {"error": "x"})
+        signalwire_client._http.post(
+            self._CREATE_ADDRESS_PATH,
+            body={"label": "x"},
+            request_options=RequestOptions(retries=1, retry_backoff=0.0),
+        )
+        posts = [
+            e
+            for e in mock.journal
+            if e.path == self._CREATE_ADDRESS_PATH and e.method == "POST"
+        ]
+        assert len(posts) == 2, "POST retries a 503 throttle (safe): 503 then 200"
+
+
+class TestTimeout:
+    """A server-side delay exceeding the timeout raises the transport error."""
+
+    def test_slow_response_times_out(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        # Arm a 200 delayed 400ms; a 100ms timeout must fire → transport error.
+        mock.push_scenario(
+            _ADDRESSES_ENDPOINT_ID, 200, {"data": [], "links": {}}, delay_ms=400
+        )
+        with pytest.raises(SignalWireRestTransportError):
+            _addresses(signalwire_client, RequestOptions(timeout=0.1))
+
+
+class TestAbortSignal:
+    """A set abort_signal raises before the request goes out."""
+
+    def test_preset_abort_raises_transport_error(
+        self, signalwire_client: RestClient, mock: _MockHarness
+    ) -> None:
+        ev = threading.Event()
+        ev.set()
+        with pytest.raises(SignalWireRestTransportError):
+            _addresses(signalwire_client, RequestOptions(abort_signal=ev))
+        # Nothing reached the mock — cancelled before the send.
+        gets = [
+            e
+            for e in mock.journal
+            if e.path == "/api/fabric/addresses" and e.method == "GET"
+        ]
+        assert gets == [], "aborted request must not reach the server"
+
+
+class TestPerRequestOverride:
+    """Per-request options shallow-override the client default."""
+
+    def test_per_request_retries_override_client_default(
+        self, mock: _MockHarness
+    ) -> None:
+        from signalwire.rest.client import RestClient
+
+        # Client default = no retries; per-request opts in to 1 retry.
+        client = RestClient(
+            project="p" * 34,
+            token="t" * 34,
+            host="127.0.0.1",
+            request_options=RequestOptions(retries=0),
+        )
+        # Point it at the mock.
+        client._http._base_url = mock.url
+        # Auth-scope the scenario to this client.
+        mock_scoped = mock  # unscoped harness; use shared bucket
+        mock_scoped.push_scenario(
+            _ADDRESSES_ENDPOINT_ID, 503, {"errors": [{"code": "X"}]}
+        )
+        result = client._http.get(
+            "/api/fabric/addresses",
+            request_options=RequestOptions(retries=1, retry_backoff=0.0),
+        )
+        assert result is not None

--- a/tests/unit/rest/test_request_options.py
+++ b/tests/unit/rest/test_request_options.py
@@ -20,7 +20,7 @@ Contract pinned here (the oracle):
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -37,7 +37,9 @@ if TYPE_CHECKING:
 _ADDRESSES_ENDPOINT_ID = "fabric.list_fabric_addresses"
 
 
-def _addresses(client: RestClient, request_options: RequestOptions | None = None):
+def _addresses(
+    client: RestClient, request_options: RequestOptions | None = None
+) -> Any:
     """Drive one GET /api/fabric/addresses through the real transport."""
     return client._http.get("/api/fabric/addresses", request_options=request_options)
 


### PR DESCRIPTION
Plan item 4.2 — the RequestOptions transport envelope, python reference (the ORACLE for the cross-port rollout).

Adds `RequestOptions` (timeout + retries + retry_on_status + retry_backoff + abort_signal), client-default + per-request override, with an idempotency-aware retry policy (GET/PUT/DELETE retry the full status set; POST/PATCH only 429/503 throttles), exponential backoff honoring Retry-After, and cooperative abort. Replaces the former no-retry contract with opt-in retries (default 0 = today's behavior). 8 behavioral tests over the shared mock (wire-proven, no mock.patch); full REST suite green (642).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
