### PR TITLE
ci: unpin porting-sdk checkout to main (post-merge)

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -38,7 +38,7 @@ jobs:
           repository: signalwire/porting-sdk
           # PINNED to the A+ campaign branch wave/1-aplus (see test.yml). REVERT to
           # main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           # SPEC-PARITY gates use these; on main they lack request_options and crash
           # (RecordingHttp.get() got an unexpected keyword argument 'request_options').
           # REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 


### PR DESCRIPTION
Wave 1 merged; wave/1-aplus deleted. Revert workflow pins to `ref: main`. 0 residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)