### PR TITLE
ci: unpin porting-sdk checkout from deleted wave/1-aplus to main

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -38,7 +38,7 @@ jobs:
           repository: signalwire/porting-sdk
           # PINNED to the A+ campaign branch wave/1-aplus (see test.yml). REVERT to
           # main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           # SPEC-PARITY gates use these; on main they lack request_options and crash
           # (RecordingHttp.get() got an unexpected keyword argument 'request_options').
           # REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 


### PR DESCRIPTION
porting-sdk `wave/1-aplus` was merged into porting-sdk main (via porting-sdk#108) and the branch **deleted**. Workflows here still pinned the porting-sdk checkout to that branch, which now fails:

```
gh: No commit found for SHA: wave/1-aplus (HTTP 422)
```

(confirmed live on java's `Multi-OS (nightly)` guard step, run 29858501705). The wave content — request_options threading through the REST generator, the regenerated `python_signatures.json` oracle, the mcp_gateway skill oracle — is all on **porting-sdk main @72c7ff5** now, so `main` is the correct ref. This is exactly the REVERT the inline `# REVERT this ref to main when porting-sdk wave/1-aplus merges` comments prescribed.

Reverts every active `ref: wave/1-aplus` / `commits/wave/1-aplus` → `main`. No behavior change beyond restoring a resolvable ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhUoqrbptHNS3cypq9s6t
