### PR TITLE
Wave 2 (A+): reference fix — agents/__init__.py closes BedrockAgent oracle hole

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -36,9 +36,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: signalwire/porting-sdk
-          # PINNED to the A+ campaign branch wave/1-aplus (see test.yml). REVERT to
-          # main when porting-sdk wave/1-aplus merges.
-          ref: main
+          # Coordinated-pass pin: `main` normally; set the PORTING_SDK_REF repo variable
+          # to a wave branch to test a coordinated porting-sdk change, declared on the PR
+          # (see porting-sdk/COORDINATED_PASS.md). No revert commit.
+          ref: ${{ vars.PORTING_SDK_REF || 'main' }}
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/multi-os.yml
+++ b/.github/workflows/multi-os.yml
@@ -35,11 +35,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: signalwire/porting-sdk
-          # PINNED to the gate-enforcement plan branch: WIRED-MODES/DOC-SURFACE call
-          # porting-sdk scripts (check_wired_modes.py, doc_surface.py) not yet on main,
-          # and DRIFT diffs the regenerated 6.6 oracle committed there. REVERT this ref
-          # to main when the porting-sdk plan branch merges.
-          ref: main
+          # Coordinated-pass pin: `main` normally; set the PORTING_SDK_REF repo variable
+          # to a wave branch to test a coordinated porting-sdk change, declared on the PR
+          # (see porting-sdk/COORDINATED_PASS.md). No revert commit.
+          ref: ${{ vars.PORTING_SDK_REF || 'main' }}
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -126,6 +126,9 @@ jobs:
         env:
           PORTING_SDK: ${{ github.workspace }}/porting-sdk
           SW_CI_TIER: nightly
+          # COORDINATED-PASS reads the live PR body/labels via `gh api` to see a
+          # `Coordinated-With:` declaration edited after the triggering push.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/run-ci.sh
 
       - name: Record green marker for this input triple

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -89,11 +89,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: signalwire/porting-sdk
-          # PINNED to the gate-enforcement plan branch: WIRED-MODES/DOC-SURFACE call
-          # porting-sdk scripts (check_wired_modes.py, doc_surface.py) not yet on main,
-          # and DRIFT diffs the regenerated 6.6 oracle committed there. REVERT this ref
-          # to main when the porting-sdk plan branch merges.
-          ref: main
+          # Coordinated-pass pin: `main` normally; set the PORTING_SDK_REF repo variable
+          # to a wave branch to test a coordinated porting-sdk change, declared on the PR
+          # (see porting-sdk/COORDINATED_PASS.md). No revert commit.
+          ref: ${{ vars.PORTING_SDK_REF || 'main' }}
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -34,10 +34,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: signalwire/porting-sdk
-          # PINNED to the gate-enforcement plan branch: WIRED-MODES/DOC-SURFACE call
-          # porting-sdk scripts (check_wired_modes.py, doc_surface.py) not yet on main,
-          # and DRIFT diffs the regenerated 6.6 oracle committed there. REVERT this ref
-          # to main when the porting-sdk plan branch merges.
+          # Publish always builds against porting-sdk main — deliberately NOT the
+          # coordinated-pass PORTING_SDK_REF variable, so a release can never ship from
+          # an unmerged wave branch (see porting-sdk/COORDINATED_PASS.md).
           ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,10 +30,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: signalwire/porting-sdk
-          # PINNED to the gate-enforcement plan branch: WIRED-MODES/DOC-SURFACE call
-          # porting-sdk scripts (check_wired_modes.py, doc_surface.py) not yet on main,
-          # and DRIFT diffs the regenerated 6.6 oracle committed there. REVERT this ref
-          # to main when the porting-sdk plan branch merges.
+          # Publish always builds against porting-sdk main — deliberately NOT the
+          # coordinated-pass PORTING_SDK_REF variable, so a release can never ship from
+          # an unmerged wave branch (see porting-sdk/COORDINATED_PASS.md).
           ref: main
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,14 +37,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: signalwire/porting-sdk
-          # PINNED to the A+ campaign branch wave/1-aplus: PY-7 threads request_options
-          # through the REST generator (generate_python_rest_types.py) + regenerates the
-          # python_signatures.json oracle + the python_route_registry.py RecordingHttp
-          # shim — all on porting-sdk wave/1-aplus. CI's DRIFT/GEN-FRESH/ROUTE-COLLISION/
-          # SPEC-PARITY gates use these; on main they lack request_options and crash
-          # (RecordingHttp.get() got an unexpected keyword argument 'request_options').
-          # REVERT this ref to main when porting-sdk wave/1-aplus merges.
-          ref: main
+          # Coordinated-pass pin: `main` normally; set the PORTING_SDK_REF repo variable
+          # to a wave branch (e.g. wave/2-aplus) to test a coordinated porting-sdk change,
+          # and declare it on the PR (see porting-sdk/COORDINATED_PASS.md). No revert commit.
+          ref: ${{ vars.PORTING_SDK_REF || 'main' }}
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,4 +90,7 @@ jobs:
         env:
           PORTING_SDK: ${{ github.workspace }}/porting-sdk
           SW_CI_TIER: ${{ steps.tier.outputs.tier }}
+          # COORDINATED-PASS reads the live PR body/labels via `gh api` to see a
+          # `Coordinated-With:` declaration edited after the triggering push.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash scripts/run-ci.sh

--- a/EXAMPLES_RUN_ALLOW.md
+++ b/EXAMPLES_RUN_ALLOW.md
@@ -16,3 +16,4 @@ real example bug; every entry names a concrete external requirement.
 - examples/quickstart_rest.py — issues a real fabric.ai_agents.create() REST call on load; needs real SignalWire project creds (401 against mock) (mike, 2026-07-08)
 - examples/lambda_agent.py — requires the optional `mangum` AWS-Lambda adapter (deployment-only, not a base dependency) (mike, 2026-07-08)
 - examples/swml_service_example.py — interactive: calls input() for a menu choice; cannot run headless (EOFError) (mike, 2026-07-08)
+- relay/examples/relay_dial_and_play.py — drives an outbound RELAY call via a direct `await client.connect()` (no reconnect loop), which opens a real `wss://` RELAY WebSocket; the EXAMPLES-RUN harness starts only the REST mock (no RELAY WS endpoint), so connect() raises immediately. Needs a real SignalWire RELAY endpoint (mike, 2026-07-23)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Each agent is a self-contained microservice that generates [SWML](docs/swml_serv
 from signalwire import AgentBase
 from signalwire.core.function_result import FunctionResult
 
+
 class MyAgent(AgentBase):
     def __init__(self):
         super().__init__(name="my-agent", route="/agent")
@@ -56,7 +57,9 @@ class MyAgent(AgentBase):
     def get_time(self):
         """Get the current time"""
         from datetime import datetime
+
         return FunctionResult(f"The time is {datetime.now().strftime('%H:%M:%S')}")
+
 
 if __name__ == "__main__":
     agent = MyAgent()
@@ -116,7 +119,10 @@ Real-time call control and messaging over WebSocket. The RELAY client connects t
 ```python
 from signalwire.relay import RelayClient
 
-client = RelayClient(project="...", token="...", host="example.signalwire.com", contexts=["default"])
+client = RelayClient(
+    project="...", token="...", host="example.signalwire.com", contexts=["default"]
+)
+
 
 @client.on_call
 async def handle(call):
@@ -124,6 +130,7 @@ async def handle(call):
     action = await call.play([{"type": "tts", "params": {"text": "Welcome!"}}])
     await action.wait()
     await call.hangup()
+
 
 client.run()
 ```

--- a/SNIPPET_RUN_ALLOW.md
+++ b/SNIPPET_RUN_ALLOW.md
@@ -12,4 +12,4 @@ display quickstart, not a runnable program). The agent/relay quickstart entries
 auto-classify covers a server-starting quickstart (verified — the gate is clean without
 them), so those lines were redundant (double-allowlist purge, plan 3-python-f).
 
-- README.md:145 — quickstart_rest include: hardcoded placeholder creds + real host — a display quickstart, not runnable against the mock (burn-py, 2026-07-09; reason updated 2026-07-19)
+- README.md:152 — quickstart_rest include: hardcoded placeholder creds + real host — a display quickstart, not runnable against the mock (burn-py, 2026-07-09; reason updated 2026-07-19; anchor refreshed 2026-07-23 after the quickstart_agent/relay blocks above gained ruff-format blank lines)

--- a/examples/advanced_datamap_demo.py
+++ b/examples/advanced_datamap_demo.py
@@ -22,139 +22,198 @@ This example demonstrates all the comprehensive DataMap features including:
 from signalwire.core.data_map import DataMap
 from signalwire.core.function_result import FunctionResult
 
+
 def create_expression_demo():
     """Demonstrate expression-based responses with test values and patterns"""
-    return (DataMap('command_processor')
-        .description('Process user commands with pattern matching')
-        .parameter('command', 'string', 'User command to process', required=True)
-        .parameter('target', 'string', 'Optional target for the command', required=False)
-        
+    return (
+        DataMap("command_processor")
+        .description("Process user commands with pattern matching")
+        .parameter("command", "string", "User command to process", required=True)
+        .parameter(
+            "target", "string", "Optional target for the command", required=False
+        )
         # Expression with pattern matching
-        .expression('${args.command}', r'^start', 
-                   FunctionResult('Starting process: ${args.target}').add_action('start_process', {'target': '${args.target}'}))
-        .expression('${args.command}', r'^stop', 
-                   FunctionResult('Stopping process: ${args.target}').add_action('stop_process', {'target': '${args.target}'}))
-        .expression('${args.command}', r'^status', 
-                   FunctionResult('Checking status of: ${args.target}').add_action('check_status', {'target': '${args.target}'}),
-                   nomatch_output=FunctionResult('Unknown command: ${args.command}. Try start, stop, or status.'))
+        .expression(
+            "${args.command}",
+            r"^start",
+            FunctionResult("Starting process: ${args.target}").add_action(
+                "start_process", {"target": "${args.target}"}
+            ),
+        )
+        .expression(
+            "${args.command}",
+            r"^stop",
+            FunctionResult("Stopping process: ${args.target}").add_action(
+                "stop_process", {"target": "${args.target}"}
+            ),
+        )
+        .expression(
+            "${args.command}",
+            r"^status",
+            FunctionResult("Checking status of: ${args.target}").add_action(
+                "check_status", {"target": "${args.target}"}
+            ),
+            nomatch_output=FunctionResult(
+                "Unknown command: ${args.command}. Try start, stop, or status."
+            ),
+        )
     )
+
 
 def create_advanced_webhook_demo():
     """Demonstrate advanced webhook features"""
-    return (DataMap('advanced_api_tool')
-        .description('API tool with advanced webhook features')
-        .parameter('action', 'string', 'Action to perform', required=True)
-        .parameter('data', 'string', 'Data to send', required=False)
-        .parameter('format', 'string', 'Response format', required=False)
-        
+    return (
+        DataMap("advanced_api_tool")
+        .description("API tool with advanced webhook features")
+        .parameter("action", "string", "Action to perform", required=True)
+        .parameter("data", "string", "Data to send", required=False)
+        .parameter("format", "string", "Response format", required=False)
         # Primary API with all advanced features
-        .webhook('POST', 'https://api.example.com/advanced',
-                headers={
-                    'Authorization': 'Bearer ${token}',
-                    'User-Agent': 'SignalWire-Agent/1.0'
-                },
-                input_args_as_params=True,  # Merge function args into params
-                require_args=['action'],    # Only execute if action is provided
-                form_param='payload')       # Send as form data
-        
-        # Add post-webhook expressions
-        .webhook_expressions([
-            {
-                "string": "${response.status}",
-                "pattern": "^success$",
-                "output": {"response": "Operation completed successfully"}
+        .webhook(
+            "POST",
+            "https://api.example.com/advanced",
+            headers={
+                "Authorization": "Bearer ${token}",
+                "User-Agent": "SignalWire-Agent/1.0",
             },
-            {
-                "string": "${response.error_code}",
-                "pattern": "^(404|500)$",
-                "output": {"response": "API Error: ${response.error_message}"}
-            }
-        ])
-        
+            input_args_as_params=True,  # Merge function args into params
+            require_args=["action"],  # Only execute if action is provided
+            form_param="payload",
+        )  # Send as form data
+        # Add post-webhook expressions
+        .webhook_expressions(
+            [
+                {
+                    "string": "${response.status}",
+                    "pattern": "^success$",
+                    "output": {"response": "Operation completed successfully"},
+                },
+                {
+                    "string": "${response.error_code}",
+                    "pattern": "^(404|500)$",
+                    "output": {"response": "API Error: ${response.error_message}"},
+                },
+            ]
+        )
         # Fallback API without form encoding
-        .webhook('GET', 'https://backup-api.example.com/simple',
-                headers={'Accept': 'application/json'})
-        .params({'q': '${args.action}'})
-        .output(FunctionResult('Backup result: ${response.data}'))
-        
+        .webhook(
+            "GET",
+            "https://backup-api.example.com/simple",
+            headers={"Accept": "application/json"},
+        )
+        .params({"q": "${args.action}"})
+        .output(FunctionResult("Backup result: ${response.data}"))
         # Global fallback
-        .fallback_output(FunctionResult('All APIs are currently unavailable'))
-        .global_error_keys(['error', 'fault', 'exception'])
+        .fallback_output(FunctionResult("All APIs are currently unavailable"))
+        .global_error_keys(["error", "fault", "exception"])
     )
+
 
 def create_form_encoding_demo():
     """Demonstrate form parameter encoding"""
-    return (DataMap('form_submission_tool')
-        .description('Submit form data using form encoding')
-        .parameter('name', 'string', 'User name', required=True)
-        .parameter('email', 'string', 'User email', required=True)
-        .parameter('message', 'string', 'Message content', required=True)
-        
-        .webhook('POST', 'https://forms.example.com/submit',
-                headers={
-                    'Content-Type': 'application/x-www-form-urlencoded',
-                    'X-API-Key': '${api_key}'
-                },
-                form_param='form_data')  # Sends entire JSON as form_data parameter
-        .params({
-            'name': '${args.name}',
-            'email': '${args.email}',
-            'message': '${args.message}',
-            'timestamp': '@{strftime_tz UTC %Y-%m-%d %H:%M:%S}'
-        })
-        .output(FunctionResult('Form submitted successfully for ${args.name}'))
-        .error_keys(['error', 'validation_errors'])
+    return (
+        DataMap("form_submission_tool")
+        .description("Submit form data using form encoding")
+        .parameter("name", "string", "User name", required=True)
+        .parameter("email", "string", "User email", required=True)
+        .parameter("message", "string", "Message content", required=True)
+        .webhook(
+            "POST",
+            "https://forms.example.com/submit",
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "X-API-Key": "${api_key}",
+            },
+            form_param="form_data",
+        )  # Sends entire JSON as form_data parameter
+        .params(
+            {
+                "name": "${args.name}",
+                "email": "${args.email}",
+                "message": "${args.message}",
+                "timestamp": "@{strftime_tz UTC %Y-%m-%d %H:%M:%S}",
+            }
+        )
+        .output(FunctionResult("Form submitted successfully for ${args.name}"))
+        .error_keys(["error", "validation_errors"])
     )
+
 
 def create_array_processing_demo():
     """Demonstrate array processing with foreach"""
-    return (DataMap('search_results_tool')
-        .description('Search and format results from API')
-        .parameter('query', 'string', 'Search query', required=True)
-        .parameter('limit', 'string', 'Maximum results', required=False)
-        
-        .webhook('GET', 'https://search-api.example.com/search',
-                headers={'Authorization': 'Bearer ${search_token}'})
-        .params({
-            'q': '${args.query}',
-            'max_results': '@{expr ${args.limit} > 10 ? 10 : ${args.limit}}'
-        })
-        .foreach({
-            "input_key": "results",
-            "output_key": "formatted_results",
-            "max": 5,
-            "append": "Title: ${this.title}\n${this.summary}\nURL: ${this.url}\n\n"
-        })
-        .output(FunctionResult('Found @{expr ${response.total}} results for "${args.query}":\n\n${formatted_results}'))
-        .error_keys(['error'])
+    return (
+        DataMap("search_results_tool")
+        .description("Search and format results from API")
+        .parameter("query", "string", "Search query", required=True)
+        .parameter("limit", "string", "Maximum results", required=False)
+        .webhook(
+            "GET",
+            "https://search-api.example.com/search",
+            headers={"Authorization": "Bearer ${search_token}"},
+        )
+        .params(
+            {
+                "q": "${args.query}",
+                "max_results": "@{expr ${args.limit} > 10 ? 10 : ${args.limit}}",
+            }
+        )
+        .foreach(
+            {
+                "input_key": "results",
+                "output_key": "formatted_results",
+                "max": 5,
+                "append": "Title: ${this.title}\n${this.summary}\nURL: ${this.url}\n\n",
+            }
+        )
+        .output(
+            FunctionResult(
+                'Found @{expr ${response.total}} results for "${args.query}":\n\n${formatted_results}'
+            )
+        )
+        .error_keys(["error"])
     )
+
 
 def create_conditional_logic_demo():
     """Demonstrate complex conditional logic with expressions and functions"""
-    return (DataMap('smart_calculator')
-        .description('Smart calculator with conditional responses')
-        .parameter('expression', 'string', 'Mathematical expression', required=True)
-        .parameter('format', 'string', 'Output format (simple/detailed)', required=False)
-        
+    return (
+        DataMap("smart_calculator")
+        .description("Smart calculator with conditional responses")
+        .parameter("expression", "string", "Mathematical expression", required=True)
+        .parameter(
+            "format", "string", "Output format (simple/detailed)", required=False
+        )
         # Check if expression is simple arithmetic
-        .expression('${args.expression}', r'^\s*\d+\s*[+\-*/]\s*\d+\s*$',
-                   FunctionResult('Quick calculation: ${args.expression} = @{expr ${args.expression}}'))
-        
+        .expression(
+            "${args.expression}",
+            r"^\s*\d+\s*[+\-*/]\s*\d+\s*$",
+            FunctionResult(
+                "Quick calculation: ${args.expression} = @{expr ${args.expression}}"
+            ),
+        )
         # Check if requesting detailed format
-        .expression('${args.format}', r'^detailed$',
-                   FunctionResult().add_action('detailed_calc', {
-                       'expression': '${args.expression}',
-                       'result': '@{expr ${args.expression}}',
-                       'timestamp': '@{strftime_tz UTC %Y-%m-%d %H:%M:%S}'
-                   }))
-        
+        .expression(
+            "${args.format}",
+            r"^detailed$",
+            FunctionResult().add_action(
+                "detailed_calc",
+                {
+                    "expression": "${args.expression}",
+                    "result": "@{expr ${args.expression}}",
+                    "timestamp": "@{strftime_tz UTC %Y-%m-%d %H:%M:%S}",
+                },
+            ),
+        )
         # Fallback for complex expressions
-        .fallback_output(FunctionResult(
-            'Expression: ${args.expression}\n' +
-            'Result: @{expr ${args.expression}}\n' +
-            'Calculated at: @{strftime_tz UTC %Y-%m-%d %H:%M:%S}'
-        ))
+        .fallback_output(
+            FunctionResult(
+                "Expression: ${args.expression}\n"
+                + "Result: @{expr ${args.expression}}\n"
+                + "Calculated at: @{strftime_tz UTC %Y-%m-%d %H:%M:%S}"
+            )
+        )
     )
+
 
 if __name__ == "__main__":
     # Create and display all demo tools
@@ -163,13 +222,14 @@ if __name__ == "__main__":
         ("Advanced Webhook Demo", create_advanced_webhook_demo()),
         ("Form Encoding Demo", create_form_encoding_demo()),
         ("Array Processing Demo", create_array_processing_demo()),
-        ("Conditional Logic Demo", create_conditional_logic_demo())
+        ("Conditional Logic Demo", create_conditional_logic_demo()),
     ]
-    
+
     for name, demo in demos:
-        print(f"\n{'='*50}")
+        print(f"\n{'=' * 50}")
         print(f"{name}")
-        print('='*50)
-        
+        print("=" * 50)
+
         import json
-        print(json.dumps(demo.to_swaig_function(), indent=2)) 
+
+        print(json.dumps(demo.to_swaig_function(), indent=2))

--- a/examples/auto_vivified_example.py
+++ b/examples/auto_vivified_example.py
@@ -18,12 +18,9 @@ and more intuitive API for building SWML documents.
 Example: service.play(url="say:Hello") instead of service.add_verb("play", {"url": "say:Hello"})
 """
 
-import os
-import sys
 import json
 import argparse
 import logging
-import types
 
 # Import structlog for logger instance creation
 import structlog
@@ -39,25 +36,20 @@ class VoicemailService(SWMLService):
     """
     Simple voicemail service using auto-vivified verb methods
     """
-    
+
     def __init__(self, host="0.0.0.0", port=3000):
-        super().__init__(
-            name="voicemail",
-            route="/voicemail",
-            host=host,
-            port=port
-        )
-        
+        super().__init__(name="voicemail", route="/voicemail", host=host, port=port)
+
         # Debug: Print available verbs and schema details
         verb_names = self.schema_utils.get_all_verb_names()
         print(f"Available verbs: {verb_names}")
         print(f"Schema path: {self.schema_utils.schema_path}")
         print(f"Schema loaded: {bool(self.schema_utils.schema)}")
         print(f"Number of verbs extracted: {len(self.schema_utils.verbs)}")
-        
+
         # Explicit testing of auto-vivification
         print("\n--- Testing Auto-Vivification Mechanism ---")
-        
+
         # Try normal attribute access to see if __getattr__ gets triggered
         try:
             print("\nAttempting normal attribute access for 'play'...")
@@ -68,40 +60,47 @@ class VoicemailService(SWMLService):
             print(f"hasattr(self, 'play'): {hasattr(self, 'play')}")
         except Exception as e:
             print(f"Error in getattr: {type(e)}: {e}")
-            
+
         # Examine the __dict__ to see if methods are being added
         print("\nExamining instance __dict__:")
         print(f"'play' in self.__dict__: {'play' in self.__dict__}")
-        print(f"'_verb_methods_cache' in self.__dict__: {'_verb_methods_cache' in self.__dict__}")
-        if hasattr(self, '_verb_methods_cache'):
+        print(
+            f"'_verb_methods_cache' in self.__dict__: {'_verb_methods_cache' in self.__dict__}"
+        )
+        if hasattr(self, "_verb_methods_cache"):
             print(f"Cache contents: {list(self._verb_methods_cache.keys())}")
-        
+
         print("--- End of Auto-Vivification Testing ---\n")
-        
+
         # Build the SWML document
         self.build_voicemail_document()
-    
+
     def build_voicemail_document(self):
         """Build the voicemail SWML document using auto-vivified methods"""
         # Reset the document
         self.reset_document()
-        
+
         # Add answer verb - temporarily using add_verb
         self.add_verb("answer", {})
-        
+
         # Add play verb for greeting - try using auto-vivified method
         try:
             print("Attempting to use auto-vivified play() method...")
-            self.play(url="say:Hello, you've reached the voicemail service. Please leave a message after the beep.")
+            self.play(
+                url="say:Hello, you've reached the voicemail service. Please leave a message after the beep."
+            )
             print("Successfully used auto-vivified play() method")
         except Exception as e:
             print(f"Error using auto-vivified method: {type(e)}: {e}")
             # Fallback to add_verb
-            self.add_verb("play", {
-                "url": "say:Hello, you've reached the voicemail service. Please leave a message after the beep."
-            })
+            self.add_verb(
+                "play",
+                {
+                    "url": "say:Hello, you've reached the voicemail service. Please leave a message after the beep."
+                },
+            )
             print("Fell back to add_verb")
-        
+
         # Add a small pause - try using auto-vivified method
         try:
             print("Attempting to use auto-vivified sleep() method...")
@@ -112,7 +111,7 @@ class VoicemailService(SWMLService):
             # Fallback to add_verb
             self.add_verb("sleep", 1000)
             print("Fell back to add_verb")
-        
+
         # Play a beep - try using auto-vivified method
         try:
             print("Attempting to use auto-vivified play() method for beep...")
@@ -121,11 +120,9 @@ class VoicemailService(SWMLService):
         except Exception as e:
             print(f"Error using auto-vivified method: {type(e)}: {e}")
             # Fallback to add_verb
-            self.add_verb("play", {
-                "url": "https://example.com/beep.wav"
-            })
+            self.add_verb("play", {"url": "https://example.com/beep.wav"})
             print("Fell back to add_verb")
-        
+
         # Record the message - try using auto-vivified method
         try:
             print("Attempting to use auto-vivified record() method...")
@@ -135,22 +132,25 @@ class VoicemailService(SWMLService):
                 beep=False,  # We already played a beep
                 max_length=120,  # 2 minutes max
                 terminators="#",  # Allow # to stop recording
-                status_url="https://example.com/voicemail-status"
+                status_url="https://example.com/voicemail-status",
             )
             print("Successfully used auto-vivified record() method")
         except Exception as e:
             print(f"Error using auto-vivified method: {type(e)}: {e}")
             # Fallback to add_verb
-            self.add_verb("record", {
-                "format": "mp3",
-                "stereo": False,
-                "beep": False,
-                "max_length": 120,
-                "terminators": "#",
-                "status_url": "https://example.com/voicemail-status"
-            })
+            self.add_verb(
+                "record",
+                {
+                    "format": "mp3",
+                    "stereo": False,
+                    "beep": False,
+                    "max_length": 120,
+                    "terminators": "#",
+                    "status_url": "https://example.com/voicemail-status",
+                },
+            )
             print("Fell back to add_verb")
-        
+
         # Thank the caller - try using auto-vivified method
         try:
             print("Attempting to use auto-vivified play() method for thank you...")
@@ -159,9 +159,7 @@ class VoicemailService(SWMLService):
         except Exception as e:
             print(f"Error using auto-vivified method: {type(e)}: {e}")
             # Fallback to add_verb
-            self.add_verb("play", {
-                "url": "say:Thank you for your message. Goodbye!"
-            })
+            self.add_verb("play", {"url": "say:Thank you for your message. Goodbye!"})
             print("Fell back to add_verb")
 
         # Hang up - use the add_verb method
@@ -174,95 +172,102 @@ class IvrMenuService(SWMLService):
     """
     Interactive Voice Response (IVR) menu system using auto-vivified verb methods
     """
-    
+
     def __init__(self, host="0.0.0.0", port=3000):
-        super().__init__(
-            name="ivr",
-            route="/ivr",
-            host=host,
-            port=port
-        )
-        
+        super().__init__(name="ivr", route="/ivr", host=host, port=port)
+
         # Build the SWML document
         self.build_ivr_document()
-    
+
     def build_ivr_document(self):
         """Build the IVR menu SWML document using auto-vivified methods"""
         # Reset the document
         self.reset_document()
-        
+
         # Add answer verb
         self.add_verb("answer", {})
-        
+
         # Add main menu section
         self.add_section("main_menu")
         self.log.debug("adding_section", section="main_menu")
-        
+
         # Add prompt verb for the main menu
-        self.add_verb_to_section("main_menu", "prompt", {
-            "play": "say:Welcome to our service. Press 1 for sales, 2 for support, or 3 to leave a message.",
-            "max_digits": 1,
-            "terminators": "#",
-            "digit_timeout": 5.0,
-            "initial_timeout": 10.0
-        })
-        
-        # Add switch verb to handle menu options
-        self.add_verb_to_section("main_menu", "switch", {
-            "variable": "prompt_digits",
-            "case": {
-                "1": [
-                    {"transfer": {"dest": "sales"}}
-                ],
-                "2": [
-                    {"transfer": {"dest": "support"}}
-                ],
-                "3": [
-                    {"transfer": {"dest": "voicemail"}}
-                ]
+        self.add_verb_to_section(
+            "main_menu",
+            "prompt",
+            {
+                "play": "say:Welcome to our service. Press 1 for sales, 2 for support, or 3 to leave a message.",
+                "max_digits": 1,
+                "terminators": "#",
+                "digit_timeout": 5.0,
+                "initial_timeout": 10.0,
             },
-            "default": [
-                {"play": {"url": "say:I'm sorry, I didn't understand your selection."}},
-                {"transfer": {"dest": "main_menu"}}
-            ]
-        })
-        
+        )
+
+        # Add switch verb to handle menu options
+        self.add_verb_to_section(
+            "main_menu",
+            "switch",
+            {
+                "variable": "prompt_digits",
+                "case": {
+                    "1": [{"transfer": {"dest": "sales"}}],
+                    "2": [{"transfer": {"dest": "support"}}],
+                    "3": [{"transfer": {"dest": "voicemail"}}],
+                },
+                "default": [
+                    {
+                        "play": {
+                            "url": "say:I'm sorry, I didn't understand your selection."
+                        }
+                    },
+                    {"transfer": {"dest": "main_menu"}},
+                ],
+            },
+        )
+
         # Add sales section
         self.add_section("sales")
         self.log.debug("adding_section", section="sales")
-        
+
         # Add play and connect verbs to sales section
-        self.add_verb_to_section("sales", "play", {"url": "say:Connecting you to sales. Please hold."})
+        self.add_verb_to_section(
+            "sales", "play", {"url": "say:Connecting you to sales. Please hold."}
+        )
         self.add_verb_to_section("sales", "connect", {"to": "+15551234567"})
-        
+
         # Add support section
         self.add_section("support")
         self.log.debug("adding_section", section="support")
-        
+
         # Add play and connect verbs to support section
-        self.add_verb_to_section("support", "play", {"url": "say:Connecting you to support. Please hold."})
+        self.add_verb_to_section(
+            "support", "play", {"url": "say:Connecting you to support. Please hold."}
+        )
         self.add_verb_to_section("support", "connect", {"to": "+15557654321"})
-        
+
         # Add voicemail section
         self.add_section("voicemail")
         self.log.debug("adding_section", section="voicemail")
-        
+
         # Add verbs to voicemail section
-        self.add_verb_to_section("voicemail", "play", {"url": "say:Please leave a message after the beep."})
+        self.add_verb_to_section(
+            "voicemail", "play", {"url": "say:Please leave a message after the beep."}
+        )
         self.add_verb_to_section("voicemail", "sleep", 1000)  # 1 second pause
-        self.add_verb_to_section("voicemail", "record", {
-            "format": "mp3",
-            "max_length": 120,
-            "terminators": "#"
-        })
-        self.add_verb_to_section("voicemail", "play", {"url": "say:Thank you for your message. Goodbye!"})
+        self.add_verb_to_section(
+            "voicemail",
+            "record",
+            {"format": "mp3", "max_length": 120, "terminators": "#"},
+        )
+        self.add_verb_to_section(
+            "voicemail", "play", {"url": "say:Thank you for your message. Goodbye!"}
+        )
         self.add_verb_to_section("voicemail", "hangup", {})
-        
+
         # Start with the main menu
-        self.add_verb("transfer", {
-            "dest": "main_menu"
-        })
-        
+        self.add_verb("transfer", {"dest": "main_menu"})
+
         self.log.debug("ivr_document_built")
 
 
@@ -270,63 +275,73 @@ class CallTransferService(SWMLService):
     """
     Call transfer service with parallel dialing using auto-vivified verb methods
     """
-    
+
     def __init__(self, host="0.0.0.0", port=3000):
-        super().__init__(
-            name="transfer",
-            route="/transfer",
-            host=host,
-            port=port
-        )
-        
+        super().__init__(name="transfer", route="/transfer", host=host, port=port)
+
         # Build the SWML document
         self.build_transfer_document()
-    
+
     def build_transfer_document(self):
         """Build the call transfer SWML document using auto-vivified methods"""
         # Reset the document
         self.reset_document()
-        
+
         # Add answer verb
         self.add_verb("answer", {})
-        
+
         # Add play verb for greeting
-        self.add_verb("play", {
-            "url": "say:Thank you for calling. We'll connect you with the next available agent."
-        })
-        
+        self.add_verb(
+            "play",
+            {
+                "url": "say:Thank you for calling. We'll connect you with the next available agent."
+            },
+        )
+
         # Add connect verb with parallel dialing
         self.log.debug("setting_up_parallel_dialing", agents=3)
-        self.add_verb("connect", {
-            "from": "+15551234567",  # Using "from" directly in the config
-            "timeout": 30,
-            "answer_on_bridge": True,
-            "ringback": ["ring:us"],
-            "parallel": [
-                {"to": "+15552223333"},
-                {"to": "+15554445555"},
-                {"to": "+15556667777"}
-            ]
-        })
-        
+        self.add_verb(
+            "connect",
+            {
+                "from": "+15551234567",  # Using "from" directly in the config
+                "timeout": 30,
+                "answer_on_bridge": True,
+                "ringback": ["ring:us"],
+                "parallel": [
+                    {"to": "+15552223333"},
+                    {"to": "+15554445555"},
+                    {"to": "+15556667777"},
+                ],
+            },
+        )
+
         # Add fallback if no one answers
-        self.add_verb("play", {
-            "url": "say:We're sorry, but all of our agents are currently busy. Please leave a message."
-        })
-        
+        self.add_verb(
+            "play",
+            {
+                "url": "say:We're sorry, but all of our agents are currently busy. Please leave a message."
+            },
+        )
+
         # Record a message if no agents available
-        self.add_verb("record", {
-            "format": "mp3",
-            "stereo": False,
-            "beep": True,
-            "max_length": 120,
-            "terminators": "#"
-        })
-        
+        self.add_verb(
+            "record",
+            {
+                "format": "mp3",
+                "stereo": False,
+                "beep": True,
+                "max_length": 120,
+                "terminators": "#",
+            },
+        )
+
         # Thank the caller
-        self.add_verb("play", {
-            "url": "say:Thank you for your message. We'll get back to you as soon as possible."
-        })
+        self.add_verb(
+            "play",
+            {
+                "url": "say:Thank you for your message. We'll get back to you as soon as possible."
+            },
+        )
 
         # Hang up
         self.add_verb("hangup", {})
@@ -337,19 +352,29 @@ class CallTransferService(SWMLService):
 def main():
     """Main entry point"""
     parser = argparse.ArgumentParser(description="Auto-Vivified SWML Service Examples")
-    parser.add_argument("--service", choices=["voicemail", "ivr", "transfer"], 
-                        default="voicemail", help="Which service to run")
+    parser.add_argument(
+        "--service",
+        choices=["voicemail", "ivr", "transfer"],
+        default="voicemail",
+        help="Which service to run",
+    )
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
     parser.add_argument("--port", type=int, default=3000, help="Port to bind to")
-    parser.add_argument("--show-swml", action="store_true", help="Show SWML document only, don't start server")
-    parser.add_argument("--suppress-logs", action="store_true", help="Suppress structured logs")
-    
+    parser.add_argument(
+        "--show-swml",
+        action="store_true",
+        help="Show SWML document only, don't start server",
+    )
+    parser.add_argument(
+        "--suppress-logs", action="store_true", help="Suppress structured logs"
+    )
+
     args = parser.parse_args()
-    
+
     # Set log level based on suppress-logs flag
     if args.suppress_logs:
         logging.getLogger().setLevel(logging.WARNING)
-    
+
     # Create the selected service
     if args.service == "voicemail":
         service = VoicemailService(host=args.host, port=args.port)
@@ -357,28 +382,34 @@ def main():
         service = IvrMenuService(host=args.host, port=args.port)
     elif args.service == "transfer":
         service = CallTransferService(host=args.host, port=args.port)
-    
+
     # Either show the SWML or start the server
     if args.show_swml:
         swml_doc = service.render_document()
-        logger.info("displaying_swml_document", service=args.service, size=len(swml_doc))
+        logger.info(
+            "displaying_swml_document", service=args.service, size=len(swml_doc)
+        )
         print(json.dumps(json.loads(swml_doc), indent=2))
     else:
         # Get auth credentials
         username, password = service.get_basic_auth_credentials()
-        
-        logger.info("starting_service", 
-                   service=args.service, 
-                   url=f"http://{args.host}:{args.port}{service.route}",
-                   username=username,
-                   password_length=len(password))
-        
-        print(f"Starting {args.service} service on http://{args.host}:{args.port}{service.route}")
+
+        logger.info(
+            "starting_service",
+            service=args.service,
+            url=f"http://{args.host}:{args.port}{service.route}",
+            username=username,
+            password_length=len(password),
+        )
+
+        print(
+            f"Starting {args.service} service on http://{args.host}:{args.port}{service.route}"
+        )
         print(f"Basic Auth: {username}:{password}")
         print("\nYou can access this service via:")
         print(f"  - GET http://{args.host}:{args.port}{service.route}")
         print(f"  - POST http://{args.host}:{args.port}{service.route}")
-        
+
         # Start the server
         try:
             service.serve(host=args.host, port=args.port)
@@ -388,4 +419,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/basic_swml_service.py
+++ b/examples/basic_swml_service.py
@@ -22,8 +22,6 @@ Examples include:
 4. Call recording
 """
 
-import os
-import sys
 import json
 import argparse
 import logging
@@ -33,7 +31,6 @@ import structlog
 
 # Import the SWMLService class - this will set up the logging configuration
 from signalwire.core.swml_service import SWMLService
-from signalwire.core.swml_builder import SWMLBuilder
 
 # Create structured logger for this example
 logger = structlog.get_logger("basic_swml")
@@ -43,53 +40,55 @@ class VoicemailService(SWMLService):
     """
     Simple voicemail service that plays a greeting and records a message
     """
-    
+
     def __init__(self, host="0.0.0.0", port=3000):
-        super().__init__(
-            name="voicemail",
-            route="/voicemail",
-            host=host,
-            port=port
-        )
-        
+        super().__init__(name="voicemail", route="/voicemail", host=host, port=port)
+
         # Build the SWML document
         self.build_voicemail_document()
-    
+
     def build_voicemail_document(self):
         """Build the voicemail SWML document"""
         # Reset the document
         self.reset_document()
-        
+
         # Add answer verb
         self.add_verb("answer", {})
-        
+
         # Add play verb for greeting
-        self.add_verb("play", {
-            "url": "say:Hello, you've reached the voicemail service. Please leave a message after the beep."
-        })
-        
+        self.add_verb(
+            "play",
+            {
+                "url": "say:Hello, you've reached the voicemail service. Please leave a message after the beep."
+            },
+        )
+
         # Add a small pause
         self.add_verb("sleep", 1000)  # 1 second in milliseconds
-        
+
         # Play a beep
-        self.add_verb("play", {
-            "url": "https://example.com/beep.wav"  # Replace with actual beep sound URL
-        })
-        
+        self.add_verb(
+            "play",
+            {
+                "url": "https://example.com/beep.wav"  # Replace with actual beep sound URL
+            },
+        )
+
         # Record the message
-        self.add_verb("record", {
-            "format": "mp3",
-            "stereo": False,
-            "beep": False,  # We already played a beep
-            "max_length": 120,  # 2 minutes max
-            "terminators": "#",  # Allow # to stop recording
-            "status_url": "https://example.com/voicemail-status"  # Replace with your status webhook
-        })
-        
+        self.add_verb(
+            "record",
+            {
+                "format": "mp3",
+                "stereo": False,
+                "beep": False,  # We already played a beep
+                "max_length": 120,  # 2 minutes max
+                "terminators": "#",  # Allow # to stop recording
+                "status_url": "https://example.com/voicemail-status",  # Replace with your status webhook
+            },
+        )
+
         # Thank the caller
-        self.add_verb("play", {
-            "url": "say:Thank you for your message. Goodbye!"
-        })
+        self.add_verb("play", {"url": "say:Thank you for your message. Goodbye!"})
 
         # Hang up
         self.add_verb("hangup", {})
@@ -101,101 +100,112 @@ class IvrMenuService(SWMLService):
     """
     Interactive Voice Response (IVR) menu system
     """
-    
+
     def __init__(self, host="0.0.0.0", port=3000):
-        super().__init__(
-            name="ivr",
-            route="/ivr",
-            host=host,
-            port=port
-        )
-        
+        super().__init__(name="ivr", route="/ivr", host=host, port=port)
+
         # Build the SWML document
         self.build_ivr_document()
-    
+
     def build_ivr_document(self):
         """Build the IVR menu SWML document"""
         # Reset the document
         self.reset_document()
-        
+
         # Add answer verb
         self.add_verb("answer", {})
-        
+
         # Add main menu section
         self.add_section("main_menu")
         self.log.debug("adding_section", section="main_menu")
-        
+
         # Add prompt verb for the main menu
-        self.add_verb_to_section("main_menu", "prompt", {
-            "play": "say:Welcome to our service. Press 1 for sales, 2 for support, or 3 to leave a message.",
-            "max_digits": 1,
-            "terminators": "#",
-            "digit_timeout": 5.0,
-            "initial_timeout": 10.0
-        })
-        
-        # Add switch verb to handle menu options
-        self.add_verb_to_section("main_menu", "switch", {
-            "variable": "prompt_digits",
-            "case": {
-                "1": [
-                    {"transfer": {"dest": "sales"}}
-                ],
-                "2": [
-                    {"transfer": {"dest": "support"}}
-                ],
-                "3": [
-                    {"transfer": {"dest": "voicemail"}}
-                ]
+        self.add_verb_to_section(
+            "main_menu",
+            "prompt",
+            {
+                "play": "say:Welcome to our service. Press 1 for sales, 2 for support, or 3 to leave a message.",
+                "max_digits": 1,
+                "terminators": "#",
+                "digit_timeout": 5.0,
+                "initial_timeout": 10.0,
             },
-            "default": [
-                {"play": {"url": "say:I'm sorry, I didn't understand your selection."}},
-                {"transfer": {"dest": "main_menu"}}
-            ]
-        })
-        
+        )
+
+        # Add switch verb to handle menu options
+        self.add_verb_to_section(
+            "main_menu",
+            "switch",
+            {
+                "variable": "prompt_digits",
+                "case": {
+                    "1": [{"transfer": {"dest": "sales"}}],
+                    "2": [{"transfer": {"dest": "support"}}],
+                    "3": [{"transfer": {"dest": "voicemail"}}],
+                },
+                "default": [
+                    {
+                        "play": {
+                            "url": "say:I'm sorry, I didn't understand your selection."
+                        }
+                    },
+                    {"transfer": {"dest": "main_menu"}},
+                ],
+            },
+        )
+
         # Add sales section
         self.add_section("sales")
         self.log.debug("adding_section", section="sales")
-        self.add_verb_to_section("sales", "play", {
-            "url": "say:Connecting you to sales. Please hold."
-        })
-        self.add_verb_to_section("sales", "connect", {
-            "to": "+15551234567"  # Replace with actual sales number
-        })
-        
+        self.add_verb_to_section(
+            "sales", "play", {"url": "say:Connecting you to sales. Please hold."}
+        )
+        self.add_verb_to_section(
+            "sales",
+            "connect",
+            {
+                "to": "+15551234567"  # Replace with actual sales number
+            },
+        )
+
         # Add support section
         self.add_section("support")
         self.log.debug("adding_section", section="support")
-        self.add_verb_to_section("support", "play", {
-            "url": "say:Connecting you to support. Please hold."
-        })
-        self.add_verb_to_section("support", "connect", {
-            "to": "+15557654321"  # Replace with actual support number
-        })
-        
+        self.add_verb_to_section(
+            "support", "play", {"url": "say:Connecting you to support. Please hold."}
+        )
+        self.add_verb_to_section(
+            "support",
+            "connect",
+            {
+                "to": "+15557654321"  # Replace with actual support number
+            },
+        )
+
         # Add voicemail section
         self.add_section("voicemail")
         self.log.debug("adding_section", section="voicemail")
-        self.add_verb_to_section("voicemail", "play", {
-            "url": "say:Please leave a message after the beep."
-        })
+        self.add_verb_to_section(
+            "voicemail", "play", {"url": "say:Please leave a message after the beep."}
+        )
         self.add_verb_to_section("voicemail", "sleep", 1000)  # 1 second pause
-        self.add_verb_to_section("voicemail", "record", {
-            "format": "mp3",
-            "max_length": 120,  # 2 minutes max
-            "terminators": "#"
-        })
-        self.add_verb_to_section("voicemail", "play", {
-            "url": "say:Thank you for your message. Goodbye!"
-        })
+        self.add_verb_to_section(
+            "voicemail",
+            "record",
+            {
+                "format": "mp3",
+                "max_length": 120,  # 2 minutes max
+                "terminators": "#",
+            },
+        )
+        self.add_verb_to_section(
+            "voicemail", "play", {"url": "say:Thank you for your message. Goodbye!"}
+        )
         self.add_verb_to_section("voicemail", "hangup", {})
-        
+
         # Start with the main menu
-        self.add_verb("transfer", {
-            "dest": "main_menu"
-        })
-        
+        self.add_verb("transfer", {"dest": "main_menu"})
+
         self.log.debug("ivr_document_built")
 
 
@@ -203,63 +213,73 @@ class CallTransferService(SWMLService):
     """
     Call transfer service with parallel dialing
     """
-    
+
     def __init__(self, host="0.0.0.0", port=3000):
-        super().__init__(
-            name="transfer",
-            route="/transfer",
-            host=host,
-            port=port
-        )
-        
+        super().__init__(name="transfer", route="/transfer", host=host, port=port)
+
         # Build the SWML document
         self.build_transfer_document()
-    
+
     def build_transfer_document(self):
         """Build the call transfer SWML document"""
         # Reset the document
         self.reset_document()
-        
+
         # Add answer verb
         self.add_verb("answer", {})
-        
+
         # Add play verb for greeting
-        self.add_verb("play", {
-            "url": "say:Thank you for calling. We'll connect you with the next available agent."
-        })
-        
+        self.add_verb(
+            "play",
+            {
+                "url": "say:Thank you for calling. We'll connect you with the next available agent."
+            },
+        )
+
         # Add connect verb with parallel dialing
         self.log.debug("setting_up_parallel_dialing", agents=3)
-        self.add_verb("connect", {
-            "from": "+15551234567",  # Replace with your from number
-            "timeout": 30,  # 30 seconds timeout
-            "answer_on_bridge": True,
-            "ringback": ["ring:us"],  # US ringback tone
-            "parallel": [
-                {"to": "+15552223333"},  # Replace with actual agent numbers
-                {"to": "+15554445555"},
-                {"to": "+15556667777"}
-            ]
-        })
-        
+        self.add_verb(
+            "connect",
+            {
+                "from": "+15551234567",  # Replace with your from number
+                "timeout": 30,  # 30 seconds timeout
+                "answer_on_bridge": True,
+                "ringback": ["ring:us"],  # US ringback tone
+                "parallel": [
+                    {"to": "+15552223333"},  # Replace with actual agent numbers
+                    {"to": "+15554445555"},
+                    {"to": "+15556667777"},
+                ],
+            },
+        )
+
         # Add fallback if no one answers
-        self.add_verb("play", {
-            "url": "say:We're sorry, but all of our agents are currently busy. Please leave a message."
-        })
-        
+        self.add_verb(
+            "play",
+            {
+                "url": "say:We're sorry, but all of our agents are currently busy. Please leave a message."
+            },
+        )
+
         # Record a message if no agents available
-        self.add_verb("record", {
-            "format": "mp3",
-            "stereo": False,
-            "beep": True,
-            "max_length": 120,  # 2 minutes max
-            "terminators": "#"  # Allow # to stop recording
-        })
-        
+        self.add_verb(
+            "record",
+            {
+                "format": "mp3",
+                "stereo": False,
+                "beep": True,
+                "max_length": 120,  # 2 minutes max
+                "terminators": "#",  # Allow # to stop recording
+            },
+        )
+
         # Thank the caller
-        self.add_verb("play", {
-            "url": "say:Thank you for your message. We'll get back to you as soon as possible."
-        })
+        self.add_verb(
+            "play",
+            {
+                "url": "say:Thank you for your message. We'll get back to you as soon as possible."
+            },
+        )
 
         # Hang up
         self.add_verb("hangup", {})
@@ -271,67 +291,68 @@ class CallRecordingService(SWMLService):
     """
     Demonstrates call recording features
     """
-    
+
     def __init__(self, host="0.0.0.0", port=3000):
-        super().__init__(
-            name="record",
-            route="/record",
-            host=host,
-            port=port
-        )
-        
+        super().__init__(name="record", route="/record", host=host, port=port)
+
         # Build the SWML document
         self.build_recording_document()
-    
+
     def build_recording_document(self):
         """Build the call recording SWML document"""
         # Reset the document
         self.reset_document()
-        
+
         # Add answer verb
         self.add_verb("answer", {})
-        
+
         # Start recording the call in the background
         self.log.debug("starting_call_recording", format="mp3", stereo=True)
-        self.add_verb("record_call", {
-            "control_id": "call_recording",
-            "format": "mp3",
-            "stereo": True,
-            "direction": "both",
-            "beep": True
-        })
-        
+        self.add_verb(
+            "record_call",
+            {
+                "control_id": "call_recording",
+                "format": "mp3",
+                "stereo": True,
+                "direction": "both",
+                "beep": True,
+            },
+        )
+
         # Inform the caller about recording
-        self.add_verb("play", {
-            "url": "say:This call is being recorded for quality and training purposes."
-        })
-        
+        self.add_verb(
+            "play",
+            {
+                "url": "say:This call is being recorded for quality and training purposes."
+            },
+        )
+
         # Add play verb for prompt
-        self.add_verb("play", {
-            "url": "say:Please tell us about your experience with our product."
-        })
-        
+        self.add_verb(
+            "play",
+            {"url": "say:Please tell us about your experience with our product."},
+        )
+
         # Add sleep to wait for the caller's response
         self.add_verb("sleep", 30000)  # 30 seconds
-        
+
         # Add play verb for closing
-        self.add_verb("play", {
-            "url": "say:Thank you for your feedback. Is there anything else you'd like to add?"
-        })
-        
+        self.add_verb(
+            "play",
+            {
+                "url": "say:Thank you for your feedback. Is there anything else you'd like to add?"
+            },
+        )
+
         # Add sleep to wait for the caller's response
         self.add_verb("sleep", 30000)  # 30 seconds
-        
+
         # Stop recording
         self.log.debug("stopping_call_recording", control_id="call_recording")
-        self.add_verb("stop_record_call", {
-            "control_id": "call_recording"
-        })
-        
+        self.add_verb("stop_record_call", {"control_id": "call_recording"})
+
         # Thank the caller
-        self.add_verb("play", {
-            "url": "say:Thank you for your time. Goodbye!"
-        })
+        self.add_verb("play", {"url": "say:Thank you for your time. Goodbye!"})
 
         # Hang up
         self.add_verb("hangup", {})
@@ -342,19 +363,29 @@ class CallRecordingService(SWMLService):
 def main():
     """Main entry point"""
     parser = argparse.ArgumentParser(description="Basic SWML Service Examples")
-    parser.add_argument("--service", choices=["voicemail", "ivr", "transfer", "record"], 
-                        default="voicemail", help="Which service to run")
+    parser.add_argument(
+        "--service",
+        choices=["voicemail", "ivr", "transfer", "record"],
+        default="voicemail",
+        help="Which service to run",
+    )
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
     parser.add_argument("--port", type=int, default=3000, help="Port to bind to")
-    parser.add_argument("--show-swml", action="store_true", help="Show SWML document only, don't start server")
-    parser.add_argument("--suppress-logs", action="store_true", help="Suppress structured logs")
-    
+    parser.add_argument(
+        "--show-swml",
+        action="store_true",
+        help="Show SWML document only, don't start server",
+    )
+    parser.add_argument(
+        "--suppress-logs", action="store_true", help="Suppress structured logs"
+    )
+
     args = parser.parse_args()
-    
+
     # Set log level based on suppress-logs flag
     if args.suppress_logs:
         logging.getLogger().setLevel(logging.WARNING)
-    
+
     # Create the selected service
     if args.service == "voicemail":
         service = VoicemailService(host=args.host, port=args.port)
@@ -364,23 +395,29 @@ def main():
         service = CallTransferService(host=args.host, port=args.port)
     elif args.service == "record":
         service = CallRecordingService(host=args.host, port=args.port)
-    
+
     # Either show the SWML or start the server
     if args.show_swml:
         swml_doc = service.render_document()
-        logger.info("displaying_swml_document", service=args.service, size=len(swml_doc))
+        logger.info(
+            "displaying_swml_document", service=args.service, size=len(swml_doc)
+        )
         print(json.dumps(json.loads(swml_doc), indent=2))
     else:
         # Get auth credentials
         username, password = service.get_basic_auth_credentials()
-        
-        logger.info("starting_service", 
-                   service=args.service, 
-                   url=f"http://{args.host}:{args.port}{service.route}",
-                   username=username,
-                   password_length=len(password))
-        
-        print(f"Starting {args.service} service on http://{args.host}:{args.port}{service.route}")
+
+        logger.info(
+            "starting_service",
+            service=args.service,
+            url=f"http://{args.host}:{args.port}{service.route}",
+            username=username,
+            password_length=len(password),
+        )
+
+        print(
+            f"Starting {args.service} service on http://{args.host}:{args.port}{service.route}"
+        )
         print(f"Basic Auth: {username}:{password}")
         print("\nYou can access this service via:")
         print(f"  - GET http://{args.host}:{args.port}{service.route}")
@@ -388,7 +425,7 @@ def main():
         print(f"  - GET http://{args.host}:{args.port}{service.route}/")
         print(f"  - POST http://{args.host}:{args.port}{service.route}/")
         print("\nAll endpoints respond with the same SWML document.")
-        
+
         # Start the server
         try:
             service.serve(host=args.host, port=args.port)
@@ -398,4 +435,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/bedrock_agent_run.py
+++ b/examples/bedrock_agent_run.py
@@ -10,15 +10,18 @@ agent = BedrockAgent(
     name="bedrock_run_test",
     system_prompt="You are a helpful AI assistant powered by Amazon Bedrock.",
     voice_id="inworld.Mark",
-    temperature=0.7
+    temperature=0.7,
 )
+
 
 # Add a function
 @agent.tool("Get the current time")
 def get_time():
     """Get the current time"""
     from datetime import datetime
+
     return {"time": datetime.now().strftime("%H:%M:%S")}
+
 
 # Run the agent
 if __name__ == "__main__":

--- a/examples/bedrock_agent_test.py
+++ b/examples/bedrock_agent_test.py
@@ -14,8 +14,9 @@ agent = BedrockAgent(
     route="/bedrock_test",
     system_prompt="You are a helpful AI assistant powered by Amazon Bedrock.",
     voice_id="inworld.Mark",
-    temperature=0.7
+    temperature=0.7,
 )
+
 
 # Add a simple function
 @agent.tool("Get the current weather for a location")
@@ -26,8 +27,9 @@ def get_weather(location: str, unit: str = "celsius"):
         "location": location,
         "temperature": 22,
         "unit": unit,
-        "conditions": "sunny"
+        "conditions": "sunny",
     }
+
 
 # Skills can be loaded if needed
 # agent.add_skill("datetime")
@@ -39,4 +41,4 @@ if __name__ == "__main__":
     print(f"BedrockAgent created: {agent}")
     print(f"Name: {agent.get_name()}")
     print(f"Route: {agent.route}")
-    print(f"Functions registered: 1 (get_weather)")
+    print("Functions registered: 1 (get_weather)")

--- a/examples/bedrock_server_test.py
+++ b/examples/bedrock_server_test.py
@@ -3,15 +3,15 @@
 Test BedrockAgent as a SWML server
 """
 
-import os
 from signalwire import BedrockAgent
 
 # Create a Bedrock agent
 agent = BedrockAgent(
     name="bedrock_server",
     system_prompt="You are a helpful AI assistant.",
-    voice_id="inworld.Mark"
+    voice_id="inworld.Mark",
 )
+
 
 # Add a simple tool
 @agent.tool
@@ -19,10 +19,11 @@ def hello_world(name: str = "World"):
     """Say hello to someone"""
     return f"Hello, {name}!"
 
-print(f"Starting BedrockAgent server...")
-print(f"Route: /bedrock")
-print(f"URL: http://localhost:3000/bedrock")
-print(f"Auth: dev:w00t")
+
+print("Starting BedrockAgent server...")
+print("Route: /bedrock")
+print("URL: http://localhost:3000/bedrock")
+print("Auth: dev:w00t")
 print("\nTo test:")
 print("  curl -u dev:w00t http://localhost:3000/bedrock")
 print("  swaig-test examples/bedrock_server_test.py --list")

--- a/examples/bedrock_with_skills.py
+++ b/examples/bedrock_with_skills.py
@@ -8,15 +8,13 @@ from signalwire import BedrockAgent
 
 # Create a Bedrock agent
 agent = BedrockAgent(
-    name="bedrock_skills_test",
-    voice_id="inworld.Mark",
-    temperature=0.8
+    name="bedrock_skills_test", voice_id="inworld.Mark", temperature=0.8
 )
 
 # Set up the agent's personality using POM (Prompt Object Model)
 agent.prompt_add_section(
     "Personality",
-    "You are a helpful AI assistant with access to various skills including real-time information lookup, weather data, and web search capabilities."
+    "You are a helpful AI assistant with access to various skills including real-time information lookup, weather data, and web search capabilities.",
 )
 
 agent.prompt_add_section(
@@ -26,8 +24,8 @@ agent.prompt_add_section(
         "Use the getWeather function when users ask about weather conditions",
         "Use the web_search function when users need current information from the internet",
         "Always provide accurate and helpful responses",
-        "Be conversational and friendly"
-    ]
+        "Be conversational and friendly",
+    ],
 )
 
 # Add skills
@@ -35,9 +33,7 @@ agent.add_skill("datetime")
 print("✓ datetime skill added")
 
 # Add weather_api skill with API key
-agent.add_skill("weather_api", {
-    "api_key": os.environ.get("WEATHER_API_KEY", "")
-})
+agent.add_skill("weather_api", {"api_key": os.environ.get("WEATHER_API_KEY", "")})
 print("✓ weather_api skill added")
 
 
@@ -46,19 +42,21 @@ google_api_key = os.environ.get("GOOGLE_SEARCH_API_KEY", "")
 google_search_engine_id = os.environ.get("GOOGLE_SEARCH_ENGINE_ID", "")
 
 if google_api_key and google_search_engine_id:
-    agent.add_skill("web_search", {
-        "api_key": google_api_key,
-        "search_engine_id": google_search_engine_id
-    })
+    agent.add_skill(
+        "web_search",
+        {"api_key": google_api_key, "search_engine_id": google_search_engine_id},
+    )
     print("✓ web_search skill added")
 else:
-    print("⚠ web_search skill skipped - Set GOOGLE_API_KEY and GOOGLE_SEARCH_ENGINE_ID environment variables")
+    print(
+        "⚠ web_search skill skipped - Set GOOGLE_API_KEY and GOOGLE_SEARCH_ENGINE_ID environment variables"
+    )
 
 # Note: joke skill has a prompt configuration issue
 # agent.add_skill("joke", {"api_key": os.environ.get("API_NINJAS_KEY", "")})
 
 # List functions
-if hasattr(agent, '_tool_registry'):
+if hasattr(agent, "_tool_registry"):
     functions = agent._tool_registry.get_all_functions()
     print(f"\nRegistered functions: {list(functions.keys())}")
 
@@ -68,6 +66,6 @@ print(f"\nAgent: {agent}")
 if __name__ == "__main__":
     # Export for testing
     test_agent = agent
-    
+
     # Run as SWML server
     agent.run()

--- a/examples/call_flow_and_actions_demo.py
+++ b/examples/call_flow_and_actions_demo.py
@@ -69,16 +69,19 @@ class CallFlowDemoAgent(AgentBase):
         # --- Prompt ---
         self.prompt_add_section(
             "Role",
-            body="You are a call center demo agent that showcases call-flow features."
+            body="You are a call center demo agent that showcases call-flow features.",
         )
-        self.prompt_add_section("Instructions", bullets=[
-            "Use transfer_to_support when the caller asks to speak to a person",
-            "Use send_confirmation to send the caller an SMS",
-            "Use start_recording when the caller agrees to be recorded",
-            "Use play_hold_music to play background music",
-            "Use update_preferences to save caller preferences",
-            "Use adjust_speech when the caller mentions unusual names or terms",
-        ])
+        self.prompt_add_section(
+            "Instructions",
+            bullets=[
+                "Use transfer_to_support when the caller asks to speak to a person",
+                "Use send_confirmation to send the caller an SMS",
+                "Use start_recording when the caller agrees to be recorded",
+                "Use play_hold_music to play background music",
+                "Use update_preferences to save caller preferences",
+                "Use adjust_speech when the caller mentions unusual names or terms",
+            ],
+        )
 
         # --- LLM parameters ---
         self.set_params({"temperature": 0.3})
@@ -89,18 +92,13 @@ class CallFlowDemoAgent(AgentBase):
 
         # Play a US ringback tone before answering. auto_answer=False prevents
         # the play verb from implicitly answering the call.
-        self.add_pre_answer_verb("play", {
-            "urls": ["ring:us"],
-            "auto_answer": False
-        })
+        self.add_pre_answer_verb("play", {"urls": ["ring:us"], "auto_answer": False})
 
         # Configure the answer verb with a maximum call duration of 1 hour.
         self.add_answer_verb({"max_duration": 3600})
 
         # After answering, play a welcome message before the AI takes over.
-        self.add_post_answer_verb("play", {
-            "url": "say:Welcome to the call flow demo."
-        })
+        self.add_post_answer_verb("play", {"url": "say:Welcome to the call flow demo."})
 
         # After the AI conversation ends, cleanly hang up the call.
         self.add_post_ai_verb("hangup", {})
@@ -119,8 +117,7 @@ class CallFlowDemoAgent(AgentBase):
         @self.on_debug_event
         def handle_debug(event_type, data):
             if event_type == "barge":
-                self.log.info("barge_detected",
-                              elapsed_ms=data.get("barge_elapsed_ms"))
+                self.log.info("barge_detected", elapsed_ms=data.get("barge_elapsed_ms"))
             elif event_type == "llm_error":
                 self.log.error("llm_error", error=data.get("error"))
             else:
@@ -138,26 +135,22 @@ class CallFlowDemoAgent(AgentBase):
                 "type": "string",
                 "description": "Department name (e.g. billing, technical)",
             }
-        }
+        },
     )
     def transfer_to_support(self, department: str):
         """Transfer the call to a support department."""
         destinations = {
-            "billing":   "+15551000001",
+            "billing": "+15551000001",
             "technical": "+15551000002",
-            "sales":     "+15551000003",
+            "sales": "+15551000003",
         }
         dest = destinations.get(department.lower(), "+15551000000")
 
         # post_process=True lets the AI speak one more time before the
         # transfer actually executes — useful for a goodbye message.
-        return (
-            FunctionResult(
-                f"Transferring you to {department} support now.",
-                post_process=True
-            )
-            .connect(dest, final=True)
-        )
+        return FunctionResult(
+            f"Transferring you to {department} support now.", post_process=True
+        ).connect(dest, final=True)
 
     @AgentBase.tool(
         name="send_confirmation",
@@ -170,34 +163,24 @@ class CallFlowDemoAgent(AgentBase):
             "message": {
                 "type": "string",
                 "description": "The confirmation message text",
-            }
-        }
+            },
+        },
     )
     def send_confirmation(self, phone: str, message: str):
         """Send an SMS message to the caller."""
-        return (
-            FunctionResult(f"Sending confirmation to {phone}.")
-            .send_sms(
-                to_number=phone,
-                from_number="+15559999999",
-                body=message
-            )
+        return FunctionResult(f"Sending confirmation to {phone}.").send_sms(
+            to_number=phone, from_number="+15559999999", body=message
         )
 
-    @AgentBase.tool(
-        name="start_recording",
-        description="Start recording the call"
-    )
+    @AgentBase.tool(name="start_recording", description="Start recording the call")
     def start_recording(self):
         """Begin background call recording in stereo WAV format."""
-        return (
-            FunctionResult("Recording has started.")
-            .record_call(control_id="demo-recording", stereo=True, format="wav")
+        return FunctionResult("Recording has started.").record_call(
+            control_id="demo-recording", stereo=True, format="wav"
         )
 
     @AgentBase.tool(
-        name="play_hold_music",
-        description="Play hold music in the background"
+        name="play_hold_music", description="Play hold music in the background"
     )
     def play_hold_music(self):
         """Play background music and put the caller on hold."""
@@ -218,20 +201,19 @@ class CallFlowDemoAgent(AgentBase):
             "value": {
                 "type": "string",
                 "description": "Preference value",
-            }
-        }
+            },
+        },
     )
     def update_preferences(self, key: str, value: str):
         """Update global session data and toggle functions based on preferences."""
-        result = (
-            FunctionResult(f"Preference '{key}' set to '{value}'.")
-            .update_global_data({key: value})
-        )
+        result = FunctionResult(
+            f"Preference '{key}' set to '{value}'."
+        ).update_global_data({key: value})
         # Example: disable the send_confirmation tool if notifications are off
         if key == "notifications" and value == "off":
-            result.toggle_functions([
-                {"function": "send_confirmation", "active": False}
-            ])
+            result.toggle_functions(
+                [{"function": "send_confirmation", "active": False}]
+            )
         return result
 
     @AgentBase.tool(
@@ -242,7 +224,7 @@ class CallFlowDemoAgent(AgentBase):
                 "type": "string",
                 "description": "Comma-separated terms to add as speech hints",
             }
-        }
+        },
     )
     def adjust_speech(self, hints: str):
         """Add dynamic hints and adjust speech timeout for better recognition."""

--- a/examples/comprehensive_dynamic_agent.py
+++ b/examples/comprehensive_dynamic_agent.py
@@ -8,7 +8,6 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-
 """
 Comprehensive Dynamic Agent Configuration Example
 
@@ -50,50 +49,56 @@ Query Parameters:
 
 from signalwire import AgentBase
 
+
 class ComprehensiveDynamicAgent(AgentBase):
     def __init__(self, route="/dynamic"):
         super().__init__(
             name="Comprehensive Dynamic Agent",
             route=route,  # Custom path for this agent
             auto_answer=True,
-            record_call=True
+            record_call=True,
         )
-        
+
         # Set up dynamic configuration
         self.set_dynamic_config_callback(self.configure_agent_dynamically)
-        
+
         # Define available voice options by tier
         self.voice_options = {
             "standard": ["inworld.Mark", "inworld.Sarah", "inworld.Blake"],
             "premium": ["inworld.Sarah", "inworld.Hanna", "inworld.Mark"],
-            "enterprise": ["inworld.Mark", "inworld.Sarah", "inworld.Hanna", "inworld.Blake"]
+            "enterprise": [
+                "inworld.Mark",
+                "inworld.Sarah",
+                "inworld.Hanna",
+                "inworld.Blake",
+            ],
         }
-        
+
         # Industry-specific configurations
         self.industry_configs = {
             "healthcare": {
                 "compliance_level": "high",
                 "privacy_emphasis": True,
                 "terminology": "medical",
-                "response_style": "professional"
+                "response_style": "professional",
             },
             "finance": {
-                "compliance_level": "high", 
+                "compliance_level": "high",
                 "security_emphasis": True,
                 "terminology": "financial",
-                "response_style": "formal"
+                "response_style": "formal",
             },
             "retail": {
                 "compliance_level": "medium",
                 "sales_emphasis": True,
                 "terminology": "customer_service",
-                "response_style": "friendly"
+                "response_style": "friendly",
             },
             "general": {
                 "compliance_level": "standard",
                 "terminology": "general",
-                "response_style": "conversational"
-            }
+                "response_style": "conversational",
+            },
         }
 
     def configure_agent_dynamically(self, query_params, body_params, headers, agent):
@@ -101,45 +106,51 @@ class ComprehensiveDynamicAgent(AgentBase):
         Dynamic configuration callback that demonstrates comprehensive agent customization
         """
         # Extract key parameters
-        tier = query_params.get('tier', 'standard').lower()
-        industry = query_params.get('industry', 'general').lower()
-        requested_voice = query_params.get('voice', '').lower()
-        language = query_params.get('language', 'en').lower()
-        locale = query_params.get('locale', 'us').lower()
-        test_group = query_params.get('test_group', 'A').upper()
-        debug_mode = query_params.get('debug', '').lower() == 'true'
-        customer_id = query_params.get('customer_id', '')
-        
+        tier = query_params.get("tier", "standard").lower()
+        industry = query_params.get("industry", "general").lower()
+        requested_voice = query_params.get("voice", "").lower()
+        language = query_params.get("language", "en").lower()
+        locale = query_params.get("locale", "us").lower()
+        test_group = query_params.get("test_group", "A").upper()
+        debug_mode = query_params.get("debug", "").lower() == "true"
+        customer_id = query_params.get("customer_id", "")
+
         # === Voice Configuration ===
-        self._configure_voice_and_language(agent, tier, requested_voice, language, locale)
-        
+        self._configure_voice_and_language(
+            agent, tier, requested_voice, language, locale
+        )
+
         # === Tier-based Parameters ===
         self._configure_tier_parameters(agent, tier, test_group)
-        
+
         # === Industry-specific Prompts ===
         self._configure_industry_prompts(agent, industry, tier)
-        
+
         # === Global Data Setup ===
-        self._configure_global_data(agent, tier, industry, customer_id, test_group, debug_mode)
-        
+        self._configure_global_data(
+            agent, tier, industry, customer_id, test_group, debug_mode
+        )
+
         # === Debug Features ===
         if debug_mode:
             self._configure_debug_features(agent, query_params)
-            
+
         # === A/B Testing Configuration ===
         self._configure_ab_testing(agent, test_group, tier)
 
-    def _configure_voice_and_language(self, agent, tier, requested_voice, language, locale):
+    def _configure_voice_and_language(
+        self, agent, tier, requested_voice, language, locale
+    ):
         """Configure voice and language settings"""
         # Determine available voices for tier
         available_voices = self.voice_options.get(tier, self.voice_options["standard"])
-        
+
         # Select voice (use requested if available for tier, otherwise default)
         if requested_voice and requested_voice in available_voices:
             voice = requested_voice
         else:
             voice = available_voices[0]  # Default to first available
-        
+
         if language == "en":
             if locale == "us":
                 agent.add_language("English US", "en-US", voice)
@@ -165,56 +176,62 @@ class ComprehensiveDynamicAgent(AgentBase):
     def _configure_tier_parameters(self, agent, tier, test_group):
         """Configure parameters based on service tier"""
         params = {}
-        
+
         if tier == "enterprise":
-            params.update({
-                "end_of_speech_timeout": 800,
-                "attention_timeout": 25000,
-                "background_file_volume": -35,
-                "background_file_loops": -1,
-                "digit_timeout": 8000,
-                "energy_level": 150
-            })
+            params.update(
+                {
+                    "end_of_speech_timeout": 800,
+                    "attention_timeout": 25000,
+                    "background_file_volume": -35,
+                    "background_file_loops": -1,
+                    "digit_timeout": 8000,
+                    "energy_level": 150,
+                }
+            )
         elif tier == "premium":
-            params.update({
-                "end_of_speech_timeout": 600,
-                "attention_timeout": 20000,
-                "background_file_volume": -30,
-                "background_file_loops": 5,
-                "digit_timeout": 6000,
-                "energy_level": 120
-            })
+            params.update(
+                {
+                    "end_of_speech_timeout": 600,
+                    "attention_timeout": 20000,
+                    "background_file_volume": -30,
+                    "background_file_loops": 5,
+                    "digit_timeout": 6000,
+                    "energy_level": 120,
+                }
+            )
         else:  # standard
-            params.update({
-                "end_of_speech_timeout": 400,
-                "attention_timeout": 15000,
-                "background_file_volume": -20,
-                "background_file_loops": 3,
-                "digit_timeout": 4000,
-                "energy_level": 100
-            })
-            
+            params.update(
+                {
+                    "end_of_speech_timeout": 400,
+                    "attention_timeout": 15000,
+                    "background_file_volume": -20,
+                    "background_file_loops": 3,
+                    "digit_timeout": 4000,
+                    "energy_level": 100,
+                }
+            )
+
         # A/B test parameter variation
         if test_group == "B":
             params["end_of_speech_timeout"] = int(params["end_of_speech_timeout"] * 1.2)
-            
+
         # Add ai_model to all configurations
         params["ai_model"] = "gpt-4.1-nano"
-            
+
         agent.set_params(params)
 
     def _configure_industry_prompts(self, agent, industry, tier):
         """Configure industry-specific prompts"""
         config = self.industry_configs.get(industry, self.industry_configs["general"])
-        
+
         # Base introduction
         agent.prompt_add_section(
             "Role and Purpose",
             f"You are a professional AI assistant specialized in {industry} services. "
             f"Your role is to provide helpful, accurate information while maintaining "
-            f"{config['response_style']} communication standards."
+            f"{config['response_style']} communication standards.",
         )
-        
+
         # Industry-specific guidelines
         if industry == "healthcare":
             agent.prompt_add_section(
@@ -222,21 +239,21 @@ class ComprehensiveDynamicAgent(AgentBase):
                 "Follow HIPAA compliance standards. Never provide medical diagnoses or treatment advice.",
                 bullets=[
                     "Protect patient privacy at all times",
-                    "Direct medical questions to qualified healthcare providers", 
+                    "Direct medical questions to qualified healthcare providers",
                     "Use appropriate medical terminology when helpful",
-                    "Maintain professional bedside manner"
-                ]
+                    "Maintain professional bedside manner",
+                ],
             )
         elif industry == "finance":
             agent.prompt_add_section(
-                "Financial Guidelines", 
+                "Financial Guidelines",
                 "Adhere to financial industry regulations and maintain strict confidentiality.",
                 bullets=[
                     "Never provide specific investment advice",
                     "Protect sensitive financial information",
                     "Use precise financial terminology",
-                    "Refer complex matters to qualified advisors"
-                ]
+                    "Refer complex matters to qualified advisors",
+                ],
             )
         elif industry == "retail":
             agent.prompt_add_section(
@@ -246,10 +263,10 @@ class ComprehensiveDynamicAgent(AgentBase):
                     "Maintain friendly, helpful demeanor",
                     "Understand product features and benefits",
                     "Handle complaints with empathy",
-                    "Look for opportunities to enhance customer experience"
-                ]
+                    "Look for opportunities to enhance customer experience",
+                ],
             )
-        
+
         # Tier-specific capabilities
         if tier in ["premium", "enterprise"]:
             agent.prompt_add_section(
@@ -257,13 +274,15 @@ class ComprehensiveDynamicAgent(AgentBase):
                 f"As a {tier} service, you have access to advanced features:",
                 bullets=[
                     "Extended conversation memory",
-                    "Priority processing and faster responses", 
+                    "Priority processing and faster responses",
                     "Access to specialized knowledge bases",
-                    "Advanced personalization options"
-                ]
+                    "Advanced personalization options",
+                ],
             )
 
-    def _configure_global_data(self, agent, tier, industry, customer_id, test_group, debug_mode):
+    def _configure_global_data(
+        self, agent, tier, industry, customer_id, test_group, debug_mode
+    ):
         """Configure global data for the session"""
         global_data = {
             "service_tier": tier,
@@ -271,20 +290,20 @@ class ComprehensiveDynamicAgent(AgentBase):
             "test_group": test_group,
             "session_start": "2024-01-01T00:00:00Z",  # Would be actual timestamp
             "features_enabled": self._get_enabled_features(tier),
-            "compliance_level": self.industry_configs[industry]["compliance_level"]
+            "compliance_level": self.industry_configs[industry]["compliance_level"],
         }
-        
+
         if customer_id:
             global_data["customer_id"] = customer_id
             global_data["customer_tier"] = tier
-            
+
         if debug_mode:
             global_data["debug_mode"] = True
             global_data["debug_info"] = {
                 "voice_options": self.voice_options[tier],
-                "available_features": self._get_enabled_features(tier)
+                "available_features": self._get_enabled_features(tier),
             }
-            
+
         agent.set_global_data(global_data)
 
     def _configure_debug_features(self, agent, query_params):
@@ -296,18 +315,12 @@ class ComprehensiveDynamicAgent(AgentBase):
                 "Show decision-making process when appropriate",
                 "Include relevant global data references",
                 "Explain feature availability based on tier",
-                "Provide timing and performance insights"
-            ]
+                "Provide timing and performance insights",
+            ],
         )
-        
+
         # Add debug-specific speech recognition hints
-        agent.add_hints([
-            "debug",
-            "verbose",
-            "reasoning",
-            "capabilities",
-            "tier"
-        ])
+        agent.add_hints(["debug", "verbose", "reasoning", "capabilities", "tier"])
 
     def _configure_ab_testing(self, agent, test_group, tier):
         """Configure A/B testing variations"""
@@ -324,38 +337,35 @@ class ComprehensiveDynamicAgent(AgentBase):
                     "Ask clarifying questions more frequently",
                     "Provide more detailed explanations",
                     "Offer proactive suggestions when appropriate",
-                    "Use more conversational, engaging language"
-                ]
+                    "Use more conversational, engaging language",
+                ],
             )
 
     def _get_enabled_features(self, tier):
         """Return list of features enabled for the given tier"""
         features = ["basic_conversation", "function_calling"]
-        
+
         if tier in ["premium", "enterprise"]:
-            features.extend([
-                "extended_memory",
-                "priority_processing", 
-                "advanced_analytics"
-            ])
-            
+            features.extend(
+                ["extended_memory", "priority_processing", "advanced_analytics"]
+            )
+
         if tier == "enterprise":
-            features.extend([
-                "custom_integration",
-                "dedicated_support",
-                "advanced_security"
-            ])
-            
+            features.extend(
+                ["custom_integration", "dedicated_support", "advanced_security"]
+            )
+
         return features
 
 
 # Example usage and testing
 def main():
     agent = ComprehensiveDynamicAgent()
-    
+
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/concierge_agent_example.py
+++ b/examples/concierge_agent_example.py
@@ -20,10 +20,10 @@ Features demonstrated:
 3. Running the agent server
 """
 
-import os
 import logging
 import sys
 import argparse
+from pathlib import Path
 
 # Import the ConciergeAgent prefab
 from signalwire.prefabs import ConciergeAgent
@@ -50,18 +50,18 @@ def main():
     args, _ = parser.parse_known_args()
 
     # Find schema.json in the current directory or parent directory
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    parent_dir = os.path.dirname(current_dir)
+    current_dir = Path(__file__).resolve().parent
+    parent_dir = current_dir.parent
 
     schema_locations = [
-        os.path.join(current_dir, "schema.json"),
-        os.path.join(parent_dir, "schema.json"),
+        current_dir / "schema.json",
+        parent_dir / "schema.json",
     ]
 
     schema_path = None
     for loc in schema_locations:
-        if os.path.exists(loc):
-            schema_path = loc
+        if loc.exists():
+            schema_path = str(loc)
             logger.info(f"Found schema.json at: {schema_path}")
             break
 
@@ -136,7 +136,7 @@ def main():
     )
 
     # Create the concierge agent
-    agent = ConciergeAgent(
+    return ConciergeAgent(
         venue_name=venue_name,
         services=services,
         amenities=amenities,
@@ -147,8 +147,6 @@ def main():
         host=args.host,
         port=args.port,
     )
-
-    return agent
 
 
 if __name__ == "__main__":

--- a/examples/concierge_agent_example.py
+++ b/examples/concierge_agent_example.py
@@ -41,32 +41,36 @@ logger = logging.getLogger("concierge_example")
 
 def main():
     parser = argparse.ArgumentParser(description="Run the ConciergeAgent Example")
-    parser.add_argument("--port", type=int, default=3000, help="Port to run the server on")
-    parser.add_argument("--host", type=str, default="0.0.0.0", help="Host to bind the server to")
+    parser.add_argument(
+        "--port", type=int, default=3000, help="Port to run the server on"
+    )
+    parser.add_argument(
+        "--host", type=str, default="0.0.0.0", help="Host to bind the server to"
+    )
     args, _ = parser.parse_known_args()
-    
+
     # Find schema.json in the current directory or parent directory
     current_dir = os.path.dirname(os.path.abspath(__file__))
     parent_dir = os.path.dirname(current_dir)
-    
+
     schema_locations = [
         os.path.join(current_dir, "schema.json"),
-        os.path.join(parent_dir, "schema.json")
+        os.path.join(parent_dir, "schema.json"),
     ]
-    
+
     schema_path = None
     for loc in schema_locations:
         if os.path.exists(loc):
             schema_path = loc
             logger.info(f"Found schema.json at: {schema_path}")
             break
-            
+
     if not schema_path:
         logger.warning(f"Could not find schema.json in: {schema_locations}")
-    
+
     # Define a luxury resort concierge
     venue_name = "Oceanview Resort"
-    
+
     # Define services
     services = [
         "room service",
@@ -75,54 +79,54 @@ def main():
         "activity bookings",
         "airport shuttle",
         "valet parking",
-        "concierge assistance"
+        "concierge assistance",
     ]
-    
+
     # Define amenities with details
     amenities = {
         "infinity pool": {
             "hours": "7:00 AM - 10:00 PM",
             "location": "Main Level, Ocean View",
             "description": "Heated infinity pool overlooking the ocean with poolside service.",
-            "features": "Cabanas, hot tub, kids' splash area"
+            "features": "Cabanas, hot tub, kids' splash area",
         },
         "spa": {
             "hours": "9:00 AM - 8:00 PM",
             "location": "Lower Level, East Wing",
             "description": "Full-service luxury spa offering massages, facials, and body treatments.",
-            "reservation": "Required"
+            "reservation": "Required",
         },
         "fitness center": {
             "hours": "24 hours",
             "location": "2nd Floor, North Wing",
             "description": "State-of-the-art fitness center with cardio equipment, weights, and yoga studio.",
-            "features": "Personal trainers available by appointment"
+            "features": "Personal trainers available by appointment",
         },
         "beach access": {
             "hours": "Dawn to Dusk",
             "location": "Southern Pathway",
             "description": "Private beach access with complimentary chairs, umbrellas, and towels.",
-            "services": "Beach attendants, food and beverage service"
-        }
+            "services": "Beach attendants, food and beverage service",
+        },
     }
-    
+
     # Define hours of operation
     hours = {
         "check-in": "3:00 PM",
         "check-out": "11:00 AM",
         "front desk": "24 hours",
         "concierge": "7:00 AM - 11:00 PM",
-        "room service": "24 hours"
+        "room service": "24 hours",
     }
-    
+
     # Special instructions for the concierge
     special_instructions = [
         "Always greet guests by name when possible.",
         "Offer to make reservations for guests at local attractions.",
         "Provide weather updates when discussing outdoor activities.",
-        "Inform guests about the daily resort activities and events."
+        "Inform guests about the daily resort activities and events.",
     ]
-    
+
     # Welcome message
     welcome_message = (
         "Welcome to Oceanview Resort, where luxury meets comfort. "
@@ -130,7 +134,7 @@ def main():
         "or answer questions about our amenities and services. "
         "How may I help you today?"
     )
-    
+
     # Create the concierge agent
     agent = ConciergeAgent(
         venue_name=venue_name,
@@ -141,9 +145,9 @@ def main():
         welcome_message=welcome_message,
         schema_path=schema_path,
         host=args.host,
-        port=args.port
+        port=args.port,
     )
-    
+
     return agent
 
 
@@ -153,8 +157,8 @@ if __name__ == "__main__":
     # Print credentials
     username, password, source = agent.get_basic_auth_credentials(include_source=True)
 
-    logger.info(f"Starting Concierge Agent for Oceanview Resort")
+    logger.info("Starting Concierge Agent for Oceanview Resort")
 
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
-    agent.run() 
+    agent.run()

--- a/examples/contexts_demo.py
+++ b/examples/contexts_demo.py
@@ -52,13 +52,12 @@ from signalwire import AgentBase
 
 class AdvancedContextsDemoAgent(AgentBase):
     """Advanced Computer Sales Agent demonstrating full contexts system"""
-    
+
     def __init__(self):
         super().__init__(
-            name="Advanced Computer Sales Agent",
-            route="/advanced-contexts-demo"
+            name="Advanced Computer Sales Agent", route="/advanced-contexts-demo"
         )
-        
+
         # Set base prompt (required even when using contexts)
 
         self.prompt_add_section(
@@ -67,178 +66,230 @@ class AdvancedContextsDemoAgent(AgentBase):
             bullets=[
                 "Complete each step's specific criteria before advancing",
                 "Ask focused questions to gather the exact information needed",
-                "Be helpful and consultative, not pushy"
-            ]
+                "Be helpful and consultative, not pushy",
+            ],
         )
-        
+
         # define_contexts() returns a ContextBuilder that lets you create
         # contexts and steps using a fluent API. Must be called after super().__init__().
         contexts = self.define_contexts()
 
         # --- Context 1: Sales workflow ---
         # An isolated context with its own persona (Franklin) and a 3-step workflow.
-        sales_context = contexts.add_context("sales") \
-            .set_isolated(True) \
-            .add_section("Role", "You are Franklin, a helpful computer sales agent. Introduce yourself by name and welcome customers to help them find the perfect computer through your systematic approach.") \
-            .add_section("Voice Instructions", "Use the English-Franklin language for natural conversation flow.") \
-            .add_bullets("When to use change_context tool", [
-                "Customer asks for manager/supervisor/store manager - change_context to 'manager'",
-                "Customer asks technical questions - change_context to 'tech_support'",
-                "Customer frustrated/confused - change_context to 'manager'"
-            ])
-        
+        sales_context = (
+            contexts.add_context("sales")
+            .set_isolated(True)
+            .add_section(
+                "Role",
+                "You are Franklin, a helpful computer sales agent. Introduce yourself by name and welcome customers to help them find the perfect computer through your systematic approach.",
+            )
+            .add_section(
+                "Voice Instructions",
+                "Use the English-Franklin language for natural conversation flow.",
+            )
+            .add_bullets(
+                "When to use change_context tool",
+                [
+                    "Customer asks for manager/supervisor/store manager - change_context to 'manager'",
+                    "Customer asks technical questions - change_context to 'tech_support'",
+                    "Customer frustrated/confused - change_context to 'manager'",
+                ],
+            )
+        )
+
         # Steps within a context form a guided workflow. The AI can only advance
         # to steps listed in set_valid_steps(), and only after set_step_criteria() is met.
 
         # Step 1: Determine use case
-        sales_context.add_step("determine_use_case") \
-            .add_section("Current Task", "Identify the customer's primary computer use case") \
-            .add_bullets("Required Information to Collect", [
+        sales_context.add_step("determine_use_case").add_section(
+            "Current Task", "Identify the customer's primary computer use case"
+        ).add_bullets(
+            "Required Information to Collect",
+            [
                 "What will they primarily use the computer for?",
                 "Do they play video games? If so, what types and how often?",
                 "Do they need it for work? What kind of work applications?",
                 "Do they do creative work like video editing, design, or programming?",
-                "Help them categorize as: GAMING, WORK, or BALANCED"
-            ]) \
-            .set_step_criteria("Customer has clearly stated their use case as one of: GAMING, WORK, or BALANCED") \
-            .set_valid_steps(["determine_form_factor"]) \
-            .set_valid_contexts(["tech_support", "manager"])
-        
+                "Help them categorize as: GAMING, WORK, or BALANCED",
+            ],
+        ).set_step_criteria(
+            "Customer has clearly stated their use case as one of: GAMING, WORK, or BALANCED"
+        ).set_valid_steps(["determine_form_factor"]).set_valid_contexts(
+            ["tech_support", "manager"]
+        )
+
         # Step 2: Form factor preference
-        sales_context.add_step("determine_form_factor") \
-            .add_section("Current Task", "Determine if customer wants a laptop or desktop computer") \
-            .add_bullets("Decision-Making Questions", [
+        sales_context.add_step("determine_form_factor").add_section(
+            "Current Task", "Determine if customer wants a laptop or desktop computer"
+        ).add_bullets(
+            "Decision-Making Questions",
+            [
                 "Ask directly: 'Are you looking for a laptop or desktop computer or if they need help deciding?'",
-                "If they're unsure, help them decide by asking about portability vs performance needs"
-            ]) \
-            .set_step_criteria("Customer has explicitly stated they want either a LAPTOP or DESKTOP") \
-            .set_valid_steps(["make_recommendation"]) \
-            .set_valid_contexts(["tech_support", "manager"])
-        
+                "If they're unsure, help them decide by asking about portability vs performance needs",
+            ],
+        ).set_step_criteria(
+            "Customer has explicitly stated they want either a LAPTOP or DESKTOP"
+        ).set_valid_steps(["make_recommendation"]).set_valid_contexts(
+            ["tech_support", "manager"]
+        )
+
         # Step 3: Recommendation with context switching options
-        sales_context.add_step("make_recommendation") \
-            .add_section("Current Task", "Provide specific computer recommendation based on gathered information") \
-            .add_bullets("Recommendation Requirements", [
+        sales_context.add_step("make_recommendation").add_section(
+            "Current Task",
+            "Provide specific computer recommendation based on gathered information",
+        ).add_bullets(
+            "Recommendation Requirements",
+            [
                 "Recommend a specific computer type based on their use case and form factor",
                 "Explain why this recommendation fits their needs",
                 "Mention key specs that matter for their use case",
                 "Provide a rough price range they should expect",
-                "Ask if they want technical support or need to speak with a manager"
-            ]) \
-            .set_step_criteria("Customer has received a specific recommendation with explanation and pricing guidance") \
-            .set_valid_contexts(["tech_support", "manager"])
-        
+                "Ask if they want technical support or need to speak with a manager",
+            ],
+        ).set_step_criteria(
+            "Customer has received a specific recommendation with explanation and pricing guidance"
+        ).set_valid_contexts(["tech_support", "manager"])
+
         # --- Context 2: Technical Support ---
         # When the user asks a technical question, the AI switches to this context.
         # set_valid_contexts() on the sales steps above allows switching here.
-        tech_context = contexts.add_context("tech_support") \
-            .set_isolated(True)
-        
+        tech_context = contexts.add_context("tech_support").set_isolated(True)
+
         # Configure context switching behavior (when entering this context)
-        
+
         # Add context prompt for technical support with Rachael persona
-        tech_context.add_section("Role", "You are Rachael, a technical support specialist. Introduce yourself by name and offer to help with technical questions.") \
-            .add_section("Voice Instructions", "Use the English-Rachael language for helpful and knowledgeable technical assistance.") \
-            .add_section("Your Expertise", "Provide detailed technical assistance for computer-related questions and troubleshooting.") \
-            .add_bullets("When to use change_context tool", [
+        tech_context.add_section(
+            "Role",
+            "You are Rachael, a technical support specialist. Introduce yourself by name and offer to help with technical questions.",
+        ).add_section(
+            "Voice Instructions",
+            "Use the English-Rachael language for helpful and knowledgeable technical assistance.",
+        ).add_section(
+            "Your Expertise",
+            "Provide detailed technical assistance for computer-related questions and troubleshooting.",
+        ).add_bullets(
+            "When to use change_context tool",
+            [
                 "Customer wants to continue shopping - change_context to 'sales'",
                 "Customer asks for manager/store manager/pricing issues - change_context to 'manager'",
-                "Technical question resolved, wants to buy - change_context to 'sales'"
-            ])
-        
+                "Technical question resolved, wants to buy - change_context to 'sales'",
+            ],
+        )
+
         # Technical support step with return to sales
-        tech_context.add_step("provide_support") \
-            .add_section("Current Task", "Help with technical questions about computers") \
-            .add_bullets("Areas of Support", [
+        tech_context.add_step("provide_support").add_section(
+            "Current Task", "Help with technical questions about computers"
+        ).add_bullets(
+            "Areas of Support",
+            [
                 "Specifications and compatibility questions",
-                "Setup and installation guidance", 
+                "Setup and installation guidance",
                 "Performance optimization tips",
-                "Troubleshooting common issues"
-            ]) \
-            .set_step_criteria("Customer's technical question has been answered satisfactorily") \
-            .set_valid_contexts(["sales", "manager"])
-        
+                "Troubleshooting common issues",
+            ],
+        ).set_step_criteria(
+            "Customer's technical question has been answered satisfactorily"
+        ).set_valid_contexts(["sales", "manager"])
+
         # --- Context 3: Manager Escalation ---
         # This context uses enter fillers — phrases spoken while transitioning.
         # add_enter_filler() provides language-specific transition messages.
-        manager_context = contexts.add_context("manager") \
-            .set_isolated(True) \
-            .add_enter_filler("en-US", [
-                "Let me connect you with our store manager right away...",
-                "I'll get the manager for you immediately...",
-                "One moment while I bring in the store manager to assist you...",
-                "The manager will be right with you to help resolve this..."
-            ]) \
-            .add_enter_filler("default", [
-                "Transferring to the manager...",
-                "Getting the manager for you..."
-            ])
-        
+        manager_context = (
+            contexts.add_context("manager")
+            .set_isolated(True)
+            .add_enter_filler(
+                "en-US",
+                [
+                    "Let me connect you with our store manager right away...",
+                    "I'll get the manager for you immediately...",
+                    "One moment while I bring in the store manager to assist you...",
+                    "The manager will be right with you to help resolve this...",
+                ],
+            )
+            .add_enter_filler(
+                "default",
+                ["Transferring to the manager...", "Getting the manager for you..."],
+            )
+        )
+
         # Configure context entry
-        
+
         # Add manager context prompt with introduction
-        manager_context.add_section("Role", "You are Dwight, the store manager. Introduce yourself by name and acknowledge that the customer needs additional assistance with their computer purchase.") \
-            .add_section("Voice Instructions", "Use the English-Dwight language for authoritative but friendly communication.") \
-            .add_section("Authority Level", "You are a senior store manager with decision-making power") \
-            .add_bullets("Your Capabilities", [
+        manager_context.add_section(
+            "Role",
+            "You are Dwight, the store manager. Introduce yourself by name and acknowledge that the customer needs additional assistance with their computer purchase.",
+        ).add_section(
+            "Voice Instructions",
+            "Use the English-Dwight language for authoritative but friendly communication.",
+        ).add_section(
+            "Authority Level",
+            "You are a senior store manager with decision-making power",
+        ).add_bullets(
+            "Your Capabilities",
+            [
                 "Authorize special pricing and discounts",
-                "Handle complex customer requirements", 
+                "Handle complex customer requirements",
                 "Resolve escalated issues",
-                "Make final purchasing decisions"
-            ]) \
-            .add_section("Approach", "Express commitment to finding the right solution and ask how you can help resolve their concerns.") \
-            .add_bullets("When to use change_context tool", [
+                "Make final purchasing decisions",
+            ],
+        ).add_section(
+            "Approach",
+            "Express commitment to finding the right solution and ask how you can help resolve their concerns.",
+        ).add_bullets(
+            "When to use change_context tool",
+            [
                 "Customer needs technical help - change_context to 'tech_support'",
                 "Issue resolved, wants to continue shopping - change_context to 'sales'",
-                "Customer wants to talk to sales team - change_context to 'sales'"
-            ])
+                "Customer wants to talk to sales team - change_context to 'sales'",
+            ],
+        )
 
-        manager_context.add_step("handle_escalation") \
-            .add_section("Current Task", "Understand the customer's specific concerns and work to resolve their issues") \
-            .add_bullets("Manager Approach", [
+        manager_context.add_step("handle_escalation").add_section(
+            "Current Task",
+            "Understand the customer's specific concerns and work to resolve their issues",
+        ).add_bullets(
+            "Manager Approach",
+            [
                 "Ask what specific concerns they have about their computer purchase",
                 "Listen carefully to their issues",
                 "Use your authority to provide solutions",
-                "Offer appropriate assistance based on their needs"
-            ]) \
-            .set_step_criteria("Customer issue has been resolved by manager") \
-            .set_valid_contexts(["sales", "tech_support"])
-        
+                "Offer appropriate assistance based on their needs",
+            ],
+        ).set_step_criteria(
+            "Customer issue has been resolved by manager"
+        ).set_valid_contexts(["sales", "tech_support"])
+
         # Each context references a language by name. Define languages with
         # different voices so each persona sounds distinct.
-        self.add_language(
-            name="English-Franklin",
-            code="en-US",
-            voice="inworld.Mark"
-        )
+        self.add_language(name="English-Franklin", code="en-US", voice="inworld.Mark")
 
-        self.add_language(
-            name="English-Dwight",
-            code="en-US",
-            voice="inworld.Blake"
-        )
+        self.add_language(name="English-Dwight", code="en-US", voice="inworld.Blake")
 
-        self.add_language(
-            name="English-Rachael",
-            code="en-US",
-            voice="inworld.Sarah"
-        )
-        
+        self.add_language(name="English-Rachael", code="en-US", voice="inworld.Sarah")
+
         # Internal fillers are spoken when the AI triggers built-in actions like
         # next_step or change_context. They fill silence during transitions.
-        self.add_internal_filler("next_step", "en-US", [
-            "Great! Let's move to the next step...",
-            "Perfect! Moving forward in our conversation...",
-            "Excellent! Let's continue to the next part...",
-            "Wonderful! Progressing to the next step..."
-        ])
-        
-        self.add_internal_filler("change_context", "en-US", [
-            "Let me connect you with the right department...",
-            "I'm transferring you to a specialist...",
-            "One moment while I get the right person...",
-            "Let me get someone who can help with that..."
-        ])
+        self.add_internal_filler(
+            "next_step",
+            "en-US",
+            [
+                "Great! Let's move to the next step...",
+                "Perfect! Moving forward in our conversation...",
+                "Excellent! Let's continue to the next part...",
+                "Wonderful! Progressing to the next step...",
+            ],
+        )
+
+        self.add_internal_filler(
+            "change_context",
+            "en-US",
+            [
+                "Let me connect you with the right department...",
+                "I'm transferring you to a specialist...",
+                "One moment while I get the right person...",
+                "Let me get someone who can help with that...",
+            ],
+        )
 
 
 def main():
@@ -250,7 +301,9 @@ def main():
     print("This agent demonstrates the complete contexts system including:")
     print()
     print("Context Features:")
-    print("  • Context entry parameters (system_prompt, consolidate, full_reset, user_prompt)")
+    print(
+        "  • Context entry parameters (system_prompt, consolidate, full_reset, user_prompt)"
+    )
     print("  • Context prompts (structured POM format)")
     print("  • Post prompt overrides per context")
     print("  • Enter fillers for smooth context transitions (manager context demo)")
@@ -273,16 +326,16 @@ def main():
     print()
     print("Test the agent at: http://localhost:3000/advanced-contexts-demo")
     print()
-    
+
     agent = AdvancedContextsDemoAgent()
-    
+
     print("Agent configuration:")
     print(f"  Name: {agent.get_name()}")
-    print(f"  Route: /advanced-contexts-demo")
-    print(f"  Contexts: 3 (sales, tech_support, manager)")
-    print(f"  Features: Context entry params + Context switching")
+    print("  Route: /advanced-contexts-demo")
+    print("  Contexts: 3 (sales, tech_support, manager)")
+    print("  Features: Context entry params + Context switching")
     print()
-    
+
     try:
         agent.run()
     except KeyboardInterrupt:
@@ -290,4 +343,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/custom_path_agent.py
+++ b/examples/custom_path_agent.py
@@ -8,7 +8,6 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-
 """
 Custom Path Agent Example
 
@@ -35,76 +34,73 @@ Try these requests:
 
 from signalwire import AgentBase
 
+
 class ChatAgent(AgentBase):
     def __init__(self, route="/chat"):
         super().__init__(
             name="Chat Assistant",
             route=route,  # Custom path for this agent
             auto_answer=True,
-            record_call=True
+            record_call=True,
         )
-        
+
         # Set up dynamic configuration based on query parameters
         self.set_dynamic_config_callback(self.configure_chat_agent)
-        
+
         # Base prompt
         self.prompt_add_section(
             "Role",
-            "You are a friendly chat assistant ready to help with any questions or conversations."
+            "You are a friendly chat assistant ready to help with any questions or conversations.",
         )
 
     def configure_chat_agent(self, query_params, body_params, headers, agent):
         """Configure the agent based on request parameters"""
-        user_name = query_params.get('user_name', 'friend')
-        topic = query_params.get('topic', 'general conversation')
-        mood = query_params.get('mood', 'friendly').lower()
-        
+        user_name = query_params.get("user_name", "friend")
+        topic = query_params.get("topic", "general conversation")
+        mood = query_params.get("mood", "friendly").lower()
+
         # Personalize the greeting
         agent.prompt_add_section(
             "Personalization",
-            f"The user's name is {user_name}. They're interested in discussing {topic}."
+            f"The user's name is {user_name}. They're interested in discussing {topic}.",
         )
-        
+
         # Adjust voice and tone based on mood
         voice_model = "inworld.Mark"
         agent.add_language("English", "en-US", voice_model)
-        
-        if mood == 'professional':
+
+        if mood == "professional":
             agent.prompt_add_section(
                 "Communication Style",
-                "Maintain a professional, business-appropriate tone in all interactions."
+                "Maintain a professional, business-appropriate tone in all interactions.",
             )
-        elif mood == 'casual':
+        elif mood == "casual":
             agent.prompt_add_section(
-                "Communication Style", 
-                "Use a casual, relaxed conversational style. Feel free to use informal language."
+                "Communication Style",
+                "Use a casual, relaxed conversational style. Feel free to use informal language.",
             )
         else:  # friendly (default)
             agent.prompt_add_section(
                 "Communication Style",
-                "Be warm, friendly, and approachable in your responses."
+                "Be warm, friendly, and approachable in your responses.",
             )
-        
+
         # Set global data for the conversation
-        agent.set_global_data({
-            "user_name": user_name,
-            "topic": topic,
-            "mood": mood,
-            "session_type": "chat"
-        })
-        
+        agent.set_global_data(
+            {
+                "user_name": user_name,
+                "topic": topic,
+                "mood": mood,
+                "session_type": "chat",
+            }
+        )
+
         # Add speech recognition hints for common chat terms
-        agent.add_hints([
-            "chat",
-            "assistant",
-            "help", 
-            "conversation",
-            "question"
-        ])
+        agent.add_hints(["chat", "assistant", "help", "conversation", "question"])
 
 
 if __name__ == "__main__":
     # Create and start the agent
     agent = ChatAgent("/chat")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
-    agent.run() 
+    agent.run()

--- a/examples/data_map_demo.py
+++ b/examples/data_map_demo.py
@@ -21,9 +21,12 @@ Each tool generates SWAIG JSON with data_map instead of webhook URLs,
 letting the SignalWire server handle all the REST API calls and processing.
 """
 
-import os
 from signalwire import AgentBase
-from signalwire.core.data_map import DataMap, create_simple_api_tool, create_expression_tool
+from signalwire.core.data_map import (
+    DataMap,
+    create_simple_api_tool,
+    create_expression_tool,
+)
 from signalwire.core.function_result import FunctionResult
 
 
@@ -31,138 +34,183 @@ class DataMapDemoAgent(AgentBase):
     """
     Demo agent showing different data_map patterns
     """
-    
+
     def __init__(self):
-        super().__init__(
-            name="datamap-demo",
-            route="/datamap-demo"
-        )
+        super().__init__(name="datamap-demo", route="/datamap-demo")
         self.setup()
-    
+
     def setup(self):
         """Set up the agent with data_map tools"""
-        
+
         # Add a regular SWAIG function for comparison
         self.define_tool(
             name="echo_test",
             description="A simple echo function for testing",
             parameters={
-                "message": {
-                    "type": "string",
-                    "description": "Message to echo back"
-                },
+                "message": {"type": "string", "description": "Message to echo back"},
                 "repeat": {
-                    "type": "integer", 
-                    "description": "Number of times to repeat"
-                }
+                    "type": "integer",
+                    "description": "Number of times to repeat",
+                },
             },
-            handler=self.echo_handler
+            handler=self.echo_handler,
         )
-        
+
         # 1. Simple weather API - basic pattern
         weather_tool = create_simple_api_tool(
-            name='get_weather',
-            url='https://api.weather.com/v1/current?key=API_KEY&q=${location}',
-            response_template='Current weather in ${location}: ${response.current.condition.text}, ${response.current.temp_f}°F',
+            name="get_weather",
+            url="https://api.weather.com/v1/current?key=API_KEY&q=${location}",
+            response_template="Current weather in ${location}: ${response.current.condition.text}, ${response.current.temp_f}°F",
             parameters={
-                'location': {
-                    'type': 'string', 
-                    'description': 'City name or location',
-                    'required': True
+                "location": {
+                    "type": "string",
+                    "description": "City name or location",
+                    "required": True,
                 }
             },
-            error_keys=['error', 'message']
+            error_keys=["error", "message"],
         )
-        
+
         # 2. Expression-based file control - no API calls
-        file_control_tool = (DataMap('file_control')
-            .description('Control audio/video playback')
-            .parameter('command', 'string', 'Playback command', required=True)
-            .parameter('filename', 'string', 'File to control', required=False)
-            .expression('${args.command}', r'start.*', 
-                       FunctionResult("Starting playback").add_action('start_playback', {'file': '${args.filename}'}))
-            .expression('${args.command}', r'stop.*',
-                       FunctionResult("Stopping playback").add_action('stop_playback', True))
-            .expression('${args.command}', r'pause.*',
-                       FunctionResult("Pausing playback").add_action('pause_playback', True))
-            .expression('${args.command}', r'resume.*',
-                       FunctionResult("Resuming playback").add_action('resume_playback', True))
+        file_control_tool = (
+            DataMap("file_control")
+            .description("Control audio/video playback")
+            .parameter("command", "string", "Playback command", required=True)
+            .parameter("filename", "string", "File to control", required=False)
+            .expression(
+                "${args.command}",
+                r"start.*",
+                FunctionResult("Starting playback").add_action(
+                    "start_playback", {"file": "${args.filename}"}
+                ),
+            )
+            .expression(
+                "${args.command}",
+                r"stop.*",
+                FunctionResult("Stopping playback").add_action("stop_playback", True),
+            )
+            .expression(
+                "${args.command}",
+                r"pause.*",
+                FunctionResult("Pausing playback").add_action("pause_playback", True),
+            )
+            .expression(
+                "${args.command}",
+                r"resume.*",
+                FunctionResult("Resuming playback").add_action("resume_playback", True),
+            )
         )
-        
+
         # 3. Knowledge search with foreach - processes arrays
-        knowledge_tool = (DataMap('search_knowledge')
-            .description('Search knowledge base and return multiple results')
-            .parameter('query', 'string', 'Search query', required=True)
-            .parameter('limit', 'number', 'Max results to return', required=False)
-            .webhook('POST', 'https://api.knowledge.com/search', 
-                    headers={'Authorization': 'Bearer YOUR_TOKEN', 'Content-Type': 'application/json'})
-            .body({'query': '${query}', 'limit': '${limit}'})
-            .foreach({
-                'input_key': '${response.results}',
-                'output_key': 'foreach',
-                'append': True
-            })
-            .output(FunctionResult('Found: ${foreach.title} - ${foreach.summary}'))
-            .error_keys(['error', 'status'])
+        knowledge_tool = (
+            DataMap("search_knowledge")
+            .description("Search knowledge base and return multiple results")
+            .parameter("query", "string", "Search query", required=True)
+            .parameter("limit", "number", "Max results to return", required=False)
+            .webhook(
+                "POST",
+                "https://api.knowledge.com/search",
+                headers={
+                    "Authorization": "Bearer YOUR_TOKEN",
+                    "Content-Type": "application/json",
+                },
+            )
+            .body({"query": "${query}", "limit": "${limit}"})
+            .foreach(
+                {
+                    "input_key": "${response.results}",
+                    "output_key": "foreach",
+                    "append": True,
+                }
+            )
+            .output(FunctionResult("Found: ${foreach.title} - ${foreach.summary}"))
+            .error_keys(["error", "status"])
         )
-        
-        # 4. Random joke API - handles array responses differently  
-        joke_tool = (DataMap('get_joke')
-            .description('Get a random joke from specific category')
-            .parameter('category', 'string', 'Joke category', 
-                      enum=['programming', 'dad', 'general'], required=False)
-            .webhook('GET', 'https://api.jokes.com/random?category=${category}')
-            .output(FunctionResult("Here's a ${response.category} joke: ${response.joke}"))
-            .error_keys(['error'])
+
+        # 4. Random joke API - handles array responses differently
+        joke_tool = (
+            DataMap("get_joke")
+            .description("Get a random joke from specific category")
+            .parameter(
+                "category",
+                "string",
+                "Joke category",
+                enum=["programming", "dad", "general"],
+                required=False,
+            )
+            .webhook("GET", "https://api.jokes.com/random?category=${category}")
+            .output(
+                FunctionResult("Here's a ${response.category} joke: ${response.joke}")
+            )
+            .error_keys(["error"])
         )
-        
+
         # 5. Complex API with multiple webhooks and fallback
-        complex_search_tool = (DataMap('complex_search')
-            .description('Search with fallback APIs')
-            .parameter('query', 'string', 'Search query', required=True)
-            .parameter('priority', 'string', 'Search priority', 
-                      enum=['fast', 'comprehensive'], required=False)
+        complex_search_tool = (
+            DataMap("complex_search")
+            .description("Search with fallback APIs")
+            .parameter("query", "string", "Search query", required=True)
+            .parameter(
+                "priority",
+                "string",
+                "Search priority",
+                enum=["fast", "comprehensive"],
+                required=False,
+            )
             # First try fast API
-            .webhook('GET', 'https://api.fastsearch.com/q?term=${query}', 
-                    headers={'X-API-Key': 'FAST_KEY'})
+            .webhook(
+                "GET",
+                "https://api.fastsearch.com/q?term=${query}",
+                headers={"X-API-Key": "FAST_KEY"},
+            )
             # Fallback to comprehensive API if first fails
-            .webhook('GET', 'https://api.comprehensive.com/search?q=${query}&detail=full',
-                    headers={'Authorization': 'Bearer COMPREHENSIVE_TOKEN'})
-            .foreach({
-                'input_key': '${response.items}',
-                'output_key': 'foreach',
-                'append': True
-            })
-            .output(FunctionResult('Search result: ${foreach.title} - Score: ${foreach.relevance}'))
-            .error_keys(['error', 'failed', 'unavailable'])
+            .webhook(
+                "GET",
+                "https://api.comprehensive.com/search?q=${query}&detail=full",
+                headers={"Authorization": "Bearer COMPREHENSIVE_TOKEN"},
+            )
+            .foreach(
+                {
+                    "input_key": "${response.items}",
+                    "output_key": "foreach",
+                    "append": True,
+                }
+            )
+            .output(
+                FunctionResult(
+                    "Search result: ${foreach.title} - Score: ${foreach.relevance}"
+                )
+            )
+            .error_keys(["error", "failed", "unavailable"])
         )
-        
+
         # Register all tools with the agent
         self.register_data_map_tool(weather_tool)
-        self.register_data_map_tool(file_control_tool) 
+        self.register_data_map_tool(file_control_tool)
         self.register_data_map_tool(knowledge_tool)
         self.register_data_map_tool(joke_tool)
         self.register_data_map_tool(complex_search_tool)
-        
+
         # Add some context about the capabilities
-        self.prompt_add_section("Available data_map tools for testing:",
+        self.prompt_add_section(
+            "Available data_map tools for testing:",
             "- get_weather(location): Get current weather for a city",
             "- file_control(command, filename): Control audio/video playback",
             "- search_knowledge(query, limit): Search knowledge base",
             "- get_joke(category): Get random jokes",
-            "- complex_search(query, priority): Multi-API search with fallback"
+            "- complex_search(query, priority): Multi-API search with fallback",
         )
 
     def register_data_map_tool(self, data_map: DataMap):
         """
         Register a DataMap as a SWAIG function
-        
+
         Args:
             data_map: DataMap object to register
         """
         # Convert DataMap to SWAIG function definition
         function_def = data_map.to_swaig_function()
-        
+
         # Register the raw function dictionary directly
         self.register_swaig_function(function_def)
 
@@ -176,54 +224,68 @@ class DataMapDemoAgent(AgentBase):
 
 def print_data_map_examples():
     """Print example data_map JSON structures"""
-    
+
     print("=" * 80)
     print("DATA MAP EXAMPLES - Generated SWAIG Function Definitions")
     print("=" * 80)
-    
+
     # Simple weather API
     weather = create_simple_api_tool(
-        'get_weather',
-        'https://api.weather.com/v1/current?key=API_KEY&q=${location}',
-        'Weather in ${location}: ${response.current.condition.text}, ${response.current.temp_f}°F',
-        parameters={'location': {'type': 'string', 'description': 'City name', 'required': True}}
+        "get_weather",
+        "https://api.weather.com/v1/current?key=API_KEY&q=${location}",
+        "Weather in ${location}: ${response.current.condition.text}, ${response.current.temp_f}°F",
+        parameters={
+            "location": {"type": "string", "description": "City name", "required": True}
+        },
     )
-    
+
     print("\n1. Simple API Tool (Weather):")
     print(f"   Generated SWAIG: {weather.to_swaig_function()}")
-    
+
     # Expression tool — patterns map a test_value to a (regex, FunctionResult) tuple
     patterns = {
-        '${args.command}': (r'start.*', FunctionResult().add_action('start_playback', {'file': '${args.filename}'})),
+        "${args.command}": (
+            r"start.*",
+            FunctionResult().add_action("start_playback", {"file": "${args.filename}"}),
+        ),
     }
-    
+
     file_control = create_expression_tool(
-        'file_control',
+        "file_control",
         patterns,
-        parameters={'command': {'type': 'string', 'description': 'Command', 'required': True}}
+        parameters={
+            "command": {"type": "string", "description": "Command", "required": True}
+        },
     )
-    
+
     print("\n2. Expression Tool (File Control):")
     print(f"   Generated SWAIG: {file_control.to_swaig_function()}")
-    
+
     # Complex tool with foreach
-    search_tool = (DataMap('search_docs')
-        .description('Search documentation')
-        .parameter('query', 'string', 'Search query', required=True) 
-        .webhook('POST', 'https://api.docs.com/search', headers={'Authorization': 'Bearer TOKEN'})
-        .body({'query': '${query}', 'limit': 3})
-        .foreach({
-            'input_key': '${response.results}',
-            'output_key': 'foreach',
-            'append': True
-        })
-        .output(FunctionResult('Found: ${foreach.title} - ${foreach.summary}'))
-        .error_keys(['error'])
+    search_tool = (
+        DataMap("search_docs")
+        .description("Search documentation")
+        .parameter("query", "string", "Search query", required=True)
+        .webhook(
+            "POST",
+            "https://api.docs.com/search",
+            headers={"Authorization": "Bearer TOKEN"},
+        )
+        .body({"query": "${query}", "limit": 3})
+        .foreach(
+            {
+                "input_key": "${response.results}",
+                "output_key": "foreach",
+                "append": True,
+            }
+        )
+        .output(FunctionResult("Found: ${foreach.title} - ${foreach.summary}"))
+        .error_keys(["error"])
     )
-    
+
     print("\n3. Complex Tool (Search with Foreach):")
     print(f"   Generated SWAIG: {search_tool.to_swaig_function()}")
-    
+
     print("\n" + "=" * 80)
     print("These tools generate SWAIG functions with 'data_map' instead of 'url'")
     print("SignalWire server handles all REST API calls, variable expansion,")
@@ -237,7 +299,7 @@ agent = DataMapDemoAgent()
 if __name__ == "__main__":
     # Print examples first
     print_data_map_examples()
-    
+
     print("\n" + "=" * 80)
     print("All examples above show the pattern:")
     print("SUCCESS: Uses DataMap class with FunctionResult for outputs")
@@ -245,13 +307,13 @@ if __name__ == "__main__":
     print("SUCCESS: SignalWire server handles REST API calls automatically")
     print("SUCCESS: Supports expressions, foreach, webhooks, error handling")
     print("=" * 80)
-    
+
     print("\nKey benefits of this approach:")
     print("- Familiar FunctionResult pattern for all outputs")
     print("- Method chaining like: DataMap('name').webhook().output().foreach()")
     print("- No webhook servers needed - everything runs on SignalWire")
     print("- Covers all data_map patterns from real examples")
     print("- Progressive complexity: simple helpers + full builder API")
-    
+
     print("\nThis provides a clean SDK for data_map without reinventing")
-    print("the wheel - just extends existing patterns developers know!") 
+    print("the wheel - just extends existing patterns developers know!")

--- a/examples/datasphere_multi_instance_demo.py
+++ b/examples/datasphere_multi_instance_demo.py
@@ -25,140 +25,154 @@ To use this demo, you'll need:
 - Valid space_name, project_id, token, and document_id values
 """
 
-import os
 from signalwire import AgentBase
+
 
 def main():
     # Create an agent
     agent = AgentBase("Multi-DataSphere Assistant", route="/datasphere-demo")
-    
+
     # Configure the agent with inworld.Mark voice
     agent.add_language("English", "en-US", "inworld.Mark")
-    
+
     print("Creating agent with multiple DataSphere skill instances...")
-    
+
     # Add datetime and math skills for basic functionality
     try:
         agent.add_skill("datetime")
         print("Added datetime skill")
     except Exception as e:
         print(f"Failed to add datetime skill: {e}")
-    
+
     try:
         agent.add_skill("math")
         print("Added math skill")
     except Exception as e:
         print(f"Failed to add math skill: {e}")
-    
+
     # Example configuration - replace with your actual DataSphere details
     example_config = {
-        'space_name': 'your-space',
-        'project_id': 'your-project-id', 
-        'token': 'your-token'
+        "space_name": "your-space",
+        "project_id": "your-project-id",
+        "token": "your-token",
     }
-    
+
     # Instance 1: Drinks knowledge base
     try:
-        agent.add_skill("datasphere", {
-            **example_config,
-            "document_id": "drinks-doc-123",
-            "tool_name": "search_drinks_knowledge",
-            "tags": ["Drinks", "Bar", "Cocktails"],
-            "count": 2,
-            "distance": 5.0,
-            "no_results_message": "I couldn't find any drink recipes or information about '{query}'. Try asking about a different cocktail or beverage.",
-            "swaig_fields": {
-                "fillers": {
-                    "en-US": [
-                        "Let me check our drink recipes...",
-                        "Searching our cocktail database...",
-                        "Looking up drink information..."
-                    ]
-                }
-            }
-        })
+        agent.add_skill(
+            "datasphere",
+            {
+                **example_config,
+                "document_id": "drinks-doc-123",
+                "tool_name": "search_drinks_knowledge",
+                "tags": ["Drinks", "Bar", "Cocktails"],
+                "count": 2,
+                "distance": 5.0,
+                "no_results_message": "I couldn't find any drink recipes or information about '{query}'. Try asking about a different cocktail or beverage.",
+                "swaig_fields": {
+                    "fillers": {
+                        "en-US": [
+                            "Let me check our drink recipes...",
+                            "Searching our cocktail database...",
+                            "Looking up drink information...",
+                        ]
+                    }
+                },
+            },
+        )
         print("Added drinks knowledge search (tool: search_drinks_knowledge)")
     except Exception as e:
         print(f"Failed to add drinks DataSphere skill: {e}")
         print("   Note: Replace example_config with your actual DataSphere credentials")
-    
+
     # Instance 2: Food knowledge base
     try:
-        agent.add_skill("datasphere", {
-            **example_config,
-            "document_id": "food-doc-456",
-            "tool_name": "search_food_knowledge", 
-            "tags": ["Food", "Recipes", "Cooking"],
-            "count": 3,
-            "distance": 4.0,
-            "language": "en",
-            "no_results_message": "I couldn't find any recipes or cooking information about '{query}'. Try asking about a different dish or ingredient.",
-            "swaig_fields": {
-                "fillers": {
-                    "en-US": [
-                        "Checking our recipe collection...",
-                        "Searching cooking instructions...",
-                        "Looking through our food database..."
-                    ]
-                }
-            }
-        })
+        agent.add_skill(
+            "datasphere",
+            {
+                **example_config,
+                "document_id": "food-doc-456",
+                "tool_name": "search_food_knowledge",
+                "tags": ["Food", "Recipes", "Cooking"],
+                "count": 3,
+                "distance": 4.0,
+                "language": "en",
+                "no_results_message": "I couldn't find any recipes or cooking information about '{query}'. Try asking about a different dish or ingredient.",
+                "swaig_fields": {
+                    "fillers": {
+                        "en-US": [
+                            "Checking our recipe collection...",
+                            "Searching cooking instructions...",
+                            "Looking through our food database...",
+                        ]
+                    }
+                },
+            },
+        )
         print("Added food knowledge search (tool: search_food_knowledge)")
     except Exception as e:
         print(f"Failed to add food DataSphere skill: {e}")
         print("   Note: Replace example_config with your actual DataSphere credentials")
-    
+
     # Instance 3: General knowledge base with default tool name
     try:
-        agent.add_skill("datasphere", {
-            **example_config,
-            "document_id": "general-doc-789",
-            # No tool_name specified, so it will use default "search_knowledge"
-            "count": 1,
-            "distance": 3.0,
-            "no_results_message": "I couldn't find information about '{query}' in our general knowledge base. Please try rephrasing your question."
-        })
+        agent.add_skill(
+            "datasphere",
+            {
+                **example_config,
+                "document_id": "general-doc-789",
+                # No tool_name specified, so it will use default "search_knowledge"
+                "count": 1,
+                "distance": 3.0,
+                "no_results_message": "I couldn't find information about '{query}' in our general knowledge base. Please try rephrasing your question.",
+            },
+        )
         print("Added general knowledge search (tool: search_knowledge - default)")
     except Exception as e:
         print(f"Failed to add general DataSphere skill: {e}")
         print("   Note: Replace example_config with your actual DataSphere credentials")
-    
+
     # Show what skills/instances are loaded
     loaded_skills = agent.list_skills()
     print(f"\nLoaded skill instances: {', '.join(loaded_skills)}")
-    
+
     # Show available skills from registry
     try:
         from signalwire.skills.registry import skill_registry
+
         available_skills = skill_registry.list_skills()
-        print(f"\nAvailable skills in registry:")
+        print("\nAvailable skills in registry:")
         for skill in available_skills:
             print(f"  - {skill['name']}: {skill['description']}")
-            if skill['name'] == 'datasphere':
-                print(f"    Supports multiple instances: Yes")
+            if skill["name"] == "datasphere":
+                print("    Supports multiple instances: Yes")
             else:
-                print(f"    Supports multiple instances: No")
+                print("    Supports multiple instances: No")
     except Exception as e:
         print(f"Failed to list available skills: {e}")
-    
+
     print(f"\nAgent available at: {agent.get_full_url()}")
     print("The agent now has enhanced capabilities:")
     print("   - Can tell current date/time")
-    print("   - Can perform mathematical calculations") 
-    
+    print("   - Can perform mathematical calculations")
+
     # Count how many DataSphere instances we have
-    datasphere_instances = [skill for skill in loaded_skills if skill.startswith('datasphere_')]
+    datasphere_instances = [
+        skill for skill in loaded_skills if skill.startswith("datasphere_")
+    ]
     if datasphere_instances:
         print(f"   - Has {len(datasphere_instances)} knowledge search capabilities:")
         for instance in datasphere_instances:
-            tool_name = instance.split('_', 1)[1] if '_' in instance else 'search_knowledge'
+            tool_name = (
+                instance.split("_", 1)[1] if "_" in instance else "search_knowledge"
+            )
             print(f"     * {tool_name}")
-    
+
     print("\nDataSphere Multiple Instance Examples:")
     print("   # Basic usage with default tool name")
     print("   agent.add_skill('datasphere', {")
     print("       'space_name': 'my-space',")
-    print("       'project_id': 'my-project',") 
+    print("       'project_id': 'my-project',")
     print("       'token': 'my-token',")
     print("       'document_id': 'my-doc-id'")
     print("   })")
@@ -180,10 +194,11 @@ def main():
     print("   agent.add_skill('datasphere', {..., 'tool_name': 'search_products'})")
     print("   agent.add_skill('datasphere', {..., 'tool_name': 'search_support'})")
     print("   agent.add_skill('datasphere', {..., 'tool_name': 'search_policies'})")
-    
+
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/datasphere_serverless_demo.py
+++ b/examples/datasphere_serverless_demo.py
@@ -26,140 +26,160 @@ To use this demo, you'll need:
 - Valid space_name, project_id, token, and document_id values
 """
 
-import os
 from signalwire import AgentBase
+
 
 def main():
     # Create an agent
-    agent = AgentBase("DataSphere Serverless Assistant", route="/datasphere-serverless-demo")
-    
+    agent = AgentBase(
+        "DataSphere Serverless Assistant", route="/datasphere-serverless-demo"
+    )
+
     # Configure the agent with inworld.Mark voice
     agent.add_language("English", "en-US", "inworld.Mark")
-    
+
     print("Creating agent with DataSphere Serverless skill (DataMap implementation)...")
-    
+
     # Add datetime and math skills for basic functionality
     try:
         agent.add_skill("datetime")
         print("Added datetime skill")
     except Exception as e:
         print(f"Failed to add datetime skill: {e}")
-    
+
     try:
         agent.add_skill("math")
         print("Added math skill")
     except Exception as e:
         print(f"Failed to add math skill: {e}")
-    
+
     # Example configuration - replace with your actual DataSphere details
     example_config = {
-        'space_name': 'your-space',
-        'project_id': 'your-project-id', 
-        'token': 'your-token'
+        "space_name": "your-space",
+        "project_id": "your-project-id",
+        "token": "your-token",
     }
-    
+
     # Instance 1: Drinks knowledge base (serverless)
     try:
-        agent.add_skill("datasphere_serverless", {
-            **example_config,
-            "document_id": "drinks-doc-123",
-            "tool_name": "search_drinks_serverless",
-            "tags": ["Drinks", "Bar", "Cocktails"],
-            "count": 2,
-            "distance": 5.0,
-            "no_results_message": "I couldn't find any drink recipes or information about '{query}' using serverless search. Try asking about a different cocktail or beverage.",
-            "swaig_fields": {
-                "fillers": {
-                    "en-US": [
-                        "Searching drink recipes on SignalWire servers...",
-                        "Looking up cocktail information serverlessly...",
-                        "Checking our drink database via DataMap..."
-                    ]
-                }
-            }
-        })
-        print("Added serverless drinks knowledge search (tool: search_drinks_serverless)")
+        agent.add_skill(
+            "datasphere_serverless",
+            {
+                **example_config,
+                "document_id": "drinks-doc-123",
+                "tool_name": "search_drinks_serverless",
+                "tags": ["Drinks", "Bar", "Cocktails"],
+                "count": 2,
+                "distance": 5.0,
+                "no_results_message": "I couldn't find any drink recipes or information about '{query}' using serverless search. Try asking about a different cocktail or beverage.",
+                "swaig_fields": {
+                    "fillers": {
+                        "en-US": [
+                            "Searching drink recipes on SignalWire servers...",
+                            "Looking up cocktail information serverlessly...",
+                            "Checking our drink database via DataMap...",
+                        ]
+                    }
+                },
+            },
+        )
+        print(
+            "Added serverless drinks knowledge search (tool: search_drinks_serverless)"
+        )
     except Exception as e:
         print(f"Failed to add drinks DataSphere Serverless skill: {e}")
         print("   Note: Replace example_config with your actual DataSphere credentials")
-    
+
     # Instance 2: Food knowledge base (serverless)
     try:
-        agent.add_skill("datasphere_serverless", {
-            **example_config,
-            "document_id": "food-doc-456",
-            "tool_name": "search_food_serverless", 
-            "tags": ["Food", "Recipes", "Cooking"],
-            "count": 3,
-            "distance": 4.0,
-            "language": "en",
-            "no_results_message": "I couldn't find any recipes or cooking information about '{query}' using serverless search. Try asking about a different dish or ingredient.",
-            "swaig_fields": {
-                "fillers": {
-                    "en-US": [
-                        "Searching recipes on SignalWire infrastructure...",
-                        "Looking up cooking instructions serverlessly...",
-                        "Checking our food database via DataMap..."
-                    ]
-                }
-            }
-        })
+        agent.add_skill(
+            "datasphere_serverless",
+            {
+                **example_config,
+                "document_id": "food-doc-456",
+                "tool_name": "search_food_serverless",
+                "tags": ["Food", "Recipes", "Cooking"],
+                "count": 3,
+                "distance": 4.0,
+                "language": "en",
+                "no_results_message": "I couldn't find any recipes or cooking information about '{query}' using serverless search. Try asking about a different dish or ingredient.",
+                "swaig_fields": {
+                    "fillers": {
+                        "en-US": [
+                            "Searching recipes on SignalWire infrastructure...",
+                            "Looking up cooking instructions serverlessly...",
+                            "Checking our food database via DataMap...",
+                        ]
+                    }
+                },
+            },
+        )
         print("Added serverless food knowledge search (tool: search_food_serverless)")
     except Exception as e:
         print(f"Failed to add food DataSphere Serverless skill: {e}")
         print("   Note: Replace example_config with your actual DataSphere credentials")
-    
+
     # Instance 3: General knowledge base with default tool name (serverless)
     try:
-        agent.add_skill("datasphere_serverless", {
-            **example_config,
-            "document_id": "general-doc-789",
-            # No tool_name specified, so it will use default "search_knowledge"
-            "count": 1,
-            "distance": 3.0,
-            "no_results_message": "I couldn't find information about '{query}' in our general knowledge base using serverless search. Please try rephrasing your question."
-        })
-        print("Added serverless general knowledge search (tool: search_knowledge - default)")
+        agent.add_skill(
+            "datasphere_serverless",
+            {
+                **example_config,
+                "document_id": "general-doc-789",
+                # No tool_name specified, so it will use default "search_knowledge"
+                "count": 1,
+                "distance": 3.0,
+                "no_results_message": "I couldn't find information about '{query}' in our general knowledge base using serverless search. Please try rephrasing your question.",
+            },
+        )
+        print(
+            "Added serverless general knowledge search (tool: search_knowledge - default)"
+        )
     except Exception as e:
         print(f"Failed to add general DataSphere Serverless skill: {e}")
         print("   Note: Replace example_config with your actual DataSphere credentials")
-    
+
     # Show what skills/instances are loaded
     loaded_skills = agent.list_skills()
     print(f"\nLoaded skill instances: {', '.join(loaded_skills)}")
-    
+
     # Show available skills from registry
     try:
         from signalwire.skills.registry import skill_registry
+
         available_skills = skill_registry.list_skills()
-        print(f"\nAvailable skills in registry:")
+        print("\nAvailable skills in registry:")
         for skill in available_skills:
             print(f"  - {skill['name']}: {skill['description']}")
-            if skill['name'] in ['datasphere', 'datasphere_serverless']:
-                print(f"    Supports multiple instances: Yes")
-                if skill['name'] == 'datasphere_serverless':
-                    print(f"    Execution: Serverless (DataMap)")
+            if skill["name"] in ["datasphere", "datasphere_serverless"]:
+                print("    Supports multiple instances: Yes")
+                if skill["name"] == "datasphere_serverless":
+                    print("    Execution: Serverless (DataMap)")
                 else:
-                    print(f"    Execution: Agent server")
+                    print("    Execution: Agent server")
             else:
-                print(f"    Supports multiple instances: No")
+                print("    Supports multiple instances: No")
     except Exception as e:
         print(f"Failed to list available skills: {e}")
-    
+
     print(f"\nAgent available at: {agent.get_full_url()}")
     print("The agent now has enhanced capabilities:")
     print("   - Can tell current date/time")
-    print("   - Can perform mathematical calculations") 
-    
+    print("   - Can perform mathematical calculations")
+
     # Count how many DataSphere instances we have
-    datasphere_instances = [skill for skill in loaded_skills if skill.startswith('datasphere_')]
+    datasphere_instances = [
+        skill for skill in loaded_skills if skill.startswith("datasphere_")
+    ]
     if datasphere_instances:
         print(f"   - Has {len(datasphere_instances)} knowledge search capabilities:")
         for instance in datasphere_instances:
-            tool_name = instance.split('_', 1)[1] if '_' in instance else 'search_knowledge'
+            tool_name = (
+                instance.split("_", 1)[1] if "_" in instance else "search_knowledge"
+            )
             execution_type = "Serverless" if "serverless" in instance else "Standard"
             print(f"     * {tool_name} ({execution_type})")
-    
+
     print("\nDataSphere Serverless vs Standard Comparison:")
     print("   ┌─────────────────────┬─────────────────────┬─────────────────────┐")
     print("   │ Feature             │ Standard DataSphere │ Serverless DataMap  │")
@@ -172,12 +192,12 @@ def main():
     print("   │ Error handling      │ Granular exceptions │ DataMap error keys  │")
     print("   │ Multiple instances  │ Yes                 │ Yes                 │")
     print("   └─────────────────────┴─────────────────────┴─────────────────────┘")
-    
+
     print("\nDataSphere Serverless Examples:")
     print("   # Basic usage - identical API to standard skill")
     print("   agent.add_skill('datasphere_serverless', {")
     print("       'space_name': 'my-space',")
-    print("       'project_id': 'my-project',") 
+    print("       'project_id': 'my-project',")
     print("       'token': 'my-token',")
     print("       'document_id': 'my-doc-id'")
     print("   })")
@@ -197,13 +217,14 @@ def main():
     print("   ")
     print("   # Benefits:")
     print("   # - No HTTP endpoints to expose")
-    print("   # - Executes on SignalWire infrastructure") 
+    print("   # - Executes on SignalWire infrastructure")
     print("   # - Same functionality as standard skill")
     print("   # - Simplified deployment")
-    
+
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/datasphere_serverless_env_demo.py
+++ b/examples/datasphere_serverless_env_demo.py
@@ -38,6 +38,7 @@ import os
 import sys
 from signalwire import AgentBase
 
+
 def get_required_env_var(name: str) -> str:
     """Get a required environment variable or exit with error"""
     value = os.getenv(name)
@@ -56,30 +57,32 @@ def get_required_env_var(name: str) -> str:
         sys.exit(1)
     return value
 
+
 def parse_tags(tags_str: str) -> list:
     """Parse comma-separated tags string into list"""
     if not tags_str:
         return None
-    return [tag.strip() for tag in tags_str.split(',') if tag.strip()]
+    return [tag.strip() for tag in tags_str.split(",") if tag.strip()]
+
 
 def main():
     print("DataSphere Serverless Environment Demo")
     print("=" * 50)
-    
+
     # Get required environment variables
     print("Loading configuration from environment variables...")
-    space_name = get_required_env_var('SIGNALWIRE_SPACE_NAME')
-    project_id = get_required_env_var('SIGNALWIRE_PROJECT_ID')
-    token = get_required_env_var('SIGNALWIRE_API_TOKEN')
-    document_id = get_required_env_var('DATASPHERE_DOCUMENT_ID')
-    
+    space_name = get_required_env_var("SIGNALWIRE_SPACE_NAME")
+    project_id = get_required_env_var("SIGNALWIRE_PROJECT_ID")
+    token = get_required_env_var("SIGNALWIRE_API_TOKEN")
+    document_id = get_required_env_var("DATASPHERE_DOCUMENT_ID")
+
     # Get optional environment variables with defaults
-    count = int(os.getenv('DATASPHERE_COUNT', '3'))
-    distance = float(os.getenv('DATASPHERE_DISTANCE', '4.0'))
-    language = os.getenv('DATASPHERE_LANGUAGE')
-    tags_str = os.getenv('DATASPHERE_TAGS', '')
+    count = int(os.getenv("DATASPHERE_COUNT", "3"))
+    distance = float(os.getenv("DATASPHERE_DISTANCE", "4.0"))
+    language = os.getenv("DATASPHERE_LANGUAGE")
+    tags_str = os.getenv("DATASPHERE_TAGS", "")
     tags = parse_tags(tags_str)
-    
+
     print(f"✓ Space: {space_name}")
     print(f"✓ Project ID: {project_id[:8]}...")  # Only show first 8 chars for security
     print(f"✓ Token: {'*' * len(token)}")  # Hide token completely
@@ -90,13 +93,13 @@ def main():
         print(f"✓ Language: {language}")
     if tags:
         print(f"✓ Tags: {', '.join(tags)}")
-    
+
     # Create agent
     agent = AgentBase("DataSphere Knowledge Assistant", route="/datasphere-env-demo")
-    
+
     # Configure voice
     agent.add_language("English", "en-US", "inworld.Mark")
-    
+
     # Add basic skills
     print("\nAdding basic skills...")
     try:
@@ -104,47 +107,47 @@ def main():
         print("✓ Added datetime skill")
     except Exception as e:
         print(f"✗ Failed to add datetime skill: {e}")
-    
+
     try:
         agent.add_skill("math")
         print("✓ Added math skill")
     except Exception as e:
         print(f"✗ Failed to add math skill: {e}")
-    
+
     # Build DataSphere Serverless configuration
     datasphere_config = {
-        'space_name': space_name,
-        'project_id': project_id,
-        'token': token,
-        'document_id': document_id,
-        'count': count,
-        'distance': distance,
-        'tool_name': 'search_knowledge',
-        'no_results_message': "I couldn't find any information about '{query}' in the knowledge base. Try rephrasing your question or asking about a different topic.",
-        'swaig_fields': {
-            'fillers': {
-                'en-US': [
+        "space_name": space_name,
+        "project_id": project_id,
+        "token": token,
+        "document_id": document_id,
+        "count": count,
+        "distance": distance,
+        "tool_name": "search_knowledge",
+        "no_results_message": "I couldn't find any information about '{query}' in the knowledge base. Try rephrasing your question or asking about a different topic.",
+        "swaig_fields": {
+            "fillers": {
+                "en-US": [
                     "Searching the knowledge base...",
                     "Looking up information for you...",
-                    "Checking our database..."
+                    "Checking our database...",
                 ]
             }
-        }
+        },
     }
-    
+
     # Add optional parameters if they were provided
     if language:
-        datasphere_config['language'] = language
+        datasphere_config["language"] = language
     if tags:
-        datasphere_config['tags'] = tags
-    
+        datasphere_config["tags"] = tags
+
     # Add DataSphere Serverless skill
     print("\nAdding DataSphere Serverless skill...")
     try:
         agent.add_skill("datasphere_serverless", datasphere_config)
         print("✓ Added DataSphere Serverless skill successfully")
-        print(f"  - Tool name: search_knowledge")
-        print(f"  - Execution: Serverless (DataMap)")
+        print("  - Tool name: search_knowledge")
+        print("  - Execution: Serverless (DataMap)")
         print(f"  - Document: {document_id}")
         print(f"  - Max results: {count}")
         print(f"  - Distance threshold: {distance}")
@@ -156,29 +159,29 @@ def main():
         print(f"✗ Failed to add DataSphere Serverless skill: {e}")
         print("  Check that your credentials and document ID are correct")
         return
-    
+
     # Show agent capabilities
     print(f"\nREADY: Agent ready at: {agent.get_full_url()}")
     print("\nAgent Capabilities:")
     print("DATE: Date and time information")
     print("MATH: Mathematical calculations")
     print("SEARCH: Knowledge base search (serverless execution)")
-    
+
     print("\nDataSphere Serverless Features:")
     print("• Executes on SignalWire infrastructure")
     print("• No webhook endpoints required")
     print("• Built-in response formatting via DataMap")
     print("• Automatic error handling and fallbacks")
     print("• Uses environment variables for secure configuration")
-    
+
     print("\nExample queries you can try:")
     print('• "What time is it?"')
     print('• "Calculate 25 * 47"')
     print('• "Search for information about [topic]"')
     print('• "Look up [specific question about your knowledge base]"')
-    
+
     # Show environment configuration
-    print(f"\nEnvironment Configuration:")
+    print("\nEnvironment Configuration:")
     print(f"• Space: {space_name}")
     print(f"• Document: {document_id}")
     print(f"• Results per search: {count}")
@@ -187,16 +190,17 @@ def main():
         print(f"• Language: {language}")
     if tags:
         print(f"• Tags: {', '.join(tags)}")
-    
+
     print("\nTo modify configuration, update these environment variables:")
     print("export DATASPHERE_COUNT=5          # More results")
-    print("export DATASPHERE_DISTANCE=2.0     # Stricter matching") 
+    print("export DATASPHERE_DISTANCE=2.0     # Stricter matching")
     print("export DATASPHERE_TAGS='FAQ,Help'  # Filter by tags")
     print("export DATASPHERE_LANGUAGE='en'    # Language filter")
-    
+
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/datasphere_webhook_env_demo.py
+++ b/examples/datasphere_webhook_env_demo.py
@@ -38,6 +38,7 @@ import os
 import sys
 from signalwire import AgentBase
 
+
 def get_required_env_var(name: str) -> str:
     """Get a required environment variable or exit with error"""
     value = os.getenv(name)
@@ -56,30 +57,32 @@ def get_required_env_var(name: str) -> str:
         sys.exit(1)
     return value
 
+
 def parse_tags(tags_str: str) -> list:
     """Parse comma-separated tags string into list"""
     if not tags_str:
         return None
-    return [tag.strip() for tag in tags_str.split(',') if tag.strip()]
+    return [tag.strip() for tag in tags_str.split(",") if tag.strip()]
+
 
 def main():
     print("DataSphere Webhook Environment Demo")
     print("=" * 50)
-    
+
     # Get required environment variables
     print("Loading configuration from environment variables...")
-    space_name = get_required_env_var('SIGNALWIRE_SPACE_NAME')
-    project_id = get_required_env_var('SIGNALWIRE_PROJECT_ID')
-    token = get_required_env_var('SIGNALWIRE_API_TOKEN')
-    document_id = get_required_env_var('DATASPHERE_DOCUMENT_ID')
-    
+    space_name = get_required_env_var("SIGNALWIRE_SPACE_NAME")
+    project_id = get_required_env_var("SIGNALWIRE_PROJECT_ID")
+    token = get_required_env_var("SIGNALWIRE_API_TOKEN")
+    document_id = get_required_env_var("DATASPHERE_DOCUMENT_ID")
+
     # Get optional environment variables with defaults
-    count = int(os.getenv('DATASPHERE_COUNT', '3'))
-    distance = float(os.getenv('DATASPHERE_DISTANCE', '4.0'))
-    language = os.getenv('DATASPHERE_LANGUAGE')
-    tags_str = os.getenv('DATASPHERE_TAGS', '')
+    count = int(os.getenv("DATASPHERE_COUNT", "3"))
+    distance = float(os.getenv("DATASPHERE_DISTANCE", "4.0"))
+    language = os.getenv("DATASPHERE_LANGUAGE")
+    tags_str = os.getenv("DATASPHERE_TAGS", "")
     tags = parse_tags(tags_str)
-    
+
     print(f"✓ Space: {space_name}")
     print(f"✓ Project ID: {project_id[:8]}...")  # Only show first 8 chars for security
     print(f"✓ Token: {'*' * len(token)}")  # Hide token completely
@@ -90,13 +93,15 @@ def main():
         print(f"✓ Language: {language}")
     if tags:
         print(f"✓ Tags: {', '.join(tags)}")
-    
+
     # Create agent
-    agent = AgentBase("DataSphere Knowledge Assistant", route="/datasphere-webhook-demo")
-    
+    agent = AgentBase(
+        "DataSphere Knowledge Assistant", route="/datasphere-webhook-demo"
+    )
+
     # Configure voice
     agent.add_language("English", "en-US", "inworld.Mark")
-    
+
     # Add basic skills
     print("\nAdding basic skills...")
     try:
@@ -104,47 +109,47 @@ def main():
         print("✓ Added datetime skill")
     except Exception as e:
         print(f"✗ Failed to add datetime skill: {e}")
-    
+
     try:
         agent.add_skill("math")
         print("✓ Added math skill")
     except Exception as e:
         print(f"✗ Failed to add math skill: {e}")
-    
+
     # Build DataSphere configuration
     datasphere_config = {
-        'space_name': space_name,
-        'project_id': project_id,
-        'token': token,
-        'document_id': document_id,
-        'count': count,
-        'distance': distance,
-        'tool_name': 'search_knowledge',
-        'no_results_message': "I couldn't find any information about '{query}' in the knowledge base. Try rephrasing your question or asking about a different topic.",
-        'swaig_fields': {
-            'fillers': {
-                'en-US': [
+        "space_name": space_name,
+        "project_id": project_id,
+        "token": token,
+        "document_id": document_id,
+        "count": count,
+        "distance": distance,
+        "tool_name": "search_knowledge",
+        "no_results_message": "I couldn't find any information about '{query}' in the knowledge base. Try rephrasing your question or asking about a different topic.",
+        "swaig_fields": {
+            "fillers": {
+                "en-US": [
                     "Searching the knowledge base...",
                     "Looking up information for you...",
-                    "Checking our database..."
+                    "Checking our database...",
                 ]
             }
-        }
+        },
     }
-    
+
     # Add optional parameters if they were provided
     if language:
-        datasphere_config['language'] = language
+        datasphere_config["language"] = language
     if tags:
-        datasphere_config['tags'] = tags
-    
+        datasphere_config["tags"] = tags
+
     # Add traditional DataSphere skill (webhook-based)
     print("\nAdding DataSphere skill (webhook-based)...")
     try:
         agent.add_skill("datasphere", datasphere_config)
         print("✓ Added DataSphere skill successfully")
-        print(f"  - Tool name: search_knowledge")
-        print(f"  - Execution: Webhook-based (traditional)")
+        print("  - Tool name: search_knowledge")
+        print("  - Execution: Webhook-based (traditional)")
         print(f"  - Document: {document_id}")
         print(f"  - Max results: {count}")
         print(f"  - Distance threshold: {distance}")
@@ -156,29 +161,29 @@ def main():
         print(f"✗ Failed to add DataSphere skill: {e}")
         print("  Check that your credentials and document ID are correct")
         return
-    
+
     # Show agent capabilities
     print(f"\nREADY: Agent ready at: {agent.get_full_url()}")
     print("\nAgent Capabilities:")
     print("DATE: Date and time information")
     print("MATH: Mathematical calculations")
     print("SEARCH: Knowledge base search (webhook execution)")
-    
+
     print("\nDataSphere Webhook Features:")
     print("• Executes via traditional webhook endpoints")
     print("• Full Python logic for response processing")
     print("• Custom error handling and formatting")
     print("• Requests library for HTTP calls")
     print("• Uses environment variables for secure configuration")
-    
+
     print("\nExample queries you can try:")
     print('• "What time is it?"')
     print('• "Calculate 25 * 47"')
     print('• "Search for information about [topic]"')
     print('• "Look up [specific question about your knowledge base]"')
-    
+
     # Show environment configuration
-    print(f"\nEnvironment Configuration:")
+    print("\nEnvironment Configuration:")
     print(f"• Space: {space_name}")
     print(f"• Document: {document_id}")
     print(f"• Results per search: {count}")
@@ -187,16 +192,16 @@ def main():
         print(f"• Language: {language}")
     if tags:
         print(f"• Tags: {', '.join(tags)}")
-    
+
     print("\nTo modify configuration, update these environment variables:")
     print("export DATASPHERE_COUNT=5          # More results")
-    print("export DATASPHERE_DISTANCE=2.0     # Stricter matching") 
+    print("export DATASPHERE_DISTANCE=2.0     # Stricter matching")
     print("export DATASPHERE_TAGS='FAQ,Help'  # Filter by tags")
     print("export DATASPHERE_LANGUAGE='en'    # Language filter")
-    
-    print("\n" + "="*60)
+
+    print("\n" + "=" * 60)
     print("WEBHOOK vs SERVERLESS COMPARISON")
-    print("="*60)
+    print("=" * 60)
     print("This demo uses the WEBHOOK-based DataSphere skill:")
     print("✓ Full Python control over request/response")
     print("✓ Custom error handling and logging")
@@ -211,10 +216,11 @@ def main():
     print("✓ Lower latency and higher reliability")
     print("✗ Template-based response formatting only")
     print("✗ Limited custom logic")
-    
+
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/declarative_agent.py
+++ b/examples/declarative_agent.py
@@ -21,13 +21,14 @@ Key concepts demonstrated:
 4. Multiple approaches to structuring prompt data
 """
 
-import os
 import sys
 import json
 from datetime import datetime
+from pathlib import Path
+from typing import ClassVar
 
 # Add the parent directory to the path so we can import the package
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from signalwire import AgentBase
 from signalwire.core.function_result import FunctionResult
@@ -54,7 +55,7 @@ class DeclarativeAgent(AgentBase):
 
     # Define the entire prompt structure declaratively as a class attribute
     # This will be automatically processed by AgentBase when the class is instantiated
-    PROMPT_SECTIONS = {
+    PROMPT_SECTIONS: ClassVar[dict] = {
         # Simple string sections are rendered as-is
         "Personality": "You are a friendly and helpful AI assistant who responds in a casual, conversational tone.",
         # Short sections can be defined with a simple string
@@ -233,7 +234,7 @@ class PomFormatAgent(AgentBase):
     # Define the prompt using the direct POM format (list of sections)
     # This format matches the internal representation used by the POM
     # and provides more control over the exact structure
-    PROMPT_SECTIONS = [
+    PROMPT_SECTIONS: ClassVar[list] = [
         {
             "title": "Assistant Role",  # Section title
             "body": "You are a technical support agent for SignalWire products.",

--- a/examples/declarative_agent.py
+++ b/examples/declarative_agent.py
@@ -36,39 +36,36 @@ from signalwire.core.function_result import FunctionResult
 class DeclarativeAgent(AgentBase):
     """
     A simple agent defined using the declarative PROMPT_SECTIONS approach
-    
+
     Instead of calling set_personality(), add_instruction(), etc. in __init__,
     we define the entire prompt structure as a class attribute.
-    
+
     Benefits of this approach:
     1. Separates prompt definition from agent implementation logic
     2. Makes the prompt structure more visible and maintainable
     3. Allows for easier reuse of prompt templates across agent classes
     4. Reduces the amount of code in the constructor
     """
-    
-    #------------------------------------------------------------------------
+
+    # ------------------------------------------------------------------------
     # DECLARATIVE PROMPT DEFINITION
     # Define the entire prompt structure as a class attribute
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     # Define the entire prompt structure declaratively as a class attribute
     # This will be automatically processed by AgentBase when the class is instantiated
     PROMPT_SECTIONS = {
         # Simple string sections are rendered as-is
         "Personality": "You are a friendly and helpful AI assistant who responds in a casual, conversational tone.",
-        
         # Short sections can be defined with a simple string
         "Goal": "Help users with their questions about time and weather.",
-        
         # Lists are automatically rendered as bullet points
         "Instructions": [
             "Be concise and direct in your responses.",
             "If you don't know something, say so clearly.",
             "Use the get_time function when asked about the current time.",
-            "Use the get_weather function when asked about the weather."
+            "Use the get_weather function when asked about the weather.",
         ],
-        
         # Complex sections can have subsections with their own titles and content
         "Examples": {
             # The main section body
@@ -77,38 +74,38 @@ class DeclarativeAgent(AgentBase):
             "subsections": [
                 {
                     "title": "Time request",
-                    "body": "User: What time is it?\nAssistant: Let me check for you. [call get_time]"
+                    "body": "User: What time is it?\nAssistant: Let me check for you. [call get_time]",
                 },
                 {
                     "title": "Weather request",
-                    "body": "User: What's the weather like in Paris?\nAssistant: Let me check the weather for you. [call get_weather with {\"location\": \"Paris\"}]"
-                }
-            ]
-        }
+                    "body": 'User: What\'s the weather like in Paris?\nAssistant: Let me check the weather for you. [call get_weather with {"location": "Paris"}]',
+                },
+            ],
+        },
     }
-    
+
     def __init__(self):
         """
         Initialize the DeclarativeAgent
-        
+
         When using the declarative PROMPT_SECTIONS approach, there's no need to
         manually build the prompt in the constructor. The AgentBase class will
         automatically process the PROMPT_SECTIONS and build the prompt for you.
         """
-        #------------------------------------------------------------------------
+        # ------------------------------------------------------------------------
         # BASIC AGENT CONFIGURATION
         # Set up the HTTP server and other basic settings
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Initialize the agent with a name and route
         # The PROMPT_SECTIONS will be automatically processed
         super().__init__(
-            name="declarative",        # Agent identifier used in logs
-            route="/declarative",      # HTTP endpoint path
-            host="0.0.0.0",            # Listen on all interfaces
-            port=3000                  # HTTP port number
+            name="declarative",  # Agent identifier used in logs
+            route="/declarative",  # HTTP endpoint path
+            host="0.0.0.0",  # Listen on all interfaces
+            port=3000,  # HTTP port number
         )
-        
+
         # Notice we don't need any prompt building calls here - they're handled
         # automatically by the declarative PROMPT_SECTIONS
         # This is different from the conventional approach using prompt_add_section:
@@ -116,12 +113,12 @@ class DeclarativeAgent(AgentBase):
         #   self.prompt_add_section("Goal",        body="Help users with their questions...")
         #   self.prompt_add_section("Instructions", bullets=["Be concise and direct..."])
         #   ...
-        
-        #------------------------------------------------------------------------
+
+        # ------------------------------------------------------------------------
         # POST-PROMPT CONFIGURATION
         # Define what summary information to collect after conversations
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Add a post-prompt for summary
         # This defines the structure of data we want the AI to return
         # after completing a conversation
@@ -133,28 +130,28 @@ class DeclarativeAgent(AgentBase):
             "follow_up_needed": true/false
         }
         """)
-    
-    #------------------------------------------------------------------------
+
+    # ------------------------------------------------------------------------
     # TOOL DEFINITIONS
     # Define the functions that the AI can use during conversations
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     @AgentBase.tool(
         name="get_time",
         description="Get the current time",
-        parameters={}  # No parameters needed for this function
+        parameters={},  # No parameters needed for this function
     )
     def get_time(self, args, raw_data):
         """
         Get the current time
-        
+
         A simple function with no parameters that returns the current time.
         This demonstrates the most basic SWAIG function implementation.
-        
+
         Args:
             args: Empty dictionary (no parameters)
             raw_data: The complete request data
-            
+
         Returns:
             FunctionResult with current time
         """
@@ -164,54 +161,54 @@ class DeclarativeAgent(AgentBase):
         formatted_time = now.strftime("%H:%M:%S")
         # Return a result that will be shown to the user
         return FunctionResult(f"The current time is {formatted_time}")
-    
+
     @AgentBase.tool(
         name="get_weather",
         description="Get the current weather for a location",
         parameters={
             "location": {
                 "type": "string",
-                "description": "The city or location to get weather for"
+                "description": "The city or location to get weather for",
             }
-        }
+        },
     )
     def get_weather(self, args, raw_data):
         """
         Get the current weather for a location
-        
+
         This function demonstrates a SWAIG function with parameters.
         In a real implementation, this would call a weather API,
         but here we just return a mock response.
-        
+
         Args:
-            args: Dictionary containing the "location" parameter 
+            args: Dictionary containing the "location" parameter
             raw_data: The complete request data
-            
+
         Returns:
             FunctionResult with weather information
         """
         # Extract location from the args dictionary
         location = args.get("location", "Unknown location")
-        
+
         # In a real implementation, this would call a weather API
         # For demonstration purposes, we return a mock response
         return FunctionResult(f"It's sunny and 72°F in {location}.")
-    
+
     def on_summary(self, summary, raw_data=None):
         """
         Process the conversation summary
-        
+
         This method is called after a conversation has completed and the
         post-prompt has generated a summary. It allows you to perform
         actions based on the conversation outcome.
-        
+
         Args:
             summary: Dictionary containing the structured summary data
             raw_data: The complete request data (optional)
         """
         # Log the summary with pretty-printing
         print(f"Conversation summary received: {json.dumps(summary, indent=2)}")
-        
+
         # In a real implementation, you might:
         # - Save the summary to a database
         # - Trigger follow-up actions if needed
@@ -222,68 +219,68 @@ class DeclarativeAgent(AgentBase):
 class PomFormatAgent(AgentBase):
     """
     An agent using the direct POM format for PROMPT_SECTIONS
-    
+
     This approach uses the raw POM dictionary format directly.
     It's an alternative to the more user-friendly key-value format
     and provides more control over the exact structure of the prompt.
     """
-    
-    #------------------------------------------------------------------------
+
+    # ------------------------------------------------------------------------
     # DIRECT POM FORMAT
     # Define the prompt using the low-level POM dictionary format
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     # Define the prompt using the direct POM format (list of sections)
     # This format matches the internal representation used by the POM
     # and provides more control over the exact structure
     PROMPT_SECTIONS = [
         {
-            "title": "Assistant Role",    # Section title
+            "title": "Assistant Role",  # Section title
             "body": "You are a technical support agent for SignalWire products.",
-            "numbered": True              # This section will be numbered (1.)
+            "numbered": True,  # This section will be numbered (1.)
         },
         {
             "title": "Knowledge Base",
-            "bullets": [                  # These will be rendered as bullet points
+            "bullets": [  # These will be rendered as bullet points
                 "You know about SignalWire Voice, Video, and Messaging APIs.",
                 "You can help with SWML (SignalWire Markup Language) issues.",
-                "You can provide code examples in Python, JavaScript, and Ruby."
-            ]
+                "You can provide code examples in Python, JavaScript, and Ruby.",
+            ],
         },
         {
             "title": "Response Format",
             "body": "When providing code examples, use markdown code blocks with the language specified.",
-            "subsections": [              # Nested subsection
+            "subsections": [  # Nested subsection
                 {
                     "title": "Example Format",
-                    "body": "```python\n# Python example\nfrom signalwire.rest import Client\n```"
+                    "body": "```python\n# Python example\nfrom signalwire.rest import Client\n```",
                 }
-            ]
-        }
+            ],
+        },
     ]
-    
+
     def __init__(self):
         """
         Initialize the PomFormatAgent
-        
+
         This agent demonstrates the direct POM format, which uses
         the internal representation format rather than the simpler
         key-value format used by DeclarativeAgent.
         """
         super().__init__(
-            name="pom_format",          # Agent identifier
-            route="/pom_format",        # HTTP endpoint path
-            host="0.0.0.0",             # Listen on all interfaces
-            port=3001                   # Different port from the first agent
+            name="pom_format",  # Agent identifier
+            route="/pom_format",  # HTTP endpoint path
+            host="0.0.0.0",  # Listen on all interfaces
+            port=3001,  # Different port from the first agent
         )
 
 
 def main():
-    #------------------------------------------------------------------------
+    # ------------------------------------------------------------------------
     # AGENT STARTUP
     # Create and run the declarative agent
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     # Create and start the agent
     agent = DeclarativeAgent()
     print("\nStarting agent server...")
@@ -292,4 +289,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/dynamic_info_gatherer_example.py
+++ b/examples/dynamic_info_gatherer_example.py
@@ -22,99 +22,130 @@ Test URLs:
 - /contact?set=onboarding (employee onboarding questions)
 """
 
-import os
-import sys
-import json
-import argparse
 from signalwire.prefabs import InfoGathererAgent
 
 # Question sets for different scenarios
 QUESTION_SETS = {
     "default": [
         {"key_name": "name", "question_text": "What is your full name?"},
-        {"key_name": "phone", "question_text": "What is your phone number?", "confirm": True},
-        {"key_name": "reason", "question_text": "How can I help you today?"}
+        {
+            "key_name": "phone",
+            "question_text": "What is your phone number?",
+            "confirm": True,
+        },
+        {"key_name": "reason", "question_text": "How can I help you today?"},
     ],
     "support": [
         {"key_name": "customer_name", "question_text": "What is your name?"},
-        {"key_name": "account_number", "question_text": "What is your account number?", "confirm": True},
+        {
+            "key_name": "account_number",
+            "question_text": "What is your account number?",
+            "confirm": True,
+        },
         {"key_name": "issue", "question_text": "What issue are you experiencing?"},
-        {"key_name": "priority", "question_text": "How urgent is this issue? (Low, Medium, High)"}
+        {
+            "key_name": "priority",
+            "question_text": "How urgent is this issue? (Low, Medium, High)",
+        },
     ],
     "medical": [
-        {"key_name": "patient_name", "question_text": "What is the patient's full name?"},
-        {"key_name": "symptoms", "question_text": "What symptoms are you experiencing?", "confirm": True},
-        {"key_name": "duration", "question_text": "How long have you had these symptoms?"},
-        {"key_name": "medications", "question_text": "Are you currently taking any medications?"}
+        {
+            "key_name": "patient_name",
+            "question_text": "What is the patient's full name?",
+        },
+        {
+            "key_name": "symptoms",
+            "question_text": "What symptoms are you experiencing?",
+            "confirm": True,
+        },
+        {
+            "key_name": "duration",
+            "question_text": "How long have you had these symptoms?",
+        },
+        {
+            "key_name": "medications",
+            "question_text": "Are you currently taking any medications?",
+        },
     ],
     "onboarding": [
         {"key_name": "full_name", "question_text": "What is your full name?"},
-        {"key_name": "email", "question_text": "What is your email address?", "confirm": True},
+        {
+            "key_name": "email",
+            "question_text": "What is your email address?",
+            "confirm": True,
+        },
         {"key_name": "company", "question_text": "What company do you work for?"},
-        {"key_name": "department", "question_text": "What department will you be working in?"},
-        {"key_name": "start_date", "question_text": "What is your start date?"}
-    ]
+        {
+            "key_name": "department",
+            "question_text": "What department will you be working in?",
+        },
+        {"key_name": "start_date", "question_text": "What is your start date?"},
+    ],
 }
+
 
 def get_questions_callback(query_params, body_params, headers):
     """
     Callback function to determine which questions to ask based on request parameters
-    
+
     Args:
         query_params: Dict of query string parameters
-        body_params: Dict of POST body parameters  
+        body_params: Dict of POST body parameters
         headers: Dict of HTTP headers
-        
+
     Returns:
         List of question dictionaries
     """
     # Get the question set from query parameters
-    question_set = query_params.get('set', 'default')
-    
+    question_set = query_params.get("set", "default")
+
     # Log the request for debugging
     print(f"Dynamic configuration requested: set={question_set}")
     print(f"Query params: {query_params}")
-    
+
     # Return the appropriate question set
     questions = QUESTION_SETS.get(question_set, QUESTION_SETS["default"])
-    
+
     print(f"Using {len(questions)} questions for set '{question_set}'")
     return questions
 
+
 def create_dynamic_agent():
     """Create an InfoGatherer with dynamic questions using callback"""
-    
+
     # Create agent in dynamic mode (no static questions)
     agent = InfoGathererAgent(
         questions=None,  # Dynamic mode
-        name="contact-form", 
-        route="/contact"
+        name="contact-form",
+        route="/contact",
     )
-    
+
     # Set the callback function for dynamic configuration
     agent.set_question_callback(get_questions_callback)
-    
+
     return agent
+
 
 def main():
     """Run the dynamic InfoGathererAgent example"""
-    
+
     print("Starting Dynamic InfoGatherer Agent...")
     print("This agent configures questions based on request parameters")
     print()
     print("Test with these URLs:")
     print("  /contact (default questions)")
-    print("  /contact?set=support (customer support)")  
+    print("  /contact?set=support (customer support)")
     print("  /contact?set=medical (medical intake)")
     print("  /contact?set=onboarding (employee onboarding)")
     print()
-    
+
     # Create the dynamic agent
     agent = create_dynamic_agent()
-    
+
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/dynamic_swml_service.py
+++ b/examples/dynamic_swml_service.py
@@ -16,8 +16,6 @@ different responses based on POST data. It shows how to use the
 on_request() method to customize SWML documents dynamically.
 """
 
-import os
-import sys
 import json
 import argparse
 import logging
@@ -36,37 +34,35 @@ class DynamicGreetingService(SWMLService):
     """
     A service that customizes its greeting based on POST data
     """
-    
+
     def __init__(self, host="0.0.0.0", port=3000):
         super().__init__(
-            name="dynamic-greeting",
-            route="/greeting",
-            host=host,
-            port=port
+            name="dynamic-greeting", route="/greeting", host=host, port=port
         )
-        
+
         # Build the default SWML document
         self.build_default_document()
-    
+
     def build_default_document(self):
         """Build the default SWML document with a generic greeting"""
         # Reset the document
         self.reset_document()
-        
+
         # Add answer verb
         self.add_verb("answer", {})
-        
+
         # Add play verb for generic greeting
-        self.add_verb("play", {
-            "url": "say:Hello, thank you for calling our service."
-        })
-        
+        self.add_verb("play", {"url": "say:Hello, thank you for calling our service."})
+
         # Add a generic menu prompt
-        self.add_verb("prompt", {
-            "play": "say:Please press 1 for sales, 2 for support, or 3 to leave a message.",
-            "max_digits": 1,
-            "terminators": "#"
-        })
+        self.add_verb(
+            "prompt",
+            {
+                "play": "say:Please press 1 for sales, 2 for support, or 3 to leave a message.",
+                "max_digits": 1,
+                "terminators": "#",
+            },
+        )
 
         # Add hang up
         self.add_verb("hangup", {})
@@ -76,10 +72,10 @@ class DynamicGreetingService(SWMLService):
     def on_request(self, request_data: dict = None) -> dict:
         """
         Customize the SWML document based on the request data
-        
+
         Args:
             request_data: Dictionary containing the parsed POST body
-            
+
         Returns:
             Modified SWML document or None to use the default
         """
@@ -87,100 +83,123 @@ class DynamicGreetingService(SWMLService):
         if not request_data:
             self.log.debug("no_request_data_using_default")
             return None
-        
-        self.log.debug("customizing_document", 
-                      caller_name=request_data.get("caller_name"),
-                      caller_type=request_data.get("caller_type"),
-                      department=request_data.get("department"))
-        
+
+        self.log.debug(
+            "customizing_document",
+            caller_name=request_data.get("caller_name"),
+            caller_type=request_data.get("caller_type"),
+            department=request_data.get("department"),
+        )
+
         # Reset the document to start fresh
         self.reset_document()
-        
+
         # Add answer verb
         self.add_verb("answer", {})
-        
+
         # Customize greeting based on caller_name if provided
         caller_name = request_data.get("caller_name")
         if caller_name:
-            self.add_verb("play", {
-                "url": f"say:Hello {caller_name}, welcome back to our service!"
-            })
+            self.add_verb(
+                "play",
+                {"url": f"say:Hello {caller_name}, welcome back to our service!"},
+            )
         else:
-            self.add_verb("play", {
-                "url": "say:Hello, thank you for calling our service."
-            })
-        
+            self.add_verb(
+                "play", {"url": "say:Hello, thank you for calling our service."}
+            )
+
         # Customize menu based on caller_type
         caller_type = request_data.get("caller_type", "").lower()
-        
+
         if caller_type == "vip":
             # VIP callers get priority routing
-            self.add_verb("play", {
-                "url": "say:As a VIP customer, you'll be connected to our priority support team immediately."
-            })
-            
+            self.add_verb(
+                "play",
+                {
+                    "url": "say:As a VIP customer, you'll be connected to our priority support team immediately."
+                },
+            )
+
             # Connect to VIP support
-            self.add_verb("connect", {
-                "to": "+15551234567",  # VIP support number
-                "timeout": 30,
-                "answer_on_bridge": True
-            })
-            
+            self.add_verb(
+                "connect",
+                {
+                    "to": "+15551234567",  # VIP support number
+                    "timeout": 30,
+                    "answer_on_bridge": True,
+                },
+            )
+
         elif caller_type == "existing":
             # Existing customers get customized options
-            self.add_verb("prompt", {
-                "play": "say:Please press 1 for account management, 2 for technical support, or 3 for billing.",
-                "max_digits": 1,
-                "terminators": "#"
-            })
-            
+            self.add_verb(
+                "prompt",
+                {
+                    "play": "say:Please press 1 for account management, 2 for technical support, or 3 for billing.",
+                    "max_digits": 1,
+                    "terminators": "#",
+                },
+            )
+
         elif caller_type == "new":
             # New customers get sales-focused options
-            self.add_verb("prompt", {
-                "play": "say:Please press 1 to learn about our products, 2 to speak with a sales representative, or 3 to request a demo.",
-                "max_digits": 1,
-                "terminators": "#"
-            })
-            
+            self.add_verb(
+                "prompt",
+                {
+                    "play": "say:Please press 1 to learn about our products, 2 to speak with a sales representative, or 3 to request a demo.",
+                    "max_digits": 1,
+                    "terminators": "#",
+                },
+            )
+
         else:
             # Generic options for unknown caller types
-            self.add_verb("prompt", {
-                "play": "say:Please press 1 for sales, 2 for support, or 3 to leave a message.",
-                "max_digits": 1,
-                "terminators": "#"
-            })
-        
+            self.add_verb(
+                "prompt",
+                {
+                    "play": "say:Please press 1 for sales, 2 for support, or 3 to leave a message.",
+                    "max_digits": 1,
+                    "terminators": "#",
+                },
+            )
+
         # Add dynamic routing based on department if specified
         department = request_data.get("department", "").lower()
         if department:
-            self.add_verb("play", {
-                "url": f"say:We'll connect you to our {department} department right away."
-            })
-            
+            self.add_verb(
+                "play",
+                {
+                    "url": f"say:We'll connect you to our {department} department right away."
+                },
+            )
+
             # Different phone numbers for different departments
             phone_numbers = {
                 "sales": "+15551112222",
                 "support": "+15553334444",
                 "billing": "+15555556666",
-                "technical": "+15557778888"
+                "technical": "+15557778888",
             }
-            
+
             # Connect to the appropriate department
-            to_number = phone_numbers.get(department, "+15559990000")  # Default number as fallback
-            self.add_verb("connect", {
-                "to": to_number,
-                "timeout": 30,
-                "answer_on_bridge": True
-            })
+            to_number = phone_numbers.get(
+                department, "+15559990000"
+            )  # Default number as fallback
+            self.add_verb(
+                "connect", {"to": to_number, "timeout": 30, "answer_on_bridge": True}
+            )
 
         # Add hang up as fallback
         self.add_verb("hangup", {})
-        
-        self.log.info("document_customized", 
-                     caller_type=caller_type,
-                     department=department,
-                     has_name=caller_name is not None)
-        
+
+        self.log.info(
+            "document_customized",
+            caller_type=caller_type,
+            department=department,
+            has_name=caller_name is not None,
+        )
+
         # Return None to use the document we just built
         return None  # The document has already been modified
 
@@ -189,49 +208,50 @@ class CallRouterService(SWMLService):
     """
     A service that routes calls based on POST data
     """
-    
+
     def __init__(self, host="0.0.0.0", port=3000):
-        super().__init__(
-            name="call-router",
-            route="/router",
-            host=host,
-            port=port
-        )
-        
+        super().__init__(name="call-router", route="/router", host=host, port=port)
+
         # Build the default SWML document
         self.build_default_document()
-    
+
     def build_default_document(self):
         """Build the default SWML document with a fallback routing"""
         # Reset the document
         self.reset_document()
-        
+
         # Add answer verb
         self.add_verb("answer", {})
-        
+
         # Add play verb for greeting
-        self.add_verb("play", {
-            "url": "say:Thank you for calling. We'll connect you with an available agent."
-        })
-        
+        self.add_verb(
+            "play",
+            {
+                "url": "say:Thank you for calling. We'll connect you with an available agent."
+            },
+        )
+
         # Add a fallback connection
-        self.add_verb("connect", {
-            "to": "+15551234567",  # Fallback number
-            "timeout": 30
-        })
+        self.add_verb(
+            "connect",
+            {
+                "to": "+15551234567",  # Fallback number
+                "timeout": 30,
+            },
+        )
 
         # Add hang up
         self.add_verb("hangup", {})
 
         self.log.debug("default_document_built")
-    
+
     def on_request(self, request_data: dict = None) -> dict:
         """
         Route calls differently based on POST data
-        
+
         Args:
             request_data: Dictionary containing the parsed POST body
-            
+
         Returns:
             Modified SWML document or None to use the default
         """
@@ -239,70 +259,103 @@ class CallRouterService(SWMLService):
         if not request_data:
             self.log.debug("no_request_data_using_default")
             return None
-        
-        self.log.debug("customizing_routing", 
-                      region=request_data.get("region"),
-                      high_volume=request_data.get("high_volume"),
-                      queue_length=request_data.get("queue_length"),
-                      callback_number=request_data.get("callback_number"))
-        
+
+        self.log.debug(
+            "customizing_routing",
+            region=request_data.get("region"),
+            high_volume=request_data.get("high_volume"),
+            queue_length=request_data.get("queue_length"),
+            callback_number=request_data.get("callback_number"),
+        )
+
         # Create a new document
         self.reset_document()
         self.add_verb("answer", {})
-        
+
         # Check if this is a high-volume period
         high_volume = request_data.get("high_volume", False)
-        
+
         # Get the caller's region
         region = request_data.get("region", "").lower()
-        
+
         # Get agent queue status
         queue_length = request_data.get("queue_length", 0)
-        
+
         # Check if this is a callback request
         callback_number = request_data.get("callback_number")
-        
+
         # Handle callback requests
         if callback_number:
-            self.log.info("processing_callback_request", callback_number=callback_number)
-            self.add_verb("play", {
-                "url": "say:We'll call you back at the number you provided. Thank you for your patience."
-            })
+            self.log.info(
+                "processing_callback_request", callback_number=callback_number
+            )
+            self.add_verb(
+                "play",
+                {
+                    "url": "say:We'll call you back at the number you provided. Thank you for your patience."
+                },
+            )
             self.add_verb("hangup", {})
             return None
-        
+
         # Inform caller if we're experiencing high volume
         if high_volume or queue_length > 10:
             self.log.info("high_volume_detected", queue_length=queue_length)
-            self.add_verb("play", {
-                "url": "say:We're currently experiencing higher than normal call volume. Your wait time may be extended."
-            })
-            
-            # Offer callback option
-            self.add_verb("prompt", {
-                "play": "say:Press 1 to continue holding, or press 2 to receive a callback when an agent becomes available.",
-                "max_digits": 1
-            })
-            
-            # Add conditional logic with switch
-            self.add_verb("switch", {
-                "variable": "prompt_digits",
-                "case": {
-                    "2": [
-                        {"play": {"url": "say:Please enter your 10-digit phone number followed by the pound key."}},
-                        {"prompt": {"play": "silence:1", "max_digits": 10, "terminators": "#"}}
-                        # In a real implementation, we'd have more logic here to handle the callback
-                    ]
+            self.add_verb(
+                "play",
+                {
+                    "url": "say:We're currently experiencing higher than normal call volume. Your wait time may be extended."
                 },
-                "default": [
-                    {"play": {"url": "say:Thank you for your patience. Please hold for the next available agent."}}
-                ]
-            })
+            )
+
+            # Offer callback option
+            self.add_verb(
+                "prompt",
+                {
+                    "play": "say:Press 1 to continue holding, or press 2 to receive a callback when an agent becomes available.",
+                    "max_digits": 1,
+                },
+            )
+
+            # Add conditional logic with switch
+            self.add_verb(
+                "switch",
+                {
+                    "variable": "prompt_digits",
+                    "case": {
+                        "2": [
+                            {
+                                "play": {
+                                    "url": "say:Please enter your 10-digit phone number followed by the pound key."
+                                }
+                            },
+                            {
+                                "prompt": {
+                                    "play": "silence:1",
+                                    "max_digits": 10,
+                                    "terminators": "#",
+                                }
+                            },
+                            # In a real implementation, we'd have more logic here to handle the callback
+                        ]
+                    },
+                    "default": [
+                        {
+                            "play": {
+                                "url": "say:Thank you for your patience. Please hold for the next available agent."
+                            }
+                        }
+                    ],
+                },
+            )
         else:
-            self.add_verb("play", {
-                "url": "say:Thank you for calling. We'll connect you with an agent shortly."
-            })
-        
+            self.add_verb(
+                "play",
+                {
+                    "url": "say:Thank you for calling. We'll connect you with an agent shortly."
+                },
+            )
+
         # Route based on region if provided
         if region:
             self.log.info("routing_by_region", region=region)
@@ -310,96 +363,121 @@ class CallRouterService(SWMLService):
                 "east": ["+15551112222", "+15551113333"],
                 "west": ["+15552223333", "+15552224444"],
                 "central": ["+15553334444", "+15553335555"],
-                "international": ["+15554445555"]
+                "international": ["+15554445555"],
             }
-            
-            numbers = region_numbers.get(region, ["+15551234567"])  # Default to fallback
-            
+
+            numbers = region_numbers.get(
+                region, ["+15551234567"]
+            )  # Default to fallback
+
             # If we have multiple numbers for the region, try them in parallel
             if len(numbers) > 1:
                 self.log.debug("using_parallel_connection", numbers=numbers)
                 parallel_targets = [{"to": num} for num in numbers]
-                self.add_verb("connect", {
-                    "parallel": parallel_targets,
-                    "timeout": 30,
-                    "answer_on_bridge": True
-                })
+                self.add_verb(
+                    "connect",
+                    {
+                        "parallel": parallel_targets,
+                        "timeout": 30,
+                        "answer_on_bridge": True,
+                    },
+                )
             else:
                 # Just one number, connect directly
                 self.log.debug("using_direct_connection", number=numbers[0])
-                self.add_verb("connect", {
-                    "to": numbers[0],
-                    "timeout": 30,
-                    "answer_on_bridge": True
-                })
+                self.add_verb(
+                    "connect",
+                    {"to": numbers[0], "timeout": 30, "answer_on_bridge": True},
+                )
         else:
             # No region specified, use default routing
             self.log.info("using_default_routing")
-            self.add_verb("connect", {
-                "to": "+15551234567",  # Default number
-                "timeout": 30
-            })
-        
+            self.add_verb(
+                "connect",
+                {
+                    "to": "+15551234567",  # Default number
+                    "timeout": 30,
+                },
+            )
+
         # Add fallback message and hangup
-        self.add_verb("play", {
-            "url": "say:We're sorry, but all of our agents are currently busy. Please try your call again later."
-        })
+        self.add_verb(
+            "play",
+            {
+                "url": "say:We're sorry, but all of our agents are currently busy. Please try your call again later."
+            },
+        )
         self.add_verb("hangup", {})
-        
+
         return None  # The document has already been modified
 
 
 def main():
     """Main entry point"""
     parser = argparse.ArgumentParser(description="Dynamic SWML Service Examples")
-    parser.add_argument("--service", choices=["greeting", "router"], 
-                        default="greeting", help="Which service to run")
+    parser.add_argument(
+        "--service",
+        choices=["greeting", "router"],
+        default="greeting",
+        help="Which service to run",
+    )
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
     parser.add_argument("--port", type=int, default=3000, help="Port to bind to")
-    parser.add_argument("--suppress-logs", action="store_true", help="Suppress structured logs")
-    
+    parser.add_argument(
+        "--suppress-logs", action="store_true", help="Suppress structured logs"
+    )
+
     args = parser.parse_args()
-    
+
     # Set log level based on suppress-logs flag
     if args.suppress_logs:
         logging.getLogger().setLevel(logging.WARNING)
-    
+
     # Create the selected service
     if args.service == "greeting":
         service = DynamicGreetingService(host=args.host, port=args.port)
     elif args.service == "router":
         service = CallRouterService(host=args.host, port=args.port)
-    
+
     # Get auth credentials
     username, password = service.get_basic_auth_credentials()
-    
-    logger.info("starting_service", 
-               service=args.service, 
-               url=f"http://{args.host}:{args.port}{service.route}",
-               username=username,
-               password_length=len(password))
-    
-    print(f"Starting {args.service} service on http://{args.host}:{args.port}{service.route}")
+
+    logger.info(
+        "starting_service",
+        service=args.service,
+        url=f"http://{args.host}:{args.port}{service.route}",
+        username=username,
+        password_length=len(password),
+    )
+
+    print(
+        f"Starting {args.service} service on http://{args.host}:{args.port}{service.route}"
+    )
     print(f"Basic Auth: {username}:{password}")
     print("\nYou can access this service via:")
     print(f"  - GET http://{args.host}:{args.port}{service.route}")
     print(f"  - POST http://{args.host}:{args.port}{service.route}")
-    
+
     print("\nFor dynamic behavior, send POST requests with JSON data like:")
-    
+
     if args.service == "greeting":
-        print(json.dumps({
-            "caller_name": "John Doe",
-            "caller_type": "vip",
-            "department": "technical"
-        }, indent=2))
+        print(
+            json.dumps(
+                {
+                    "caller_name": "John Doe",
+                    "caller_type": "vip",
+                    "department": "technical",
+                },
+                indent=2,
+            )
+        )
     elif args.service == "router":
-        print(json.dumps({
-            "region": "west",
-            "high_volume": True,
-            "queue_length": 15
-        }, indent=2))
-    
+        print(
+            json.dumps(
+                {"region": "west", "high_volume": True, "queue_length": 15}, indent=2
+            )
+        )
+
     # Start the server
     try:
         service.serve(host=args.host, port=args.port)
@@ -409,4 +487,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/dynamic_swml_service.py
+++ b/examples/dynamic_swml_service.py
@@ -69,7 +69,7 @@ class DynamicGreetingService(SWMLService):
 
         self.log.debug("default_document_built")
 
-    def on_request(self, request_data: dict = None) -> dict:
+    def on_request(self, request_data: dict | None = None) -> dict:
         """
         Customize the SWML document based on the request data
 
@@ -245,7 +245,7 @@ class CallRouterService(SWMLService):
 
         self.log.debug("default_document_built")
 
-    def on_request(self, request_data: dict = None) -> dict:
+    def on_request(self, request_data: dict | None = None) -> dict:
         """
         Route calls differently based on POST data
 

--- a/examples/faq_bot_agent.py
+++ b/examples/faq_bot_agent.py
@@ -23,30 +23,28 @@ Key concepts demonstrated:
 
 import os
 import sys
-from typing import Dict, List, Optional
 
 # Add the parent directory to the path so we can import the package
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from signalwire import AgentBase
-from signalwire.core.function_result import FunctionResult
 
 
 class FAQBotAgent(AgentBase):
     """
     A specialized agent for answering frequently asked questions (FAQs)
     from a predefined knowledge base.
-    
+
     This agent demonstrates:
     1. Using a class-level template for prompt sections
     2. Dynamically formatting prompt sections with instance variables
     3. Building a structured knowledge base at initialization time
     4. Processing conversation summaries
-    
+
     The FAQ bot is designed to only provide information contained in its
     knowledge base and to clearly indicate when it doesn't have an answer.
     """
-    
+
     # Define the prompt sections declaratively with placeholders
     # This demonstrates creating reusable prompt templates that can be
     # customized for different instances of the same agent type
@@ -57,23 +55,23 @@ class FAQBotAgent(AgentBase):
             "Only answer questions if the information is in the FAQ knowledge base.",
             "If you don't know the answer, politely say so and offer to help with something else.",
             "Be concise and direct in your responses.",
-            "If the answer is in the knowledge base, cite the relevant FAQ item."
+            "If the answer is in the knowledge base, cite the relevant FAQ item.",
         ],
-        "Knowledge Base": ""  # Will be populated during initialization
+        "Knowledge Base": "",  # Will be populated during initialization
     }
-    
+
     def __init__(
-        self, 
+        self,
         name: str = "faq_bot",
         route: str = "/faq",
-        host: str = "0.0.0.0", 
+        host: str = "0.0.0.0",
         port: int = 3000,
         company_name: str = "Our Company",
-        faqs: Optional[Dict[str, str]] = None
+        faqs: dict[str, str] | None = None,
     ):
         """
         Initialize the FAQ Bot Agent
-        
+
         Args:
             name: Agent identifier used for logging and management
             route: HTTP endpoint path for this agent
@@ -82,67 +80,66 @@ class FAQBotAgent(AgentBase):
             company_name: Company name to include in the personality section
             faqs: Dictionary of questions and answers to populate the knowledge base
         """
-        #------------------------------------------------------------------------
+        # ------------------------------------------------------------------------
         # BASE INITIALIZATION
         # Set up the core agent capabilities
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Initialize the base agent
         # This creates the HTTP server and sets up the basic agent functionality
-        super().__init__(
-            name=name,
-            route=route,
-            host=host,
-            port=port
-        )
-        
-        #------------------------------------------------------------------------
+        super().__init__(name=name, route=route, host=host, port=port)
+
+        # ------------------------------------------------------------------------
         # KNOWLEDGE BASE SETUP
         # Build the FAQ knowledge structure
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Store the company name for use in prompt sections
         self.company_name = company_name
-        
+
         # Default FAQs if none provided
         # This allows the agent to work out-of-the-box with sample data
         if faqs is None:
             faqs = {
                 "What are your hours?": "We are open Monday through Friday, 9am to 5pm.",
                 "How do I reset my password?": "You can reset your password by clicking on the 'Forgot Password' link on the login page.",
-                "Do you offer refunds?": "Yes, we offer refunds within 30 days of purchase if you're not satisfied with your product."
+                "Do you offer refunds?": "Yes, we offer refunds within 30 days of purchase if you're not satisfied with your product.",
             }
-        
+
         # Store FAQs for potential runtime access
         self.faqs = faqs
-        
-        #------------------------------------------------------------------------
+
+        # ------------------------------------------------------------------------
         # PROMPT CONFIGURATION
         # Set up the AI's instructions and knowledge
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Generate Knowledge Base content with a clear Q&A format
         # This structures the knowledge in a way that's easy for the AI to reference
         kb_content = "Frequently Asked Questions:\n\n"
         for question, answer in faqs.items():
             kb_content += f"Q: {question}\n"
             kb_content += f"A: {answer}\n\n"
-        
+
         # Add the Knowledge Base prompt section using the public API
         # This adds the formatted FAQs to the prompt
         self.prompt_add_section("Knowledge Base", body=kb_content)
 
         # Add the Personality section with company name
         # This demonstrates dynamically formatting template strings with instance variables
-        personality_text = self.PROMPT_SECTIONS["Personality"].format(company_name=company_name)
+        personality_text = self.PROMPT_SECTIONS["Personality"].format(
+            company_name=company_name
+        )
         self.prompt_add_section("Personality", body=personality_text)
 
         # Add the Goal section
         self.prompt_add_section("Goal", body=self.PROMPT_SECTIONS["Goal"])
 
         # Add the Instructions section with bullet points
-        self.prompt_add_section("Instructions", bullets=self.PROMPT_SECTIONS["Instructions"])
-        
+        self.prompt_add_section(
+            "Instructions", bullets=self.PROMPT_SECTIONS["Instructions"]
+        )
+
         # Set up a post-prompt for conversation summary
         # This defines the structure of data we want to capture after the conversation
         self.set_post_prompt("""
@@ -153,30 +150,30 @@ class FAQBotAgent(AgentBase):
             "follow_up_needed": true/false
         }
         """)
-        
-    def on_summary(self, summary: Dict, raw_data=None):
+
+    def on_summary(self, summary: dict, raw_data=None):
         """
         Handle the conversation summary generated by the post-prompt
-        
+
         This method is called after a conversation has completed and
         the AI has generated the summary JSON structure.
-        
+
         Args:
             summary: Dictionary containing the structured conversation summary
             raw_data: Raw request data (optional)
         """
         print(f"FAQ Bot conversation summary: {summary}")
-        
+
         # Extract useful information from the summary
         question_type = summary.get("question_type", "unknown")
         answered = summary.get("answered_from_kb", False)
         needs_followup = summary.get("follow_up_needed", False)
-        
+
         # Log the key metrics
         print(f"Question Type: {question_type}")
         print(f"Successfully Answered: {answered}")
         print(f"Needs Follow-up: {needs_followup}")
-        
+
         # In a real implementation, you might:
         # - Log this information to a database for analytics
         # - Trigger follow-up actions for unanswered questions
@@ -185,35 +182,37 @@ class FAQBotAgent(AgentBase):
 
 
 if __name__ == "__main__":
-    #------------------------------------------------------------------------
+    # ------------------------------------------------------------------------
     # AGENT CREATION AND STARTUP
     # Create and run a customized FAQ bot
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     # Create a custom FAQ bot with specific SignalWire FAQs
     # This demonstrates how to create a domain-specific instance
     # with custom knowledge
     custom_faqs = {
         "What is SignalWire?": "SignalWire is a communications platform that provides APIs for voice, video, and messaging.",
         "How do I create an AI Agent?": "You can create an AI Agent using the SignalWire AI Agent SDK, which provides a simple way to build and deploy conversational AI agents.",
-        "What is SWML?": "SWML (SignalWire Markup Language) is a markup language for defining communications workflows, including AI interactions."
+        "What is SWML?": "SWML (SignalWire Markup Language) is a markup language for defining communications workflows, including AI interactions.",
     }
-    
+
     # Initialize the agent with custom configuration
     agent = FAQBotAgent(
-        name="signalwire_faq",       # Custom name for the agent
-        company_name="SignalWire",   # Company name to include in personality
-        faqs=custom_faqs             # Custom knowledge base
+        name="signalwire_faq",  # Custom name for the agent
+        company_name="SignalWire",  # Company name to include in personality
+        faqs=custom_faqs,  # Custom knowledge base
     )
-    
+
     print("Starting the FAQ Bot. Press Ctrl+C to stop.")
-    print(f"Agent is accessible at: http://localhost:3000/faq")
-    print("Example usage: curl -X POST -H \"Content-Type: application/json\" -d '{\"message\": \"What is SignalWire?\"}' http://localhost:3000/faq")
-    
+    print("Agent is accessible at: http://localhost:3000/faq")
+    print(
+        'Example usage: curl -X POST -H "Content-Type: application/json" -d \'{"message": "What is SignalWire?"}\' http://localhost:3000/faq'
+    )
+
     # Start the agent's web server
     try:
         print("Note: Works in any deployment mode (server/CGI/Lambda)")
         agent.run()
     except KeyboardInterrupt:
         print("\nStopping the FAQ Bot.")
-        agent.stop() 
+        agent.stop()

--- a/examples/faq_bot_agent.py
+++ b/examples/faq_bot_agent.py
@@ -21,11 +21,12 @@ Key concepts demonstrated:
 4. Customizing agent behavior at runtime
 """
 
-import os
 import sys
+from pathlib import Path
+from typing import ClassVar
 
 # Add the parent directory to the path so we can import the package
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from signalwire import AgentBase
 
@@ -48,7 +49,7 @@ class FAQBotAgent(AgentBase):
     # Define the prompt sections declaratively with placeholders
     # This demonstrates creating reusable prompt templates that can be
     # customized for different instances of the same agent type
-    PROMPT_SECTIONS = {
+    PROMPT_SECTIONS: ClassVar[dict] = {
         "Personality": "You are a helpful FAQ assistant for {company_name}.",
         "Goal": "Answer customer questions using only the provided FAQ knowledge base.",
         "Instructions": [

--- a/examples/gather_info_demo.py
+++ b/examples/gather_info_demo.py
@@ -15,17 +15,14 @@ from signalwire import AgentBase
 
 class PatientIntakeAgent(AgentBase):
     def __init__(self):
-        super().__init__(
-            name="Patient Intake Agent",
-            route="/patient-intake"
-        )
+        super().__init__(name="Patient Intake Agent", route="/patient-intake")
 
         self.add_language("English", "en-US", "inworld.Mark")
 
         self.prompt_add_section(
             "Role",
             "You are a friendly medical office intake assistant. "
-            "Collect patient information accurately and professionally."
+            "Collect patient information accurately and professionally.",
         )
 
         # Define a context with gather info steps
@@ -37,11 +34,15 @@ class PatientIntakeAgent(AgentBase):
         step1.set_text("Collect the patient's basic information.")
         step1.set_gather_info(
             output_key="patient_demographics",
-            prompt="Please collect the following patient information."
+            prompt="Please collect the following patient information.",
         )
         step1.add_gather_question("full_name", "What is your full name?", type="string")
-        step1.add_gather_question("date_of_birth", "What is your date of birth?", type="string")
-        step1.add_gather_question("phone_number", "What is your phone number?", type="string", confirm=True)
+        step1.add_gather_question(
+            "date_of_birth", "What is your date of birth?", type="string"
+        )
+        step1.add_gather_question(
+            "phone_number", "What is your phone number?", type="string", confirm=True
+        )
         step1.add_gather_question("email", "What is your email address?", type="string")
         step1.set_valid_steps(["symptoms"])
 
@@ -50,11 +51,23 @@ class PatientIntakeAgent(AgentBase):
         step2.set_text("Ask about the patient's current symptoms and reason for visit.")
         step2.set_gather_info(
             output_key="patient_symptoms",
-            prompt="Now let's talk about why you're visiting today."
+            prompt="Now let's talk about why you're visiting today.",
         )
-        step2.add_gather_question("reason_for_visit", "What is the main reason for your visit today?", type="string")
-        step2.add_gather_question("symptom_duration", "How long have you been experiencing these symptoms?", type="string")
-        step2.add_gather_question("pain_level", "On a scale of 1 to 10, how would you rate your discomfort?", type="string")
+        step2.add_gather_question(
+            "reason_for_visit",
+            "What is the main reason for your visit today?",
+            type="string",
+        )
+        step2.add_gather_question(
+            "symptom_duration",
+            "How long have you been experiencing these symptoms?",
+            type="string",
+        )
+        step2.add_gather_question(
+            "pain_level",
+            "On a scale of 1 to 10, how would you rate your discomfort?",
+            type="string",
+        )
         step2.set_valid_steps(["confirmation"])
 
         # Step 3: Confirmation (normal mode, not gather)

--- a/examples/gather_per_question_functions_demo.py
+++ b/examples/gather_per_question_functions_demo.py
@@ -85,64 +85,56 @@ class GatherPerQuestionFunctionsAgent(AgentBase):
         contexts = self.define_contexts()
         ctx = contexts.add_context("default")
 
-        ctx.add_step("onboard") \
-            .set_text(
-                "Onboard a new customer by collecting their details. Use "
-                "gather_info to ask one question at a time. Each question "
-                "may unlock a specific validation tool — only that tool "
-                "and gather_submit are callable while answering it."
-            ) \
-            .set_functions([
+        ctx.add_step("onboard").set_text(
+            "Onboard a new customer by collecting their details. Use "
+            "gather_info to ask one question at a time. Each question "
+            "may unlock a specific validation tool — only that tool "
+            "and gather_submit are callable while answering it."
+        ).set_functions(
+            [
                 # Outside of the gather (which is the entire step here),
                 # these would be available. During the gather they are
                 # forcibly hidden in favor of the per-question whitelists.
                 "escalate_to_human",
                 "lookup_existing_account",
-            ]) \
-            .set_gather_info(
-                output_key="customer",
-                completion_action="next_step",
-                prompt=(
-                    "I'll need to collect a few details to set up your "
-                    "account. I'll ask one question at a time."
-                ),
-            ) \
-            .add_gather_question(
-                key="email",
-                question="What's your email address?",
-                confirm=True,
-                # Only validate_email + gather_submit are callable here.
-                functions=["validate_email"],
-            ) \
-            .add_gather_question(
-                key="zip",
-                question="What's your ZIP code?",
-                # Only geocode_zip + gather_submit are callable here.
-                functions=["geocode_zip"],
-            ) \
-            .add_gather_question(
-                key="age",
-                question="How old are you?",
-                type="integer",
-                # Only check_age_eligibility + gather_submit are callable here.
-                functions=["check_age_eligibility"],
-            ) \
-            .add_gather_question(
-                key="referral_source",
-                question="How did you hear about us?",
-                # No functions arg → only gather_submit is callable.
-                # The model cannot validate, lookup, escalate — nothing.
-                # This is the right pattern when a question needs no tools.
-            )
+            ]
+        ).set_gather_info(
+            output_key="customer",
+            completion_action="next_step",
+            prompt=(
+                "I'll need to collect a few details to set up your "
+                "account. I'll ask one question at a time."
+            ),
+        ).add_gather_question(
+            key="email",
+            question="What's your email address?",
+            confirm=True,
+            # Only validate_email + gather_submit are callable here.
+            functions=["validate_email"],
+        ).add_gather_question(
+            key="zip",
+            question="What's your ZIP code?",
+            # Only geocode_zip + gather_submit are callable here.
+            functions=["geocode_zip"],
+        ).add_gather_question(
+            key="age",
+            question="How old are you?",
+            type="integer",
+            # Only check_age_eligibility + gather_submit are callable here.
+            functions=["check_age_eligibility"],
+        ).add_gather_question(
+            key="referral_source",
+            question="How did you hear about us?",
+            # No functions arg → only gather_submit is callable.
+            # The model cannot validate, lookup, escalate — nothing.
+            # This is the right pattern when a question needs no tools.
+        )
 
         # A simple confirmation step the gather auto-advances into.
-        ctx.add_step("confirm") \
-            .set_text(
-                "Read the collected info back to the customer and "
-                "confirm everything is correct."
-            ) \
-            .set_functions([]) \
-            .set_end(True)
+        ctx.add_step("confirm").set_text(
+            "Read the collected info back to the customer and "
+            "confirm everything is correct."
+        ).set_functions([]).set_end(True)
 
 
 if __name__ == "__main__":

--- a/examples/info_gatherer_example.py
+++ b/examples/info_gatherer_example.py
@@ -13,55 +13,61 @@ See LICENSE file in the project root for full license information.
 Example of using the redesigned InfoGathererAgent to collect answers to questions
 """
 
-import os
-import sys
 from signalwire.prefabs import InfoGathererAgent
+
 
 def main():
     """Run the InfoGathererAgent example"""
-    
+
     print("Static InfoGatherer Agent - questions are fixed at startup")
     print("For dynamic configuration, see dynamic_info_gatherer_example.py")
     print()
-    
+
     # Create an agent with a list of questions (STATIC MODE)
     agent = InfoGathererAgent(
         questions=[
             {"key_name": "name", "question_text": "What is your full name?"},
-            {"key_name": "phone", "question_text": "What is your phone number?", "confirm": True},
+            {
+                "key_name": "phone",
+                "question_text": "What is your phone number?",
+                "confirm": True,
+            },
             {"key_name": "age", "question_text": "What is your age?"},
-            {"key_name": "reason", "question_text": "What are you contacting us about today?"}
+            {
+                "key_name": "reason",
+                "question_text": "What are you contacting us about today?",
+            },
         ],
         name="contact-form",
-        route="/contact"
+        route="/contact",
     )
 
     # Set voice
     agent.add_language(
-        name="English",    # Display name for the language
-        code="en-US",      # ISO language code
-        voice="inworld.Mark"  # Voice ID with provider prefix
+        name="English",  # Display name for the language
+        code="en-US",  # ISO language code
+        voice="inworld.Mark",  # Voice ID with provider prefix
     )
 
     # Customize the agent with additional prompt sections if desired
     agent.prompt_add_section(
-        "Introduction", 
+        "Introduction",
         body="I'm here to help you fill out our contact form. "
-             "This information helps us better serve you."
+        "This information helps us better serve you.",
     )
 
     # Set the post prompt to summarize the questions and answers in a concise manner
-    
+
     agent.set_post_prompt("Summarize the questions and answers in a concise manner.")
 
     # you have to set a post prompt to be able to use either of the next two options
 
     # Set the post prompt URL to the remote server, even if you define the on_summary method it will be ignored if you set the post prompt URL
     agent.set_post_prompt_url("https://user:password@example.com/ai/post.cgi")
-    
+
     # Get basic auth credentials for display
     username, password = agent.get_basic_auth_credentials()
-    
+
     # Print information about the agent
     print("Starting the Information Gathering Agent")
     print("----------------------------------------")
@@ -69,10 +75,11 @@ def main():
     print(f"Basic Auth: {username}:{password}")
     print("----------------------------------------")
     print("Press Ctrl+C to stop the agent")
-    
+
     # Start the agent server
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/joke_agent.py
+++ b/examples/joke_agent.py
@@ -24,13 +24,10 @@ from signalwire import AgentBase
 
 class JokeAgent(AgentBase):
     """Simple agent that can tell jokes using data_map"""
-    
+
     def __init__(self):
-        super().__init__(
-            name="Joke Agent",
-            route="/joke-agent"
-        )
-        
+        super().__init__(name="Joke Agent", route="/joke-agent")
+
         # Get API key from environment variable
         api_key = os.environ.get("API_NINJAS_KEY")
         if not api_key:
@@ -38,19 +35,24 @@ class JokeAgent(AgentBase):
             print("Get your free API key from https://api.api-ninjas.com/")
             print("Then run: API_NINJAS_KEY=your_api_key python examples/joke_agent.py")
             sys.exit(1)
-        
+
         # Configure the agent's personality and behavior
-        self.prompt_add_section("Personality", body="You are a funny assistant who loves to tell jokes.")
+        self.prompt_add_section(
+            "Personality", body="You are a funny assistant who loves to tell jokes."
+        )
         self.prompt_add_section("Goal", body="Make people laugh with great jokes.")
-        self.prompt_add_section("Instructions", bullets=[
-            "Use the get_joke function to tell jokes when asked",
-            "You can tell either regular jokes or dad jokes",
-            "Be enthusiastic about sharing humor"
-        ])
-        
+        self.prompt_add_section(
+            "Instructions",
+            bullets=[
+                "Use the get_joke function to tell jokes when asked",
+                "You can tell either regular jokes or dad jokes",
+                "Be enthusiastic about sharing humor",
+            ],
+        )
+
         # Register the joke function with raw data_map configuration
         self._add_joke_function(api_key)
-    
+
     def _add_joke_function(self, api_key):
         """Add the joke function using raw data_map configuration"""
         joke_function = {
@@ -60,9 +62,7 @@ class JokeAgent(AgentBase):
                 "webhooks": [
                     {
                         "url": "https://api.api-ninjas.com/v1/%{args.type}",
-                        "headers": {
-                            "X-Api-Key": api_key
-                        },
+                        "headers": {"X-Api-Key": api_key},
                         "output": {
                             "response": "Tell the user: %{array[0].joke}",
                             "action": [
@@ -77,30 +77,30 @@ class JokeAgent(AgentBase):
                                                 }
                                             ]
                                         },
-                                        "version": "1.0.0"
+                                        "version": "1.0.0",
                                     }
                                 }
-                            ]
+                            ],
                         },
                         "error_keys": "error",
-                        "method": "GET"
+                        "method": "GET",
                     }
                 ],
                 "output": {
                     "response": "Tell the user that the joke service is not working right now and just make up a joke on your own"
-                }
+                },
             },
             "parameters": {
                 "properties": {
                     "type": {
                         "description": "must either be 'jokes' or 'dadjokes'",
-                        "type": "string"
+                        "type": "string",
                     }
                 },
-                "type": "object"
-            }
+                "type": "object",
+            },
         }
-        
+
         # Register the function with the agent
         self.register_swaig_function(joke_function)
 
@@ -113,9 +113,9 @@ def main():
     print("\nAvailable function:")
     print("  get_joke - Tell a joke (jokes or dadjokes)")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
-    
+
     agent = JokeAgent()
-    
+
     try:
         agent.run()
     except KeyboardInterrupt:
@@ -123,4 +123,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/joke_skill_demo.py
+++ b/examples/joke_skill_demo.py
@@ -25,35 +25,40 @@ from signalwire import AgentBase
 
 class JokeSkillAgent(AgentBase):
     """Demo agent using the joke skill"""
-    
+
     def __init__(self):
-        super().__init__(
-            name="Joke Skill Demo Agent",
-            route="/joke-skill-demo"
-        )
-        
+        super().__init__(name="Joke Skill Demo Agent", route="/joke-skill-demo")
+
         # Get API key from environment variable
         api_key = os.environ.get("API_NINJAS_KEY")
         if not api_key:
             print("Error: API_NINJAS_KEY environment variable is required")
             print("Get your free API key from https://api.api-ninjas.com/")
-            print("Then run: API_NINJAS_KEY=your_api_key python examples/joke_skill_demo.py")
+            print(
+                "Then run: API_NINJAS_KEY=your_api_key python examples/joke_skill_demo.py"
+            )
             sys.exit(1)
-        
+
         # Configure the agent's personality
-        self.prompt_add_section("Personality", body="You are a cheerful comedian who loves sharing jokes and making people laugh.")
-        self.prompt_add_section("Goal", body="Entertain users with great jokes and spread joy.")
-        self.prompt_add_section("Instructions", bullets=[
-            "When users ask for jokes, use your joke functions to provide them",
-            "Be enthusiastic and fun in your responses", 
-            "You can tell both regular jokes and dad jokes"
-        ])
-        
+        self.prompt_add_section(
+            "Personality",
+            body="You are a cheerful comedian who loves sharing jokes and making people laugh.",
+        )
+        self.prompt_add_section(
+            "Goal", body="Entertain users with great jokes and spread joy."
+        )
+        self.prompt_add_section(
+            "Instructions",
+            bullets=[
+                "When users ask for jokes, use your joke functions to provide them",
+                "Be enthusiastic and fun in your responses",
+                "You can tell both regular jokes and dad jokes",
+            ],
+        )
+
         # Add joke skill with API key from environment
-        self.add_skill("joke", {
-            "api_key": api_key
-        })
-        
+        self.add_skill("joke", {"api_key": api_key})
+
         # Optional: Add multiple joke instances for different types
         # self.add_skill("joke", {
         #     "api_key": api_key,
@@ -72,28 +77,30 @@ def main():
     print("• DataMap integration for serverless API execution")
     print("• Automatic skill discovery and registration")
     print("• No custom webhook endpoints required")
-    
+
     print("\nBenefits of Skills vs Raw DataMap:")
     print("• One-liner integration: agent.add_skill('joke', config)")
     print("• Automatic validation and error handling")
     print("• Reusable across multiple agents")
     print("• Built-in documentation and hints")
     print("• Standardized configuration interface")
-    
+
     print("\nAPI Key Setup:")
     print("1. Sign up at https://api.api-ninjas.com/")
     print("2. Get your free API key")
     print("3. Set environment variable: export API_NINJAS_KEY=your_api_key")
-    print("4. Or run with: API_NINJAS_KEY=your_api_key python examples/joke_skill_demo.py")
-    
+    print(
+        "4. Or run with: API_NINJAS_KEY=your_api_key python examples/joke_skill_demo.py"
+    )
+
     print("\nStarting agent...")
     print("Ask for jokes like:")
     print("• 'Tell me a joke'")
     print("• 'I want to hear a dad joke'")
     print("• 'Make me laugh!'")
-    
+
     agent = JokeSkillAgent()
-    
+
     try:
         agent.run(host="0.0.0.0", port=3000)
     except KeyboardInterrupt:
@@ -101,4 +108,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/kubernetes_ready_agent.py
+++ b/examples/kubernetes_ready_agent.py
@@ -33,19 +33,20 @@ import sys
 import logging
 from signalwire import AgentBase
 
+
 class KubernetesReadyAgent(AgentBase):
     def __init__(self, port=None):
         # Allow port override via parameter, environment, or default
         if port is None:
             port = int(os.environ.get("PORT", 8080))
-            
+
         super().__init__(
             name="k8s-agent",
             route="/",  # Root route for simplicity
             host="0.0.0.0",  # Bind to all interfaces
-            port=port
+            port=port,
         )
-        
+
         # Setup graceful shutdown for Kubernetes
         self.setup_graceful_shutdown()
 
@@ -56,24 +57,23 @@ class KubernetesReadyAgent(AgentBase):
         self.prompt_add_section(
             "Role",
             body="You are a production-ready AI agent running in Kubernetes. "
-                 "You can help users with general questions and demonstrate cloud-native deployment patterns."
+            "You can help users with general questions and demonstrate cloud-native deployment patterns.",
         )
 
         # Log initialization
-        self.log.info("kubernetes_agent_initialized",
-                     port=self.port,
-                     route=self.route)
+        self.log.info("kubernetes_agent_initialized", port=self.port, route=self.route)
 
     @AgentBase.tool(
-        name="health_status",
-        description="Get the health status of this agent"
+        name="health_status", description="Get the health status of this agent"
     )
     def health_status(self, args, raw_data):
         from signalwire.core.function_result import FunctionResult
+
         return FunctionResult(
             f"Agent {self.get_name()} is healthy, running on route {self.route} "
             f"port {self.port} in Kubernetes."
         )
+
 
 if __name__ == "__main__":
     # Simple command line argument parsing
@@ -88,30 +88,32 @@ if __name__ == "__main__":
         elif sys.argv[1] in ["--help", "-h"]:
             print(__doc__)
             sys.exit(0)
-    
+
     # Environment variable configuration
     log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
-    
+
     # Configure root logger level
     logging.getLogger().setLevel(getattr(logging, log_level))
-    
+
     # Create agent
     agent = KubernetesReadyAgent(port=port)
-    
+
     # Log startup with environment info
-    agent.log.info("agent_starting_production",
-                   log_level=log_level,
-                   port=agent.port,
-                   health_endpoints=["/health", "/ready"])
-    
+    agent.log.info(
+        "agent_starting_production",
+        log_level=log_level,
+        port=agent.port,
+        health_endpoints=["/health", "/ready"],
+    )
+
     print(f"READY: Kubernetes-ready agent starting on port {agent.port}")
     print(f"HEALTH: Health check: http://localhost:{agent.port}/health")
     print(f"STATUS: Readiness check: http://localhost:{agent.port}/ready")
     print(f"LOG: Log level: {log_level}")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
-    
+
     try:
         agent.run()
     except KeyboardInterrupt:
         agent.log.info("agent_shutdown_requested")
-        print("\nSTOPPED: Agent shutdown complete") 
+        print("\nSTOPPED: Agent shutdown complete")

--- a/examples/lambda_agent.py
+++ b/examples/lambda_agent.py
@@ -32,13 +32,13 @@ Features:
     - Environment-based configuration
 """
 
-import os
 import sys
 from datetime import datetime
+from pathlib import Path
 
 # Add the signalwire module to the path if needed
 # (not needed if installed via pip)
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from signalwire import AgentBase
 from signalwire.core.function_result import FunctionResult

--- a/examples/lambda_agent.py
+++ b/examples/lambda_agent.py
@@ -38,7 +38,7 @@ from datetime import datetime
 
 # Add the signalwire module to the path if needed
 # (not needed if installed via pip)
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from signalwire import AgentBase
 from signalwire.core.function_result import FunctionResult
@@ -70,8 +70,7 @@ class HealthCheckAgent(AgentBase):
 
         # Configure prompt using prompt_add_section (the public API)
         self.prompt_add_section(
-            "Role",
-            body="You are a helpful AI assistant running in AWS Lambda."
+            "Role", body="You are a helpful AI assistant running in AWS Lambda."
         )
         self.prompt_add_section(
             "Instructions",
@@ -79,7 +78,7 @@ class HealthCheckAgent(AgentBase):
                 "Greet users warmly and offer help",
                 "Use the greet_user function when asked to greet someone",
                 "Use the get_time function when asked about the current time",
-            ]
+            ],
         )
 
     @AgentBase.tool("Greet a user by name")
@@ -107,6 +106,7 @@ app = agent.get_app()
 # This handles all the API Gateway <-> FastAPI translation
 handler = Mangum(app)
 
+
 def lambda_handler(event, context):
     """
     AWS Lambda entry point
@@ -130,6 +130,7 @@ def main():
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
+
 
 if __name__ == "__main__":
     main()

--- a/examples/llm_params_demo.py
+++ b/examples/llm_params_demo.py
@@ -13,38 +13,43 @@ import random
 
 class PreciseAssistant(AgentBase):
     """An agent configured for precise, consistent responses"""
-    
+
     def __init__(self):
         super().__init__(name="precise-assistant", route="/precise")
-        
+
         # Configure personality
         self.prompt_add_section("Role", "You are a precise technical assistant.")
-        self.prompt_add_section("Instructions", bullets=[
-            "Provide accurate, factual information",
-            "Be concise and direct",
-            "Avoid speculation or guessing",
-            "If uncertain, say so clearly"
-        ])
-        
+        self.prompt_add_section(
+            "Instructions",
+            bullets=[
+                "Provide accurate, factual information",
+                "Be concise and direct",
+                "Avoid speculation or guessing",
+                "If uncertain, say so clearly",
+            ],
+        )
+
         # Configure LLM for consistency and precision
         self.set_prompt_llm_params(
-            temperature=0.2,        # Very low for consistent responses
-            top_p=0.85,            # More focused token selection
+            temperature=0.2,  # Very low for consistent responses
+            top_p=0.85,  # More focused token selection
             barge_confidence=0.8,  # Hard to interrupt - let it finish technical info
             presence_penalty=0.0,  # No penalty - technical terms may repeat
-            frequency_penalty=0.1  # Slight penalty for word variety
+            frequency_penalty=0.1,  # Slight penalty for word variety
         )
-        
+
         # Post-prompt for technical summaries
-        self.set_post_prompt("Provide a brief technical summary of the key points discussed.")
-        self.set_post_prompt_llm_params(
-            temperature=0.1       # Extremely consistent summaries
+        self.set_post_prompt(
+            "Provide a brief technical summary of the key points discussed."
         )
-    
+        self.set_post_prompt_llm_params(
+            temperature=0.1  # Extremely consistent summaries
+        )
+
     @AgentBase.tool(
         name="get_system_info",
         description="Get technical system information",
-        parameters={}
+        parameters={},
     )
     def get_system_info(self, args, raw_data):
         """Simulated system information"""
@@ -52,7 +57,7 @@ class PreciseAssistant(AgentBase):
             "cpu_usage": f"{random.randint(10, 90)}%",
             "memory_available": f"{random.randint(1, 16)}GB",
             "disk_space": f"{random.randint(50, 500)}GB free",
-            "uptime": f"{random.randint(1, 30)} days"
+            "uptime": f"{random.randint(1, 30)} days",
         }
         return FunctionResult(
             f"System Status: CPU {info['cpu_usage']}, "
@@ -64,38 +69,41 @@ class PreciseAssistant(AgentBase):
 
 class CreativeAssistant(AgentBase):
     """An agent configured for creative, varied responses"""
-    
+
     def __init__(self):
         super().__init__(name="creative-assistant", route="/creative")
-        
+
         # Configure personality
         self.prompt_add_section("Role", "You are a creative writing assistant.")
-        self.prompt_add_section("Instructions", bullets=[
-            "Be imaginative and creative",
-            "Use varied vocabulary and expressions",
-            "Encourage creative thinking",
-            "Suggest unique perspectives"
-        ])
-        
+        self.prompt_add_section(
+            "Instructions",
+            bullets=[
+                "Be imaginative and creative",
+                "Use varied vocabulary and expressions",
+                "Encourage creative thinking",
+                "Suggest unique perspectives",
+            ],
+        )
+
         # Configure LLM for creativity
         self.set_prompt_llm_params(
-            temperature=0.8,        # High for creative variety
-            top_p=0.95,            # Wide token selection
+            temperature=0.8,  # High for creative variety
+            top_p=0.95,  # Wide token selection
             barge_confidence=0.5,  # Easy to interrupt for collaboration
             presence_penalty=0.2,  # Encourage new topics
-            frequency_penalty=0.3  # Strong vocabulary variety
+            frequency_penalty=0.3,  # Strong vocabulary variety
         )
-        
+
         # Post-prompt for creative summaries
         self.set_post_prompt("Create an artistic summary of our conversation.")
         self.set_post_prompt_llm_params(
-            temperature=0.7       # Still creative for summaries
+            temperature=0.7  # Still creative for summaries
         )
-    
+
     @AgentBase.tool(
         name="generate_story_prompt",
         description="Generate a creative story prompt",
-        parameters={"theme": {"type": "string", "description": "Story theme"}}
+        parameters={"theme": {"type": "string", "description": "Story theme"}},
     )
     def generate_story_prompt(self, args, raw_data):
         """Generate creative story prompts"""
@@ -104,75 +112,80 @@ class CreativeAssistant(AgentBase):
             "adventure": [
                 "A map that only appears during thunderstorms",
                 "A compass that points to what you need most",
-                "A backpack that's bigger on the inside"
+                "A backpack that's bigger on the inside",
             ],
             "mystery": [
                 "A photograph where people keep disappearing",
                 "A library book that writes itself",
-                "A mirror that shows different reflections"
+                "A mirror that shows different reflections",
             ],
             "default": [
                 "An ordinary object with extraordinary powers",
                 "A door that leads somewhere different each time",
-                "A message from your future self"
-            ]
+                "A message from your future self",
+            ],
         }
-        
+
         prompt_list = prompts.get(theme.lower(), prompts["default"])
         chosen_prompt = random.choice(prompt_list)
-        
-        return FunctionResult(
-            f"Story prompt for {theme}: {chosen_prompt}"
-        )
+
+        return FunctionResult(f"Story prompt for {theme}: {chosen_prompt}")
 
 
 class CustomerServiceAgent(AgentBase):
     """An agent configured for professional customer service"""
-    
+
     def __init__(self):
         super().__init__(name="customer-service", route="/support")
-        
+
         # Configure personality
-        self.prompt_add_section("Role", "You are a professional customer service representative.")
-        self.prompt_add_section("Guidelines", bullets=[
-            "Always be polite and empathetic",
-            "Listen carefully to customer concerns",
-            "Provide clear, helpful solutions",
-            "Follow company policies"
-        ])
-        
+        self.prompt_add_section(
+            "Role", "You are a professional customer service representative."
+        )
+        self.prompt_add_section(
+            "Guidelines",
+            bullets=[
+                "Always be polite and empathetic",
+                "Listen carefully to customer concerns",
+                "Provide clear, helpful solutions",
+                "Follow company policies",
+            ],
+        )
+
         # Configure LLM for professional consistency
         self.set_prompt_llm_params(
-            temperature=0.4,        # Balanced consistency
-            top_p=0.9,             # Standard token selection
+            temperature=0.4,  # Balanced consistency
+            top_p=0.9,  # Standard token selection
             barge_confidence=0.7,  # Moderate interruption threshold
             presence_penalty=0.1,  # Slight penalty for repetition
-            frequency_penalty=0.1  # Encourage natural variety
+            frequency_penalty=0.1,  # Encourage natural variety
         )
-        
+
         # Post-prompt for ticket summaries
-        self.set_post_prompt("Summarize the customer's issue and resolution for the ticket system.")
-        self.set_post_prompt_llm_params(
-            temperature=0.3       # Consistent ticket summaries
+        self.set_post_prompt(
+            "Summarize the customer's issue and resolution for the ticket system."
         )
-    
+        self.set_post_prompt_llm_params(
+            temperature=0.3  # Consistent ticket summaries
+        )
+
     @AgentBase.tool(
         name="check_order_status",
         description="Check the status of a customer order",
-        parameters={"order_id": {"type": "string", "description": "Order ID"}}
+        parameters={"order_id": {"type": "string", "description": "Order ID"}},
     )
     def check_order_status(self, args, raw_data):
         """Simulated order status check"""
         order_id = args.get("order_id", "unknown")
-        
+
         # Simulate order statuses
         statuses = [
             "Processing - Expected to ship within 24 hours",
             "Shipped - Tracking number: TRK" + str(random.randint(100000, 999999)),
             "Out for delivery - Expected today by 6 PM",
-            "Delivered - Left at front door"
+            "Delivered - Left at front door",
         ]
-        
+
         status = random.choice(statuses)
         return FunctionResult(f"Order {order_id} status: {status}")
 
@@ -180,16 +193,18 @@ class CustomerServiceAgent(AgentBase):
 def main():
     """Run the demo agent based on command line argument"""
     import sys
-    
+
     if len(sys.argv) > 1:
         agent_type = sys.argv[1].lower()
-        
+
         if agent_type == "precise":
             agent = PreciseAssistant()
             print("Starting Precise Assistant (low temperature, hard to interrupt)...")
         elif agent_type == "creative":
             agent = CreativeAssistant()
-            print("Starting Creative Assistant (high temperature, easy to interrupt)...")
+            print(
+                "Starting Creative Assistant (high temperature, easy to interrupt)..."
+            )
         elif agent_type == "support":
             agent = CustomerServiceAgent()
             print("Starting Customer Service Agent (balanced parameters)...")
@@ -202,7 +217,7 @@ def main():
         agent = CustomerServiceAgent()
         print("Starting Customer Service Agent (default)...")
         print("Try: python llm_params_demo.py [precise|creative|support]")
-    
+
     agent.serve(host="0.0.0.0", port=8000)
 
 

--- a/examples/mcp_agent.py
+++ b/examples/mcp_agent.py
@@ -40,9 +40,7 @@ class MCPAgent(AgentBase):
         # Headers are sent on every request for authentication.
         self.add_mcp_server(
             "https://mcp.example.com/tools",
-            headers={
-                "Authorization": "Bearer sk-your-mcp-api-key"
-            }
+            headers={"Authorization": "Bearer sk-your-mcp-api-key"},
         )
 
         # ── MCP Client with Resources ──────────────────────────────
@@ -52,34 +50,37 @@ class MCPAgent(AgentBase):
         # URI templates (e.g. crm://customer/{caller_id}).
         self.add_mcp_server(
             "https://mcp.example.com/crm",
-            headers={
-                "Authorization": "Bearer sk-your-crm-key"
-            },
+            headers={"Authorization": "Bearer sk-your-crm-key"},
             resources=True,
-            resource_vars={
-                "caller_id": "${caller_id_number}",
-                "tenant": "acme-corp"
-            }
+            resource_vars={"caller_id": "${caller_id_number}", "tenant": "acme-corp"},
         )
 
         # ── Agent Configuration ─────────────────────────────────────
-        self.prompt_add_section("Role", body=(
-            "You are a helpful customer support agent. "
-            "You have access to the customer's profile via global_data. "
-            "Use the available tools to look up information and assist the caller."
-        ))
+        self.prompt_add_section(
+            "Role",
+            body=(
+                "You are a helpful customer support agent. "
+                "You have access to the customer's profile via global_data. "
+                "Use the available tools to look up information and assist the caller."
+            ),
+        )
 
         # Reference MCP resource data in the prompt
-        self.prompt_add_section("Customer Context", body=(
-            "Customer name: ${global_data.customer_name}\n"
-            "Account status: ${global_data.account_status}\n"
-            "If customer data is not available, ask the caller for their name."
-        ))
+        self.prompt_add_section(
+            "Customer Context",
+            body=(
+                "Customer name: ${global_data.customer_name}\n"
+                "Account status: ${global_data.account_status}\n"
+                "If customer data is not available, ask the caller for their name."
+            ),
+        )
 
-        self.set_params({
-            "attention_timeout": 15000,
-            "conscience": "Be helpful and concise.",
-        })
+        self.set_params(
+            {
+                "attention_timeout": 15000,
+                "conscience": "Be helpful and concise.",
+            }
+        )
 
     # ── Local Tools ─────────────────────────────────────────────────
     # These are available both as SWAIG webhooks (voice calls) AND
@@ -89,32 +90,24 @@ class MCPAgent(AgentBase):
         "get_weather",
         description="Get the current weather for a location",
         parameters={
-            "location": {
-                "type": "string",
-                "description": "City name or zip code"
-            }
-        }
+            "location": {"type": "string", "description": "City name or zip code"}
+        },
     )
     def get_weather(self, args, raw_data):
         """Look up weather — available via both SWAIG and MCP"""
         location = args.get("location", "unknown")
-        return FunctionResult(
-            f"Currently 72°F and sunny in {location}."
-        )
+        return FunctionResult(f"Currently 72°F and sunny in {location}.")
 
     @AgentBase.tool(
         "create_ticket",
         description="Create a support ticket for the customer",
         parameters={
-            "subject": {
-                "type": "string",
-                "description": "Ticket subject"
-            },
+            "subject": {"type": "string", "description": "Ticket subject"},
             "description": {
                 "type": "string",
-                "description": "Detailed description of the issue"
-            }
-        }
+                "description": "Detailed description of the issue",
+            },
+        },
     )
     def create_ticket(self, args, raw_data):
         """Create a support ticket — available via both SWAIG and MCP"""

--- a/examples/mcp_gateway_demo.py
+++ b/examples/mcp_gateway_demo.py
@@ -21,10 +21,7 @@ from signalwire import AgentBase
 
 class MCPGatewayAgent(AgentBase):
     def __init__(self):
-        super().__init__(
-            name="MCP Gateway Agent",
-            route="/mcp-gateway"
-        )
+        super().__init__(name="MCP Gateway Agent", route="/mcp-gateway")
 
         self.add_language("English", "en-US", "inworld.Mark")
 
@@ -32,16 +29,23 @@ class MCPGatewayAgent(AgentBase):
             "Role",
             "You are a helpful assistant with access to external tools provided "
             "through MCP servers. Use the available tools to help users accomplish "
-            "their tasks."
+            "their tasks.",
         )
 
         # Connect to MCP gateway - tools are discovered automatically
-        self.add_skill("mcp_gateway", {
-            "gateway_url": os.environ.get("MCP_GATEWAY_URL", "http://localhost:8080"),
-            "auth_user": os.environ.get("MCP_GATEWAY_AUTH_USER", "admin"),
-            "auth_password": os.environ.get("MCP_GATEWAY_AUTH_PASSWORD", "changeme"),
-            "services": [{"name": "todo"}]  # List which MCP services to expose
-        })
+        self.add_skill(
+            "mcp_gateway",
+            {
+                "gateway_url": os.environ.get(
+                    "MCP_GATEWAY_URL", "http://localhost:8080"
+                ),
+                "auth_user": os.environ.get("MCP_GATEWAY_AUTH_USER", "admin"),
+                "auth_password": os.environ.get(
+                    "MCP_GATEWAY_AUTH_PASSWORD", "changeme"
+                ),
+                "services": [{"name": "todo"}],  # List which MCP services to expose
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/examples/multi_agent_server.py
+++ b/examples/multi_agent_server.py
@@ -38,16 +38,16 @@ Usage examples:
    curl "http://localhost:3000/dynamic?tier=enterprise&industry=tech&voice=inworld.Mark"
 """
 
-import os
 import sys
 import json
 from datetime import datetime
+from pathlib import Path
 from fastapi import FastAPI
 from signalwire import AgentBase
 from comprehensive_dynamic_agent import ComprehensiveDynamicAgent
 
 # Add the parent directory to the path so we can import the package
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from signalwire.prefabs import InfoGathererAgent
 from signalwire.core.function_result import FunctionResult
@@ -131,7 +131,7 @@ class CustomInfoGatherer(InfoGathererAgent):
 
         # Simulate CRM save by writing to a local file
         # In a real implementation, this would call a CRM API
-        with open("customer_data.json", "a") as f:
+        with Path("customer_data.json").open("a") as f:
             f.write(
                 json.dumps(
                     {

--- a/examples/multi_agent_server.py
+++ b/examples/multi_agent_server.py
@@ -49,7 +49,6 @@ from comprehensive_dynamic_agent import ComprehensiveDynamicAgent
 # Add the parent directory to the path so we can import the package
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from signalwire import AgentServer
 from signalwire.prefabs import InfoGathererAgent
 from signalwire.core.function_result import FunctionResult
 
@@ -58,19 +57,19 @@ class CustomInfoGatherer(InfoGathererAgent):
     """
     Custom information gatherer that adds a save_info tool
     and overrides on_summary to do something with the collected data
-    
+
     This demonstrates how to extend a prefab agent with:
     1. Custom SWAIG functions to perform additional actions
     2. Custom summary handling to process collected information
     3. Action integration (SMS sending) as part of the agent response
     """
-    
+
     def __init__(self):
-        #------------------------------------------------------------------------
+        # ------------------------------------------------------------------------
         # PREFAB CONFIGURATION
         # Configure the base InfoGathererAgent with our specific requirements
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Initialize with field definitions
         # The InfoGathererAgent prefab will automatically create an agent that:
         # - Collects these specific pieces of information
@@ -78,48 +77,48 @@ class CustomInfoGatherer(InfoGathererAgent):
         # - Handles clarifications and corrections
         # - Provides a confirmation once all data is collected
         super().__init__(
-            name="registration",           # Agent identifier and logging name
-            route="/register",             # HTTP endpoint path
-            fields=[                       # Information to collect
+            name="registration",  # Agent identifier and logging name
+            route="/register",  # HTTP endpoint path
+            fields=[  # Information to collect
                 {"name": "full_name", "prompt": "What is your full name?"},
                 {"name": "email", "prompt": "What is your email address?"},
-                {"name": "phone", "prompt": "What is your phone number?"}
+                {"name": "phone", "prompt": "What is your phone number?"},
             ],
             # Template uses {field_name} to insert collected data
-            confirmation_template="Thanks {full_name}! We've recorded your contact info: {email} and {phone}."
+            confirmation_template="Thanks {full_name}! We've recorded your contact info: {email} and {phone}.",
         )
-        
-        #------------------------------------------------------------------------
+
+        # ------------------------------------------------------------------------
         # CUSTOM TOOL DEFINITION
         # Add additional capabilities not included in the base prefab
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Add a tool for saving info to CRM
         # This is a custom extension not part of the base InfoGathererAgent
         self.define_tool(
-            name="save_to_crm",           # Function name the AI will use
+            name="save_to_crm",  # Function name the AI will use
             description="Save customer information to the CRM system",  # Description for the AI
-            parameters={                   # Parameter schema
+            parameters={  # Parameter schema
                 "name": {"type": "string", "description": "Customer name"},
                 "email": {"type": "string", "description": "Customer email"},
-                "phone": {"type": "string", "description": "Customer phone"}
+                "phone": {"type": "string", "description": "Customer phone"},
             },
-            handler=self.save_to_crm       # Method to call when the function is invoked
+            handler=self.save_to_crm,  # Method to call when the function is invoked
         )
-    
+
     def save_to_crm(self, args, raw_data):
         """
         Tool handler for saving info to CRM
-        
+
         This function demonstrates how to:
         1. Process collected information
         2. Integrate with external systems
         3. Return actions that trigger additional behaviors
-        
+
         Args:
             args: Dictionary with name, email, and phone parameters
             raw_data: Complete request data
-            
+
         Returns:
             FunctionResult with confirmation and SMS action
         """
@@ -127,41 +126,49 @@ class CustomInfoGatherer(InfoGathererAgent):
         name = args.get("name", "")
         email = args.get("email", "")
         phone = args.get("phone", "")
-        
+
         print(f"Saving to CRM: {name}, {email}, {phone}")
-        
+
         # Simulate CRM save by writing to a local file
         # In a real implementation, this would call a CRM API
         with open("customer_data.json", "a") as f:
-            f.write(json.dumps({
-                "name": name,
-                "email": email,
-                "phone": phone,
-                "timestamp": datetime.now().isoformat()
-            }) + "\n")
-        
+            f.write(
+                json.dumps(
+                    {
+                        "name": name,
+                        "email": email,
+                        "phone": phone,
+                        "timestamp": datetime.now().isoformat(),
+                    }
+                )
+                + "\n"
+            )
+
         # Return success response with an additional action
         # This demonstrates how to trigger SMS sending as part of the function result
         return (
-            FunctionResult("I've saved your information to our system.")
-            .add_action("send_sms", 
-                       {"to": phone,                # Phone number to send to
-                       "message": f"Thanks {name} for registering!"})  # SMS content
+            FunctionResult("I've saved your information to our system.").add_action(
+                "send_sms",
+                {
+                    "to": phone,  # Phone number to send to
+                    "message": f"Thanks {name} for registering!",
+                },
+            )  # SMS content
         )
-    
+
     def on_summary(self, summary, raw_data=None):
         """
         Process the conversation summary data
-        
+
         This method is called after all information has been collected and the post-prompt
         has generated a summary. It allows for final processing of the data.
-        
+
         Args:
             summary: JSON structure containing the collected information
             raw_data: Complete request data
         """
         print(f"Registration completed: {json.dumps(summary, indent=2)}")
-        
+
         # Additional processing could happen here
         # For example:
         # - Saving to a database
@@ -172,57 +179,58 @@ class CustomInfoGatherer(InfoGathererAgent):
 class SupportInfoGatherer(InfoGathererAgent):
     """
     Support ticket information gatherer
-    
+
     This agent demonstrates:
     1. Using validation rules in field definitions
     2. Customizing the structure of the summary data
     3. Simple processing of submitted support tickets
     """
-    
+
     def __init__(self):
-        #------------------------------------------------------------------------
+        # ------------------------------------------------------------------------
         # PREFAB CONFIGURATION
         # Configure the InfoGathererAgent for support ticket collection
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Initialize with ticket field definitions
         super().__init__(
             name="support",
             route="/support",
             fields=[
                 {"name": "name", "prompt": "What is your name?"},
-                {"name": "issue", "prompt": "Please describe the issue you're experiencing."},
+                {
+                    "name": "issue",
+                    "prompt": "Please describe the issue you're experiencing.",
+                },
                 # This field includes validation to ensure the value is a number between 1-5
-                {"name": "urgency", "prompt": "On a scale of 1-5, how urgent is this issue?", 
-                 "validation": "Must be a number between 1 and 5"}
+                {
+                    "name": "urgency",
+                    "prompt": "On a scale of 1-5, how urgent is this issue?",
+                    "validation": "Must be a number between 1 and 5",
+                },
             ],
             confirmation_template="Thanks {name}. We've recorded your {urgency}-priority issue and will respond soon.",
             # Define a custom structure for the summary data
             # The %{field_name} syntax inserts the collected data into the specified structure
             summary_format={
-                "customer": {
-                    "name": "%{name}"
-                },
-                "ticket": {
-                    "description": "%{issue}",
-                    "priority": "%{urgency}"
-                }
-            }
+                "customer": {"name": "%{name}"},
+                "ticket": {"description": "%{issue}", "priority": "%{urgency}"},
+            },
         )
-    
+
     def on_summary(self, summary, raw_data=None):
         """
         Process the ticket data after collection is complete
-        
+
         This method is called when the conversation has ended
         and all required information has been collected.
-        
+
         Args:
             summary: The structured ticket data as configured in summary_format
             raw_data: Complete request data
         """
         print(f"Support ticket created: {json.dumps(summary, indent=2)}")
-        
+
         # In a real implementation, you might:
         # - Create a ticket in a ticketing system
         # - Send a notification to support staff
@@ -235,19 +243,19 @@ class HealthcareAgent(AgentBase):
             name="Healthcare AI Assistant",
             route="/healthcare",
             auto_answer=True,
-            record_call=True
+            record_call=True,
         )
-        
+
         # Set up healthcare-specific dynamic configuration
         self.set_dynamic_config_callback(self.configure_healthcare_agent)
-        
+
         # Base healthcare configuration
         self.prompt_add_section(
             "Healthcare Role",
             "You are a HIPAA-compliant healthcare AI assistant. You help patients and "
-            "healthcare providers with information, scheduling, and basic guidance."
+            "healthcare providers with information, scheduling, and basic guidance.",
         )
-        
+
         self.prompt_add_section(
             "Compliance Guidelines",
             "Always maintain patient privacy and confidentiality:",
@@ -255,26 +263,32 @@ class HealthcareAgent(AgentBase):
                 "Never share patient information with unauthorized parties",
                 "Direct medical diagnoses to qualified healthcare providers",
                 "Use appropriate medical terminology",
-                "Maintain professional, caring communication"
-            ]
+                "Maintain professional, caring communication",
+            ],
         )
 
     def configure_healthcare_agent(self, query_params, body_params, headers, agent):
         """Configure agent based on healthcare-specific parameters"""
-        customer_id = query_params.get('customer_id', '')
-        urgency = query_params.get('urgency', 'normal').lower()
-        department = query_params.get('department', 'general').lower()
-        
+        customer_id = query_params.get("customer_id", "")
+        urgency = query_params.get("urgency", "normal").lower()
+        department = query_params.get("department", "general").lower()
+
         # Configure voice based on urgency
-        if urgency == 'high':
-            agent.add_language("English", "en-US", "inworld.Sarah")  # Clear, professional voice
-            agent.set_params({"ai_model": "gpt-4.1-nano", "end_of_speech_timeout": 300})  # Faster response
+        if urgency == "high":
+            agent.add_language(
+                "English", "en-US", "inworld.Sarah"
+            )  # Clear, professional voice
+            agent.set_params(
+                {"ai_model": "gpt-4.1-nano", "end_of_speech_timeout": 300}
+            )  # Faster response
         else:
             agent.add_language("English", "en-US", "inworld.Mark")  # Professional voice
-            agent.set_params({"ai_model": "gpt-4.1-nano", "end_of_speech_timeout": 500})  # Normal response
-        
+            agent.set_params(
+                {"ai_model": "gpt-4.1-nano", "end_of_speech_timeout": 500}
+            )  # Normal response
+
         # Department-specific configuration
-        if department == 'emergency':
+        if department == "emergency":
             agent.prompt_add_section(
                 "Emergency Protocol",
                 "Emergency department protocols are in effect:",
@@ -282,18 +296,20 @@ class HealthcareAgent(AgentBase):
                     "Prioritize urgent medical situations",
                     "Escalate immediately to medical staff when needed",
                     "Provide clear, concise information",
-                    "Maintain calm, professional demeanor"
-                ]
+                    "Maintain calm, professional demeanor",
+                ],
             )
-        
+
         # Set global data
-        agent.set_global_data({
-            "customer_id": customer_id,
-            "urgency_level": urgency,
-            "department": department,
-            "compliance_level": "hipaa",
-            "session_type": "healthcare"
-        })
+        agent.set_global_data(
+            {
+                "customer_id": customer_id,
+                "urgency_level": urgency,
+                "department": department,
+                "compliance_level": "hipaa",
+                "session_type": "healthcare",
+            }
+        )
 
 
 class FinanceAgent(AgentBase):
@@ -302,17 +318,17 @@ class FinanceAgent(AgentBase):
             name="Financial Services AI",
             route="/finance",
             auto_answer=True,
-            record_call=True
+            record_call=True,
         )
-        
+
         self.set_dynamic_config_callback(self.configure_finance_agent)
-        
+
         self.prompt_add_section(
             "Financial Services Role",
             "You are a financial services AI assistant specializing in banking, "
-            "investments, and financial planning guidance."
+            "investments, and financial planning guidance.",
         )
-        
+
         self.prompt_add_section(
             "Regulatory Compliance",
             "Adhere to financial industry regulations:",
@@ -320,41 +336,47 @@ class FinanceAgent(AgentBase):
                 "Protect sensitive financial information",
                 "Never provide specific investment advice without disclaimers",
                 "Refer complex matters to licensed financial advisors",
-                "Maintain accurate, professional communication"
-            ]
+                "Maintain accurate, professional communication",
+            ],
         )
 
     def configure_finance_agent(self, query_params, body_params, headers, agent):
         """Configure agent based on finance-specific parameters"""
-        account_type = query_params.get('account_type', 'standard').lower()
-        service = query_params.get('service', 'general').lower()
-        customer_id = query_params.get('customer_id', '')
-        
+        account_type = query_params.get("account_type", "standard").lower()
+        service = query_params.get("service", "general").lower()
+        customer_id = query_params.get("customer_id", "")
+
         # Voice and parameters based on account type
-        if account_type == 'premium':
+        if account_type == "premium":
             agent.add_language("English", "en-US", "inworld.Sarah")
-            agent.set_params({
-                "ai_model": "gpt-4.1-nano",
-                "end_of_speech_timeout": 600,
-                "attention_timeout": 20000
-            })
-        elif account_type == 'wealth':
+            agent.set_params(
+                {
+                    "ai_model": "gpt-4.1-nano",
+                    "end_of_speech_timeout": 600,
+                    "attention_timeout": 20000,
+                }
+            )
+        elif account_type == "wealth":
             agent.add_language("English", "en-US", "inworld.Hanna")
-            agent.set_params({
-                "ai_model": "gpt-4.1-nano",
-                "end_of_speech_timeout": 800,
-                "attention_timeout": 25000
-            })
+            agent.set_params(
+                {
+                    "ai_model": "gpt-4.1-nano",
+                    "end_of_speech_timeout": 800,
+                    "attention_timeout": 25000,
+                }
+            )
         else:
             agent.add_language("English", "en-US", "inworld.Mark")
-            agent.set_params({
-                "ai_model": "gpt-4.1-nano",
-                "end_of_speech_timeout": 400,
-                "attention_timeout": 15000
-            })
-        
+            agent.set_params(
+                {
+                    "ai_model": "gpt-4.1-nano",
+                    "end_of_speech_timeout": 400,
+                    "attention_timeout": 15000,
+                }
+            )
+
         # Service-specific prompts
-        if service == 'investment':
+        if service == "investment":
             agent.prompt_add_section(
                 "Investment Services",
                 "Investment consultation services:",
@@ -362,10 +384,10 @@ class FinanceAgent(AgentBase):
                     "Provide educational information about investment options",
                     "Explain market trends and analysis",
                     "Connect with licensed investment advisors for specific advice",
-                    "Discuss risk tolerance and financial goals"
-                ]
+                    "Discuss risk tolerance and financial goals",
+                ],
             )
-        elif service == 'lending':
+        elif service == "lending":
             agent.prompt_add_section(
                 "Lending Services",
                 "Loan and credit services:",
@@ -373,17 +395,19 @@ class FinanceAgent(AgentBase):
                     "Explain loan products and terms",
                     "Assist with application processes",
                     "Provide credit education and guidance",
-                    "Connect with loan specialists as needed"
-                ]
+                    "Connect with loan specialists as needed",
+                ],
             )
-        
-        agent.set_global_data({
-            "customer_id": customer_id,
-            "account_type": account_type,
-            "service_area": service,
-            "compliance_level": "financial",
-            "session_type": "finance"
-        })
+
+        agent.set_global_data(
+            {
+                "customer_id": customer_id,
+                "account_type": account_type,
+                "service_area": service,
+                "compliance_level": "financial",
+                "session_type": "finance",
+            }
+        )
 
 
 class RetailAgent(AgentBase):
@@ -392,17 +416,17 @@ class RetailAgent(AgentBase):
             name="Retail Customer Service AI",
             route="/retail",
             auto_answer=True,
-            record_call=True
+            record_call=True,
         )
-        
+
         self.set_dynamic_config_callback(self.configure_retail_agent)
-        
+
         self.prompt_add_section(
             "Customer Service Role",
             "You are a friendly retail customer service AI assistant focused on "
-            "providing excellent customer experiences and sales support."
+            "providing excellent customer experiences and sales support.",
         )
-        
+
         self.prompt_add_section(
             "Service Excellence",
             "Customer service principles:",
@@ -410,26 +434,26 @@ class RetailAgent(AgentBase):
                 "Maintain friendly, helpful demeanor",
                 "Listen actively to customer needs",
                 "Provide accurate product information",
-                "Look for opportunities to enhance the shopping experience"
-            ]
+                "Look for opportunities to enhance the shopping experience",
+            ],
         )
 
     def configure_retail_agent(self, query_params, body_params, headers, agent):
         """Configure agent based on retail-specific parameters"""
-        department = query_params.get('department', 'general').lower()
-        customer_tier = query_params.get('customer_tier', 'standard').lower()
-        customer_id = query_params.get('customer_id', '')
-        
+        department = query_params.get("department", "general").lower()
+        customer_tier = query_params.get("customer_tier", "standard").lower()
+        customer_id = query_params.get("customer_id", "")
+
         # Voice based on customer tier
-        if customer_tier == 'vip':
+        if customer_tier == "vip":
             agent.add_language("English", "en-US", "inworld.Sarah")
             agent.set_params({"ai_model": "gpt-4.1-nano", "end_of_speech_timeout": 600})
         else:
             agent.add_language("English", "en-US", "inworld.Mark")
             agent.set_params({"ai_model": "gpt-4.1-nano", "end_of_speech_timeout": 400})
-        
+
         # Department-specific knowledge
-        if department == 'electronics':
+        if department == "electronics":
             agent.prompt_add_section(
                 "Electronics Expertise",
                 "Electronics department specialization:",
@@ -437,10 +461,10 @@ class RetailAgent(AgentBase):
                     "Detailed knowledge of electronic products",
                     "Technical specifications and compatibility",
                     "Warranty and service information",
-                    "Installation and setup guidance"
-                ]
+                    "Installation and setup guidance",
+                ],
             )
-        elif department == 'clothing':
+        elif department == "clothing":
             agent.prompt_add_section(
                 "Fashion and Apparel",
                 "Clothing department specialization:",
@@ -448,34 +472,36 @@ class RetailAgent(AgentBase):
                     "Style and fashion guidance",
                     "Size and fit recommendations",
                     "Care and maintenance instructions",
-                    "Return and exchange policies"
-                ]
+                    "Return and exchange policies",
+                ],
             )
-        
-        agent.set_global_data({
-            "customer_id": customer_id,
-            "department": department,
-            "customer_tier": customer_tier,
-            "session_type": "retail"
-        })
+
+        agent.set_global_data(
+            {
+                "customer_id": customer_id,
+                "department": department,
+                "customer_tier": customer_tier,
+                "session_type": "retail",
+            }
+        )
 
 
 def create_multi_agent_app():
     """Create a FastAPI app with multiple agents"""
     app = FastAPI(title="Multi-Agent AI Server", redirect_slashes=False)
-    
+
     # Create all agents
     healthcare_agent = HealthcareAgent()
     finance_agent = FinanceAgent()
     retail_agent = RetailAgent()
     dynamic_agent = ComprehensiveDynamicAgent("/dynamic")
-    
+
     # Add all agents to the app
     app.include_router(healthcare_agent.as_router())
     app.include_router(finance_agent.as_router())
     app.include_router(retail_agent.as_router())
     app.include_router(dynamic_agent.as_router())
-    
+
     # Add a root endpoint that lists all available agents
     @app.get("/")
     async def list_agents():
@@ -483,19 +509,19 @@ def create_multi_agent_app():
             "message": "Multi-Agent AI Server",
             "available_agents": {
                 "/healthcare": "Healthcare AI Assistant - HIPAA compliant medical support",
-                "/finance": "Financial Services AI - Banking and investment guidance", 
+                "/finance": "Financial Services AI - Banking and investment guidance",
                 "/retail": "Retail Customer Service AI - Shopping and product support",
-                "/dynamic": "Dynamic AI Agent - Adapts based on request parameters"
+                "/dynamic": "Dynamic AI Agent - Adapts based on request parameters",
             },
-            "usage": "Send GET or POST requests to any agent path with appropriate query parameters"
+            "usage": "Send GET or POST requests to any agent path with appropriate query parameters",
         }
-    
+
     return app
 
 
 if __name__ == "__main__":
     import uvicorn
-    
+
     print("Starting Multi-Agent AI Server")
     print("\nAvailable agents:")
     print("- http://localhost:3000/healthcare - Healthcare AI (HIPAA compliant)")
@@ -504,10 +530,16 @@ if __name__ == "__main__":
     print("- http://localhost:3000/dynamic - Dynamic AI (adapts to parameters)")
     print("\nExample requests:")
     print("curl 'http://localhost:3000/healthcare?customer_id=patient123&urgency=high'")
-    print("curl 'http://localhost:3000/finance?account_type=premium&service=investment'")
-    print("curl 'http://localhost:3000/retail?department=electronics&customer_tier=vip'")
-    print("curl 'http://localhost:3000/dynamic?tier=enterprise&industry=tech&voice=inworld.Mark'")
+    print(
+        "curl 'http://localhost:3000/finance?account_type=premium&service=investment'"
+    )
+    print(
+        "curl 'http://localhost:3000/retail?department=electronics&customer_tier=vip'"
+    )
+    print(
+        "curl 'http://localhost:3000/dynamic?tier=enterprise&industry=tech&voice=inworld.Mark'"
+    )
     print()
-    
+
     app = create_multi_agent_app()
-    uvicorn.run(app, host="0.0.0.0", port=3000) 
+    uvicorn.run(app, host="0.0.0.0", port=3000)

--- a/examples/multi_endpoint_agent.py
+++ b/examples/multi_endpoint_agent.py
@@ -10,10 +10,9 @@ This agent demonstrates serving multiple endpoints:
 - /static/file.txt - Static file serving
 """
 
-import os
 from pathlib import Path
 from datetime import datetime
-from fastapi import FastAPI, Request, Response, APIRouter
+from fastapi import FastAPI, APIRouter
 from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
 
 from signalwire import AgentBase
@@ -22,58 +21,57 @@ from signalwire.core.function_result import FunctionResult
 
 class MultiEndpointAgent(AgentBase):
     """Agent that serves both SWML for voice and web UI endpoints"""
-    
+
     def __init__(self):
         # Initialize with route=/swml for the voice AI endpoint
         super().__init__(
             name="multi-endpoint",
             route="/swml",  # This sets the SWML endpoint at /swml
             host="0.0.0.0",
-            port=8080
+            port=8080,
         )
-        
+
         # Configure the voice AI agent
         self.prompt_add_section("Role", "You are a helpful voice assistant.")
-        self.prompt_add_section("Instructions", bullets=[
-            "Greet callers warmly",
-            "Be concise in your responses",
-            "Use the available functions when appropriate"
-        ])
-        
+        self.prompt_add_section(
+            "Instructions",
+            bullets=[
+                "Greet callers warmly",
+                "Be concise in your responses",
+                "Use the available functions when appropriate",
+            ],
+        )
+
         # Add a simple greeting skill
         self.add_language("English", "en-US", "inworld.Mark")
-        
+
         # Set up static files directory
         self.static_dir = Path(__file__).parent / "static_files"
         self.static_dir.mkdir(exist_ok=True)
-        
+
         # Create a simple text file to serve
         file_txt = self.static_dir / "file.txt"
         file_txt.write_text("Hello World from static file!")
-    
-    @AgentBase.tool(
-        name="get_time",
-        description="Get the current time",
-        parameters={}
-    )
+
+    @AgentBase.tool(name="get_time", description="Get the current time", parameters={})
     def get_time(self, args, raw_data):
         """Simple SWAIG function for voice interactions"""
         now = datetime.now().strftime("%I:%M %p")
         return FunctionResult(f"The current time is {now}")
-    
+
     def _register_routes(self, router: APIRouter):
         """
         Override route registration to add custom endpoints
-        
+
         Note: The parent class already registers /swml routes,
         we're adding additional endpoints here
         """
         # First, register the parent SWML routes
         super()._register_routes(router)
-        
+
         # Now add our custom UI and API endpoints
         # These will be available at the root level when we customize the app
-    
+
     def get_app(self):
         """
         Override get_app to add custom root-level routes
@@ -82,11 +80,12 @@ class MultiEndpointAgent(AgentBase):
             # Create the FastAPI app
             app = FastAPI(
                 title="Multi-Endpoint Agent",
-                description="Agent with SWML, UI, and API endpoints"
+                description="Agent with SWML, UI, and API endpoints",
             )
-            
+
             # Add CORS middleware
             from fastapi.middleware.cors import CORSMiddleware
+
             app.add_middleware(
                 CORSMiddleware,
                 allow_origins=["*"],
@@ -94,12 +93,12 @@ class MultiEndpointAgent(AgentBase):
                 allow_methods=["*"],
                 allow_headers=["*"],
             )
-            
+
             # Register health check endpoints
             @app.get("/health")
             async def health_check():
                 return {"status": "healthy", "agent": self.get_name()}
-            
+
             # Add root UI endpoint
             @app.get("/", response_class=HTMLResponse)
             async def root_ui():
@@ -180,75 +179,81 @@ class MultiEndpointAgent(AgentBase):
                 </html>
                 """
                 return HTMLResponse(content=html_content)
-            
+
             # Add API endpoint
             @app.get("/api")
             async def api_endpoint():
                 """Return JSON response"""
-                return JSONResponse(content={
-                    "status": "ok",
-                    "message": "Hello from API endpoint",
-                    "timestamp": datetime.now().isoformat(),
-                    "agent": self.get_name(),
-                    "endpoints": {
-                        "swml": "/swml",
-                        "swaig": "/swml/swaig",
-                        "ui": "/",
-                        "api": "/api",
-                        "static": "/static/file.txt"
+                return JSONResponse(
+                    content={
+                        "status": "ok",
+                        "message": "Hello from API endpoint",
+                        "timestamp": datetime.now().isoformat(),
+                        "agent": self.get_name(),
+                        "endpoints": {
+                            "swml": "/swml",
+                            "swaig": "/swml/swaig",
+                            "ui": "/",
+                            "api": "/api",
+                            "static": "/static/file.txt",
+                        },
                     }
-                })
-            
+                )
+
             # Add static file serving
             @app.get("/static/{file_path:path}")
             async def serve_static_file(file_path: str):
                 """Serve static files"""
                 file_full_path = self.static_dir / file_path
-                
+
                 # Security: ensure path doesn't escape static directory
                 try:
                     file_full_path = file_full_path.resolve()
-                    if not str(file_full_path).startswith(str(self.static_dir.resolve())):
+                    if not str(file_full_path).startswith(
+                        str(self.static_dir.resolve())
+                    ):
                         return PlainTextResponse("Access denied", status_code=403)
                 except Exception:
                     return PlainTextResponse("Invalid path", status_code=400)
-                
+
                 # Check if file exists
                 if not file_full_path.exists() or not file_full_path.is_file():
                     return PlainTextResponse("File not found", status_code=404)
-                
+
                 # Read and return file content
                 try:
                     content = file_full_path.read_text()
                     return PlainTextResponse(content)
                 except Exception as e:
-                    return PlainTextResponse(f"Error reading file: {e}", status_code=500)
-            
+                    return PlainTextResponse(
+                        f"Error reading file: {e}", status_code=500
+                    )
+
             # Create router for SWML endpoints
             router = self.as_router()
-            
+
             # Mount the SWML router at /swml
             # This gives us /swml and /swml/swaig endpoints
             app.include_router(router, prefix=self.route)
-            
+
             self._app = app
-        
+
         return self._app
-    
+
     def serve(self, host=None, port=None):
         """Override serve to use our custom app"""
         import uvicorn
-        
+
         host = host or self.host or "0.0.0.0"
         port = port or self.port or 8080
-        
+
         # Get our custom app with all endpoints
         app = self.get_app()
-        
+
         # Get auth credentials
         username, password, _ = self.get_basic_auth_credentials(include_source=True)
-        
-        print(f"\nMulti-Endpoint Agent starting...")
+
+        print("\nMulti-Endpoint Agent starting...")
         print(f"Server: http://{host}:{port}")
         print(f"Basic Auth: {username}:{password}")
         print("\nEndpoints:")
@@ -259,7 +264,7 @@ class MultiEndpointAgent(AgentBase):
         print(f"  SWAIG:      http://{host}:{port}/swml/swaig")
         print(f"  Health:     http://{host}:{port}/health")
         print("\nPress Ctrl+C to stop\n")
-        
+
         try:
             uvicorn.run(app, host=host, port=port)
         except KeyboardInterrupt:

--- a/examples/pgvector_search_agent.py
+++ b/examples/pgvector_search_agent.py
@@ -19,64 +19,77 @@ To create a collection:
 import os
 from signalwire import AgentBase
 
+
 class PGVectorSearchAgent(AgentBase):
     """Agent that uses pgvector for document search"""
-    
+
     def __init__(self):
         super().__init__(name="PGVector Search Assistant")
-        
+
         # Configure the main prompt
         self.prompt_add_section(
             "Role",
             "You are a helpful search assistant with access to a document knowledge base. "
             "When users ask questions, search the knowledge base to find relevant information. "
-            "Provide detailed answers based on the search results."
+            "Provide detailed answers based on the search results.",
         )
-        
+
         # Add native vector search skill with pgvector backend
-        self.add_skill("native_vector_search", {
-            "tool_name": "search_docs",
-            "description": "Search the document knowledge base for information",
-            "backend": "pgvector",
-            "connection_string": os.getenv("PGVECTOR_CONNECTION_STRING", 
-                "postgresql://signalwire:signalwire123@localhost:5432/knowledge"),
-            "collection_name": os.getenv("PGVECTOR_COLLECTION", "docs_collection"),
-            "count": 5,
-            "similarity_threshold": 0.7,
-            "no_results_message": "I couldn't find any relevant information about '{query}' in the knowledge base.",
-            "response_prefix": "Based on my search of the knowledge base:\n\n",
-            "response_postfix": "\n\nIs there anything specific about this topic you'd like to know more about?"
-        })
-        
+        self.add_skill(
+            "native_vector_search",
+            {
+                "tool_name": "search_docs",
+                "description": "Search the document knowledge base for information",
+                "backend": "pgvector",
+                "connection_string": os.getenv(
+                    "PGVECTOR_CONNECTION_STRING",
+                    "postgresql://signalwire:signalwire123@localhost:5432/knowledge",
+                ),
+                "collection_name": os.getenv("PGVECTOR_COLLECTION", "docs_collection"),
+                "count": 5,
+                "similarity_threshold": 0.7,
+                "no_results_message": "I couldn't find any relevant information about '{query}' in the knowledge base.",
+                "response_prefix": "Based on my search of the knowledge base:\n\n",
+                "response_postfix": "\n\nIs there anything specific about this topic you'd like to know more about?",
+            },
+        )
+
         # Optional: Add a second collection for different content
         if os.getenv("ENABLE_API_SEARCH", "false").lower() == "true":
-            self.add_skill("native_vector_search", {
-                "tool_name": "search_api",
-                "description": "Search API documentation",
-                "backend": "pgvector",
-                "connection_string": os.getenv("PGVECTOR_CONNECTION_STRING", 
-                    "postgresql://signalwire:signalwire123@localhost:5432/knowledge"),
-                "collection_name": "api_docs",
-                "count": 3,
-                "tags": ["api", "reference"],  # Filter by tags
-                "response_prefix": "From the API documentation:\n\n"
-            })
-    
+            self.add_skill(
+                "native_vector_search",
+                {
+                    "tool_name": "search_api",
+                    "description": "Search API documentation",
+                    "backend": "pgvector",
+                    "connection_string": os.getenv(
+                        "PGVECTOR_CONNECTION_STRING",
+                        "postgresql://signalwire:signalwire123@localhost:5432/knowledge",
+                    ),
+                    "collection_name": "api_docs",
+                    "count": 3,
+                    "tags": ["api", "reference"],  # Filter by tags
+                    "response_prefix": "From the API documentation:\n\n",
+                },
+            )
+
     @AgentBase.tool("list_collections")
     def list_available_collections(self):
         """List available search collections"""
         collections = ["docs_collection"]
         if os.getenv("ENABLE_API_SEARCH", "false").lower() == "true":
             collections.append("api_docs")
-        
+
         return {
             "result": "success",
             "collections": collections,
-            "message": f"Available collections: {', '.join(collections)}"
+            "message": f"Available collections: {', '.join(collections)}",
         }
-    
+
     @AgentBase.tool("search_with_metadata")
-    def search_with_metadata_filter(self, query: str, category: str = None, tags: list = None):
+    def search_with_metadata_filter(
+        self, query: str, category: str = None, tags: list = None
+    ):
         """Advanced search with metadata filtering (requires custom implementation)"""
         # This is a placeholder showing how you might implement custom search
         # In practice, you'd use the SearchEngine directly for advanced queries
@@ -84,22 +97,24 @@ class PGVectorSearchAgent(AgentBase):
             "result": "info",
             "message": "This would perform an advanced search with metadata filters",
             "query": query,
-            "filters": {
-                "category": category,
-                "tags": tags
-            }
+            "filters": {"category": category, "tags": tags},
         }
+
 
 if __name__ == "__main__":
     # Example of running the agent
     agent = PGVectorSearchAgent()
-    
+
     # Print configuration info
     print("PGVector Search Agent")
     print("=" * 50)
-    print(f"Connection: {os.getenv('PGVECTOR_CONNECTION_STRING', 'postgresql://signalwire:signalwire123@localhost:5432/knowledge')}")
+    print(
+        f"Connection: {os.getenv('PGVECTOR_CONNECTION_STRING', 'postgresql://signalwire:signalwire123@localhost:5432/knowledge')}"
+    )
     print(f"Collection: {os.getenv('PGVECTOR_COLLECTION', 'docs_collection')}")
-    print(f"API Search: {'Enabled' if os.getenv('ENABLE_API_SEARCH', 'false').lower() == 'true' else 'Disabled'}")
+    print(
+        f"API Search: {'Enabled' if os.getenv('ENABLE_API_SEARCH', 'false').lower() == 'true' else 'Disabled'}"
+    )
     print("=" * 50)
     print("\nStarting agent server on http://localhost:8000")
     print("\nEnvironment variables you can set:")
@@ -107,6 +122,6 @@ if __name__ == "__main__":
     print("- PGVECTOR_COLLECTION: Main collection name")
     print("- ENABLE_API_SEARCH: Enable API documentation search")
     print("\nPress Ctrl+C to stop")
-    
+
     # Serve the agent
     agent.serve()

--- a/examples/pgvector_search_agent.py
+++ b/examples/pgvector_search_agent.py
@@ -88,7 +88,7 @@ class PGVectorSearchAgent(AgentBase):
 
     @AgentBase.tool("search_with_metadata")
     def search_with_metadata_filter(
-        self, query: str, category: str = None, tags: list = None
+        self, query: str, category: str | None = None, tags: list | None = None
     ):
         """Advanced search with metadata filtering (requires custom implementation)"""
         # This is a placeholder showing how you might implement custom search

--- a/examples/quickstart_agent.py
+++ b/examples/quickstart_agent.py
@@ -17,6 +17,7 @@ See LICENSE file in the project root for full license information.
 from signalwire import AgentBase
 from signalwire.core.function_result import FunctionResult
 
+
 class MyAgent(AgentBase):
     def __init__(self):
         super().__init__(name="my-agent", route="/agent")
@@ -28,7 +29,9 @@ class MyAgent(AgentBase):
     def get_time(self):
         """Get the current time"""
         from datetime import datetime
+
         return FunctionResult(f"The time is {datetime.now().strftime('%H:%M:%S')}")
+
 
 if __name__ == "__main__":
     agent = MyAgent()

--- a/examples/quickstart_relay.py
+++ b/examples/quickstart_relay.py
@@ -16,7 +16,10 @@ See LICENSE file in the project root for full license information.
 # region: relay
 from signalwire.relay import RelayClient
 
-client = RelayClient(project="...", token="...", host="example.signalwire.com", contexts=["default"])
+client = RelayClient(
+    project="...", token="...", host="example.signalwire.com", contexts=["default"]
+)
+
 
 @client.on_call
 async def handle(call):
@@ -24,6 +27,7 @@ async def handle(call):
     action = await call.play([{"type": "tts", "params": {"text": "Welcome!"}}])
     await action.wait()
     await call.hangup()
+
 
 client.run()
 # endregion: relay

--- a/examples/receptionist_agent_example.py
+++ b/examples/receptionist_agent_example.py
@@ -116,8 +116,7 @@ def main():
     args, _ = parser.parse_known_args()
 
     # Create our custom receptionist agent
-    agent = CustomReceptionistAgent(host=args.host, port=args.port)
-    return agent
+    return CustomReceptionistAgent(host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/examples/receptionist_agent_example.py
+++ b/examples/receptionist_agent_example.py
@@ -13,53 +13,51 @@ See LICENSE file in the project root for full license information.
 Example of using the ReceptionistAgent prefab to create a call routing system
 """
 
-import os
-import sys
 import json
 import argparse
 
 # Import the ReceptionistAgent prefab
 from signalwire.prefabs import ReceptionistAgent
-from signalwire.core.function_result import FunctionResult
+
 
 class CustomReceptionistAgent(ReceptionistAgent):
     """
     Extending the ReceptionistAgent prefab with custom functionality
-    
+
     This example demonstrates:
     1. Using the prefab with minimal configuration
     2. Adding custom voice and greeting
     3. Overriding the on_summary method to log call data
     """
-    
+
     def __init__(self, **kwargs):
         # Define departments with their descriptions and transfer numbers
         departments = [
             {
-                "name": "sales", 
-                "description": "For product inquiries, pricing, and purchasing", 
-                "number": "+15551235555"
+                "name": "sales",
+                "description": "For product inquiries, pricing, and purchasing",
+                "number": "+15551235555",
             },
             {
-                "name": "support", 
-                "description": "For technical assistance, troubleshooting, and bug reports", 
-                "number": "+15551236666"
+                "name": "support",
+                "description": "For technical assistance, troubleshooting, and bug reports",
+                "number": "+15551236666",
             },
             {
-                "name": "billing", 
-                "description": "For payment questions, invoices, and subscription changes", 
-                "number": "+15551237777"
+                "name": "billing",
+                "description": "For payment questions, invoices, and subscription changes",
+                "number": "+15551237777",
             },
             {
-                "name": "general", 
-                "description": "For all other inquiries or if you're not sure which department you need", 
-                "number": "+15551238888"
-            }
+                "name": "general",
+                "description": "For all other inquiries or if you're not sure which department you need",
+                "number": "+15551238888",
+            },
         ]
-        
+
         # Custom greeting message
         greeting = "Hello, thank you for calling ACME Corporation. How may I direct your call today?"
-        
+
         # Initialize the base ReceptionistAgent with our configuration
         super().__init__(
             departments=departments,
@@ -67,29 +65,26 @@ class CustomReceptionistAgent(ReceptionistAgent):
             route="/reception",
             greeting=greeting,
             voice="inworld.Mark",  # Using proper voice format
-            **kwargs
+            **kwargs,
         )
-        
+
         # Add additional custom prompt section if needed
         self.prompt_add_section(
             "Company Information",
-            body="ACME Corporation is a leading provider of innovative solutions. Our business hours are Monday through Friday, 9 AM to 5 PM Eastern Time."
+            body="ACME Corporation is a leading provider of innovative solutions. Our business hours are Monday through Friday, 9 AM to 5 PM Eastern Time.",
         )
-        
+
         # Add a prompt section that clarifies available departments for transfers
         departments_text = "Available departments for transfer:\n"
         for dept in departments:
             departments_text += f"- {dept['name'].title()}: {dept['description']}\n"
-        
-        self.prompt_add_section(
-            "Transfer Options",
-            body=departments_text
-        )
-    
+
+        self.prompt_add_section("Transfer Options", body=departments_text)
+
     def on_summary(self, summary, raw_data=None):
         """
         Process the conversation summary with custom handling
-        
+
         Args:
             summary: Summary data from the conversation
             raw_data: The complete raw POST data from the request
@@ -101,7 +96,7 @@ class CustomReceptionistAgent(ReceptionistAgent):
             # - Send to a CRM
             # - Generate analytics
             print(f"Call Summary: {json.dumps(summary, indent=2)}")
-            
+
             # You could trigger follow-up actions based on satisfaction
             satisfaction = summary.get("satisfaction", "")
             if satisfaction == "low":
@@ -111,13 +106,15 @@ class CustomReceptionistAgent(ReceptionistAgent):
 
 def main():
     """Run the ReceptionistAgent example"""
-    
+
     # Parse command-line arguments
     parser = argparse.ArgumentParser(description="ReceptionistAgent Example")
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind the server to")
-    parser.add_argument("--port", type=int, default=3000, help="Port to bind the server to")
+    parser.add_argument(
+        "--port", type=int, default=3000, help="Port to bind the server to"
+    )
     args, _ = parser.parse_known_args()
-    
+
     # Create our custom receptionist agent
     agent = CustomReceptionistAgent(host=args.host, port=args.port)
     return agent
@@ -139,4 +136,4 @@ if __name__ == "__main__":
 
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
-    agent.run() 
+    agent.run()

--- a/examples/record_call_example.py
+++ b/examples/record_call_example.py
@@ -24,11 +24,13 @@ from signalwire.core.function_result import FunctionResult
 def basic_recording_example():
     """Simple background recording with default settings."""
     print("=== Basic Recording Example ===")
-    
-    result = FunctionResult("Starting basic call recording") \
-        .record_call() \
+
+    result = (
+        FunctionResult("Starting basic call recording")
+        .record_call()
         .say("This call is now being recorded")
-    
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -36,20 +38,22 @@ def basic_recording_example():
 def advanced_recording_example():
     """Advanced recording with custom settings."""
     print("=== Advanced Recording Example ===")
-    
-    result = FunctionResult("Starting advanced call recording") \
+
+    result = (
+        FunctionResult("Starting advanced call recording")
         .record_call(
             control_id="support_call_2024_001",
             stereo=True,
             format="mp3",
             direction="both",  # Record both parties
             terminators="*#",  # Stop on * or # key
-            beep=True,         # Play beep before recording
-            max_length=600,    # 10 minutes max
-            status_url="https://api.company.com/recording-webhook"
-        ) \
+            beep=True,  # Play beep before recording
+            max_length=600,  # 10 minutes max
+            status_url="https://api.company.com/recording-webhook",
+        )
         .say("This call is being recorded for quality and training purposes")
-    
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -57,20 +61,22 @@ def advanced_recording_example():
 def voicemail_recording_example():
     """Recording setup for voicemail system."""
     print("=== Voicemail Recording Example ===")
-    
-    result = FunctionResult("Please leave your message after the beep") \
+
+    result = (
+        FunctionResult("Please leave your message after the beep")
         .record_call(
             control_id="voicemail_123456",
             format="wav",
-            direction="speak",        # Only record caller's voice
-            terminators="#",          # Stop on # key
-            beep=True,               # Play beep before recording
-            initial_timeout=5.0,     # Wait 5 seconds for speech
-            end_silence_timeout=3.0, # Stop after 3 seconds of silence
-            max_length=120           # 2 minute max message
-        ) \
-        .set_end_of_speech_timeout(2000)  # Shorter timeout for voicemail
-    
+            direction="speak",  # Only record caller's voice
+            terminators="#",  # Stop on # key
+            beep=True,  # Play beep before recording
+            initial_timeout=5.0,  # Wait 5 seconds for speech
+            end_silence_timeout=3.0,  # Stop after 3 seconds of silence
+            max_length=120,  # 2 minute max message
+        )
+        .set_end_of_speech_timeout(2000)
+    )  # Shorter timeout for voicemail
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -78,12 +84,14 @@ def voicemail_recording_example():
 def stop_recording_example():
     """Stop a specific recording."""
     print("=== Stop Recording Example ===")
-    
+
     # Stop specific recording
-    result = FunctionResult("Ending call recording") \
-        .stop_record_call("support_call_2024_001") \
+    result = (
+        FunctionResult("Ending call recording")
+        .stop_record_call("support_call_2024_001")
         .say("Thank you for calling. Your feedback is important to us.")
-    
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -91,30 +99,34 @@ def stop_recording_example():
 def customer_service_workflow():
     """Complete customer service recording workflow."""
     print("=== Customer Service Workflow ===")
-    
+
     # Start recording when transferring to agent
-    start_recording = FunctionResult("Transferring you to a customer service agent") \
+    start_recording = (
+        FunctionResult("Transferring you to a customer service agent")
         .record_call(
             control_id="cs_transfer_001",
             format="mp3",
             direction="both",
             beep=False,  # No beep so the caller doesn't hear a tone
             max_length=1800,  # 30 minutes max
-            status_url="https://api.company.com/recording-status"
-        ) \
-        .update_global_data({"recording_id": "cs_transfer_001"}) \
+            status_url="https://api.company.com/recording-status",
+        )
+        .update_global_data({"recording_id": "cs_transfer_001"})
         .say("Please hold while I connect you to an agent")
-    
+    )
+
     print("Start recording:")
     print(json.dumps(start_recording.to_dict(), indent=2))
     print()
-    
+
     # Later in the conversation, stop recording
-    end_recording = FunctionResult("Call recording stopped") \
-        .stop_record_call("cs_transfer_001") \
-        .remove_global_data("recording_id") \
+    end_recording = (
+        FunctionResult("Call recording stopped")
+        .stop_record_call("cs_transfer_001")
+        .remove_global_data("recording_id")
         .say("Thank you for calling. Have a wonderful day!")
-    
+    )
+
     print("End recording:")
     print(json.dumps(end_recording.to_dict(), indent=2))
     print()
@@ -123,37 +135,41 @@ def customer_service_workflow():
 def compliance_recording_example():
     """Recording for compliance/legal purposes."""
     print("=== Compliance Recording Example ===")
-    
-    result = FunctionResult("This call is being recorded for compliance purposes") \
+
+    result = (
+        FunctionResult("This call is being recorded for compliance purposes")
         .record_call(
             control_id="compliance_rec_001",
-            stereo=True,           # High quality stereo
-            format="wav",          # Uncompressed for legal requirements
-            direction="both",      # Record all parties
-            beep=True,            # Legal requirement notification
-            input_sensitivity=50.0, # Higher sensitivity
-            status_url="https://compliance.company.com/recording-webhook"
-        ) \
-        .set_metadata({
-            "call_type": "compliance",
-            "recording_start": "2024-01-01T12:00:00Z",
-            "legal_notice_given": True
-        })
-    
+            stereo=True,  # High quality stereo
+            format="wav",  # Uncompressed for legal requirements
+            direction="both",  # Record all parties
+            beep=True,  # Legal requirement notification
+            input_sensitivity=50.0,  # Higher sensitivity
+            status_url="https://compliance.company.com/recording-webhook",
+        )
+        .set_metadata(
+            {
+                "call_type": "compliance",
+                "recording_start": "2024-01-01T12:00:00Z",
+                "legal_notice_given": True,
+            }
+        )
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
 
 if __name__ == "__main__":
     print("Record Call Virtual Helper Examples\n")
-    
+
     basic_recording_example()
-    advanced_recording_example() 
+    advanced_recording_example()
     voicemail_recording_example()
     stop_recording_example()
     customer_service_workflow()
     compliance_recording_example()
-    
+
     print("COMPLETE: All recording examples completed")
     print("\nKey Features Demonstrated:")
     print("- Basic and advanced recording configurations")
@@ -163,4 +179,4 @@ if __name__ == "__main__":
     print("- Timeout controls for voicemail systems")
     print("- Webhook integration for recording status updates")
     print("- Method chaining with other actions")
-    print("- Complete workflows for customer service and compliance") 
+    print("- Complete workflows for customer service and compliance")

--- a/examples/relay_answer_and_welcome.py
+++ b/examples/relay_answer_and_welcome.py
@@ -23,7 +23,9 @@ async def on_incoming_call(call):
     print(f"Incoming call: {call}")
     await call.answer()
 
-    action = await call.play([{"type": "tts", "params": {"text": "Welcome to SignalWire!"}}])
+    action = await call.play(
+        [{"type": "tts", "params": {"text": "Welcome to SignalWire!"}}]
+    )
     await action.wait()
 
     await call.hangup()

--- a/examples/room_and_sip_example.py
+++ b/examples/room_and_sip_example.py
@@ -24,11 +24,13 @@ from signalwire.core.function_result import FunctionResult
 def basic_room_join_example():
     """Simple room joining with default settings."""
     print("=== Basic Room Join Example ===")
-    
-    result = FunctionResult("Joining the support team room") \
-        .join_room("support_team_room") \
+
+    result = (
+        FunctionResult("Joining the support team room")
+        .join_room("support_team_room")
         .say("Welcome to the support team collaboration room")
-    
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -36,21 +38,24 @@ def basic_room_join_example():
 def conference_room_example():
     """Conference room setup with metadata tracking."""
     print("=== Conference Room Example ===")
-    
-    result = FunctionResult("Setting up daily standup meeting") \
-        .join_room("daily_standup_room") \
-        .set_metadata({
-            "meeting_type": "daily_standup",
-            "participant_id": "user_123",
-            "role": "scrum_master",
-            "join_time": "2024-01-01T09:00:00Z"
-        }) \
-        .update_global_data({
-            "meeting_active": True,
-            "room_name": "daily_standup_room"
-        }) \
-        .say("You have joined the daily standup meeting. Please wait for other participants")
-    
+
+    result = (
+        FunctionResult("Setting up daily standup meeting")
+        .join_room("daily_standup_room")
+        .set_metadata(
+            {
+                "meeting_type": "daily_standup",
+                "participant_id": "user_123",
+                "role": "scrum_master",
+                "join_time": "2024-01-01T09:00:00Z",
+            }
+        )
+        .update_global_data({"meeting_active": True, "room_name": "daily_standup_room"})
+        .say(
+            "You have joined the daily standup meeting. Please wait for other participants"
+        )
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -58,11 +63,13 @@ def conference_room_example():
 def basic_sip_refer_example():
     """Simple SIP REFER for call transfer."""
     print("=== Basic SIP REFER Example ===")
-    
-    result = FunctionResult("Transferring your call to support") \
-        .say("Please hold while I transfer you to our support specialist") \
+
+    result = (
+        FunctionResult("Transferring your call to support")
+        .say("Please hold while I transfer you to our support specialist")
         .sip_refer("sip:support@company.com")
-    
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -70,20 +77,26 @@ def basic_sip_refer_example():
 def advanced_sip_refer_example():
     """Advanced SIP REFER with full URI and metadata."""
     print("=== Advanced SIP REFER Example ===")
-    
-    result = FunctionResult("Transferring to technical support") \
-        .set_metadata({
-            "transfer_type": "technical_support",
-            "priority": "high",
-            "original_caller": "+15551234567"
-        }) \
-        .say("I'm connecting you to our senior technical specialist") \
-        .sip_refer("sip:tech-specialist@pbx.company.com:5060") \
-        .update_global_data({
-            "transfer_completed": True,
-            "transfer_destination": "tech-specialist@pbx.company.com"
-        })
-    
+
+    result = (
+        FunctionResult("Transferring to technical support")
+        .set_metadata(
+            {
+                "transfer_type": "technical_support",
+                "priority": "high",
+                "original_caller": "+15551234567",
+            }
+        )
+        .say("I'm connecting you to our senior technical specialist")
+        .sip_refer("sip:tech-specialist@pbx.company.com:5060")
+        .update_global_data(
+            {
+                "transfer_completed": True,
+                "transfer_destination": "tech-specialist@pbx.company.com",
+            }
+        )
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -91,30 +104,35 @@ def advanced_sip_refer_example():
 def customer_service_workflow():
     """Complete customer service workflow with room and SIP operations."""
     print("=== Customer Service Workflow ===")
-    
+
     # Step 1: Join customer service room
-    join_service_room = FunctionResult("Connecting to customer service") \
-        .join_room("customer_service_room") \
-        .set_metadata({
-            "service_type": "billing_inquiry",
-            "customer_tier": "premium",
-            "queue_position": 1
-        }) \
+    join_service_room = (
+        FunctionResult("Connecting to customer service")
+        .join_room("customer_service_room")
+        .set_metadata(
+            {
+                "service_type": "billing_inquiry",
+                "customer_tier": "premium",
+                "queue_position": 1,
+            }
+        )
         .say("You have been connected to our customer service team")
-    
+    )
+
     print("Join service room:")
     print(json.dumps(join_service_room.to_dict(), indent=2))
     print()
-    
+
     # Step 2: Escalate to manager via SIP transfer
-    escalate_to_manager = FunctionResult("Escalating to manager") \
-        .say("Let me connect you with a manager who can better assist you") \
-        .sip_refer("sip:manager@customer-service.company.com") \
-        .update_global_data({
-            "escalated": True,
-            "escalation_reason": "customer_request"
-        })
-    
+    escalate_to_manager = (
+        FunctionResult("Escalating to manager")
+        .say("Let me connect you with a manager who can better assist you")
+        .sip_refer("sip:manager@customer-service.company.com")
+        .update_global_data(
+            {"escalated": True, "escalation_reason": "customer_request"}
+        )
+    )
+
     print("Escalate to manager:")
     print(json.dumps(escalate_to_manager.to_dict(), indent=2))
     print()
@@ -123,30 +141,36 @@ def customer_service_workflow():
 def multi_party_conference_example():
     """Multi-party conference with external participants."""
     print("=== Multi-Party Conference Example ===")
-    
+
     # Host joins conference room
-    host_joins = FunctionResult("Setting up conference call") \
-        .join_room("project_kickoff_meeting") \
-        .set_metadata({
-            "role": "meeting_host",
-            "meeting_id": "proj_kick_001",
-            "recording": True
-        }) \
-        .say("Welcome to the project kickoff meeting. We're waiting for other participants")
-    
+    host_joins = (
+        FunctionResult("Setting up conference call")
+        .join_room("project_kickoff_meeting")
+        .set_metadata(
+            {"role": "meeting_host", "meeting_id": "proj_kick_001", "recording": True}
+        )
+        .say(
+            "Welcome to the project kickoff meeting. We're waiting for other participants"
+        )
+    )
+
     print("Host joins conference:")
     print(json.dumps(host_joins.to_dict(), indent=2))
     print()
-    
+
     # Add external participant via SIP
-    add_external = FunctionResult("Adding external consultant") \
-        .say("Now connecting our external consultant") \
-        .sip_refer("sip:consultant@partner-company.com") \
-        .update_global_data({
-            "external_participants": ["consultant@partner-company.com"],
-            "meeting_status": "all_participants_connected"
-        })
-    
+    add_external = (
+        FunctionResult("Adding external consultant")
+        .say("Now connecting our external consultant")
+        .sip_refer("sip:consultant@partner-company.com")
+        .update_global_data(
+            {
+                "external_participants": ["consultant@partner-company.com"],
+                "meeting_status": "all_participants_connected",
+            }
+        )
+    )
+
     print("Add external participant:")
     print(json.dumps(add_external.to_dict(), indent=2))
     print()
@@ -155,21 +179,22 @@ def multi_party_conference_example():
 def emergency_escalation_example():
     """Emergency escalation with priority handling."""
     print("=== Emergency Escalation Example ===")
-    
-    result = FunctionResult("Emergency escalation in progress") \
-        .set_metadata({
-            "alert_level": "critical",
-            "incident_id": "INC-2024-001",
-            "escalation_time": "2024-01-01T14:30:00Z"
-        }) \
-        .join_room("emergency_response_room") \
-        .say("Emergency escalation activated. Connecting to response team") \
-        .sip_refer("sip:emergency-manager@company.com:5060") \
-        .update_global_data({
-            "emergency_active": True,
-            "response_team_notified": True
-        })
-    
+
+    result = (
+        FunctionResult("Emergency escalation in progress")
+        .set_metadata(
+            {
+                "alert_level": "critical",
+                "incident_id": "INC-2024-001",
+                "escalation_time": "2024-01-01T14:30:00Z",
+            }
+        )
+        .join_room("emergency_response_room")
+        .say("Emergency escalation activated. Connecting to response team")
+        .sip_refer("sip:emergency-manager@company.com:5060")
+        .update_global_data({"emergency_active": True, "response_team_notified": True})
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -177,31 +202,41 @@ def emergency_escalation_example():
 def sales_team_handoff_example():
     """Sales team handoff from lead qualification to closing."""
     print("=== Sales Team Handoff Example ===")
-    
+
     # Qualify lead in sales room
-    qualify_lead = FunctionResult("Connecting to sales qualification team") \
-        .join_room("sales_qualification_room") \
-        .set_metadata({
-            "lead_score": 85,
-            "product_interest": "enterprise_plan",
-            "budget_qualified": True
-        }) \
+    qualify_lead = (
+        FunctionResult("Connecting to sales qualification team")
+        .join_room("sales_qualification_room")
+        .set_metadata(
+            {
+                "lead_score": 85,
+                "product_interest": "enterprise_plan",
+                "budget_qualified": True,
+            }
+        )
         .say("Thank you for your interest. Let me connect you with our sales team")
-    
+    )
+
     print("Lead qualification:")
     print(json.dumps(qualify_lead.to_dict(), indent=2))
     print()
-    
+
     # Transfer to senior sales via SIP
-    transfer_to_senior = FunctionResult("Transferring to senior sales representative") \
-        .say("Based on your requirements, I'm connecting you with our senior sales specialist") \
-        .sip_refer("sip:senior-sales@company.com") \
-        .update_global_data({
-            "qualified_lead": True,
-            "assigned_to": "senior-sales",
-            "handoff_complete": True
-        })
-    
+    transfer_to_senior = (
+        FunctionResult("Transferring to senior sales representative")
+        .say(
+            "Based on your requirements, I'm connecting you with our senior sales specialist"
+        )
+        .sip_refer("sip:senior-sales@company.com")
+        .update_global_data(
+            {
+                "qualified_lead": True,
+                "assigned_to": "senior-sales",
+                "handoff_complete": True,
+            }
+        )
+    )
+
     print("Transfer to senior sales:")
     print(json.dumps(transfer_to_senior.to_dict(), indent=2))
     print()
@@ -210,35 +245,41 @@ def sales_team_handoff_example():
 def join_conference_examples():
     """Examples using join_conference virtual helper."""
     print("=== Join Conference Examples ===")
-    
+
     # Simple conference join
-    simple_conf = FunctionResult("Joining team conference") \
-        .join_conference("daily_standup") \
+    simple_conf = (
+        FunctionResult("Joining team conference")
+        .join_conference("daily_standup")
         .say("Welcome to the daily standup conference")
-    
+    )
+
     print("Simple conference join:")
     print(json.dumps(simple_conf.to_dict(), indent=2))
     print()
-    
+
     # Advanced conference with recording and callbacks
-    advanced_conf = FunctionResult("Setting up recorded conference call") \
+    advanced_conf = (
+        FunctionResult("Setting up recorded conference call")
         .join_conference(
             name="customer_training_session",
             muted=False,
-            beep="onEnter", 
+            beep="onEnter",
             record="record-from-start",
             max_participants=50,
             region="us-east",
             status_callback="https://api.company.com/conference-events",
             status_callback_event="start end join leave",
-            recording_status_callback="https://api.company.com/recording-status"
-        ) \
-        .set_metadata({
-            "session_type": "customer_training",
-            "facilitator": "training_team",
-            "max_duration": 3600
-        })
-    
+            recording_status_callback="https://api.company.com/recording-status",
+        )
+        .set_metadata(
+            {
+                "session_type": "customer_training",
+                "facilitator": "training_team",
+                "max_duration": 3600,
+            }
+        )
+    )
+
     print("Advanced conference with recording:")
     print(json.dumps(advanced_conf.to_dict(), indent=2))
     print()
@@ -246,7 +287,7 @@ def join_conference_examples():
 
 if __name__ == "__main__":
     print("Room and SIP Virtual Helper Examples\n")
-    
+
     basic_room_join_example()
     conference_room_example()
     basic_sip_refer_example()
@@ -256,7 +297,7 @@ if __name__ == "__main__":
     emergency_escalation_example()
     sales_team_handoff_example()
     join_conference_examples()
-    
+
     print("COMPLETE: All room and SIP examples completed")
     print("\nKey Features Demonstrated:")
     print("- RELAY room joining for multi-party communication")
@@ -267,4 +308,4 @@ if __name__ == "__main__":
     print("- Global data management for workflow state")
     print("- Method chaining with other actions")
     print("- Complete workflows for customer service, sales, and emergency response")
-    print("- Integration between room collaboration and SIP transfers") 
+    print("- Integration between room collaboration and SIP transfers")

--- a/examples/search_server_standalone.py
+++ b/examples/search_server_standalone.py
@@ -67,53 +67,65 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 def main():
     """Run the standalone search server"""
-    
+
     # Parse command line arguments
-    parser = argparse.ArgumentParser(description='Run the standalone search server')
-    parser.add_argument('--backend', choices=['sqlite', 'pgvector'], default='sqlite',
-                        help='Storage backend to use (default: sqlite)')
-    parser.add_argument('--connection-string', 
-                        help='PostgreSQL connection string for pgvector backend')
-    parser.add_argument('--port', type=int, default=8001,
-                        help='Port to run the server on (default: 8001)')
+    parser = argparse.ArgumentParser(description="Run the standalone search server")
+    parser.add_argument(
+        "--backend",
+        choices=["sqlite", "pgvector"],
+        default="sqlite",
+        help="Storage backend to use (default: sqlite)",
+    )
+    parser.add_argument(
+        "--connection-string", help="PostgreSQL connection string for pgvector backend"
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8001,
+        help="Port to run the server on (default: 8001)",
+    )
     args, _ = parser.parse_known_args()
-    
+
     # Validate pgvector arguments
-    if args.backend == 'pgvector' and not args.connection_string:
+    if args.backend == "pgvector" and not args.connection_string:
         logger.error("--connection-string is required when using pgvector backend")
         return
-    
+
     # Check if search dependencies are available
     try:
         from signalwire.search import SearchService, IndexBuilder
+
         logger.info("Search dependencies are available")
     except ImportError as e:
         logger.error("Search dependencies not available")
         logger.error("Install with: pip install signalwire-sdk[search-full]")
         logger.error(f"Error: {e}")
         return
-    
+
     # Check pgvector dependencies if needed
-    if args.backend == 'pgvector':
+    if args.backend == "pgvector":
         try:
-            import psycopg2
-            import pgvector
+            import psycopg2  # noqa: F401  availability probe — the import raising is the check
+            import pgvector  # noqa: F401  availability probe
+
             logger.info("pgvector dependencies are available")
         except ImportError as e:
             logger.error("pgvector dependencies not available")
             logger.error("Install with: pip install signalwire-sdk[pgvector]")
             logger.error(f"Error: {e}")
             return
-    
+
     # Get the project root directory
     project_root = Path(__file__).parent.parent
-    
+
     # Define available indexes/collections
     indexes = {}
-    
-    if args.backend == 'pgvector':
+
+    if args.backend == "pgvector":
         # For pgvector, we need to check what collections exist
         # For this example, we'll assume 'concepts' collection exists
         # You can extend this to query the database for available collections
@@ -122,71 +134,81 @@ def main():
         }
         logger.info(f"Using pgvector backend with connection: {args.connection_string}")
         logger.info("Available collections: concepts")
-        logger.info("Note: Ensure the 'concepts' collection exists in your PostgreSQL database")
-        logger.info("You can create it with: sw-search ./docs --backend pgvector --connection-string <your-connection> --output concepts")
+        logger.info(
+            "Note: Ensure the 'concepts' collection exists in your PostgreSQL database"
+        )
+        logger.info(
+            "You can create it with: sw-search ./docs --backend pgvector --connection-string <your-connection> --output concepts"
+        )
     else:
         # SQLite backend - original behavior
         # Define the concepts guide file and index
         concepts_guide_file = project_root / "docs" / "signalwire_concepts_guide.md"
         concepts_index_file = project_root / "concepts_guide.swsearch"
-        
+
         # Check if the concepts guide file exists
         if not concepts_guide_file.exists():
             logger.error(f"Concepts guide file not found: {concepts_guide_file}")
-            logger.error("Please ensure the concepts guide file exists before running the server")
+            logger.error(
+                "Please ensure the concepts guide file exists before running the server"
+            )
             return
-        
+
         # Build index if it doesn't exist
         if not concepts_index_file.exists():
-            logger.info(f"Building search index from concepts guide: {concepts_guide_file}")
+            logger.info(
+                f"Building search index from concepts guide: {concepts_guide_file}"
+            )
             try:
                 builder = IndexBuilder(
-                    chunking_strategy='sentence',
+                    chunking_strategy="sentence",
                     max_sentences_per_chunk=5,
-                    verbose=True
+                    verbose=True,
                 )
-                
+
                 # Use the new multiple sources functionality to build from the specific file
                 builder.build_index_from_sources(
                     sources=[concepts_guide_file],
                     output_file=str(concepts_index_file),
-                    file_types=['md'],
+                    file_types=["md"],
                     exclude_patterns=None,
-                    languages=['en'],
-                    tags=['concepts', 'guide', 'sdk']
+                    languages=["en"],
+                    tags=["concepts", "guide", "sdk"],
                 )
-                
-                logger.info(f"Successfully built concepts guide search index: {concepts_index_file}")
-                
+
+                logger.info(
+                    f"Successfully built concepts guide search index: {concepts_index_file}"
+                )
+
             except Exception as e:
                 logger.error(f"Failed to build search index: {e}")
                 return
         else:
-            logger.info(f"Using existing concepts guide search index: {concepts_index_file}")
-        
+            logger.info(
+                f"Using existing concepts guide search index: {concepts_index_file}"
+            )
+
         # Define available indexes
-        indexes = {
-            "concepts": str(concepts_index_file)
-        }
-        
+        indexes = {"concepts": str(concepts_index_file)}
+
         # Check for any other .swsearch files in the project root
         for swsearch_file in project_root.glob("*.swsearch"):
             if swsearch_file.name != "concepts_guide.swsearch":
                 index_name = swsearch_file.stem
                 indexes[index_name] = str(swsearch_file)
                 logger.info(f"Found additional index: {index_name} -> {swsearch_file}")
-    
+
     # Create and start the search service
     logger.info(f"Starting search server with {len(indexes)} indexes/collections:")
     for name, path in indexes.items():
         logger.info(f"  {name}: {path}")
-    
+
     try:
         service = SearchService(
-            port=args.port, 
+            port=args.port,
             indexes=indexes,
             backend=args.backend,
-            connection_string=args.connection_string
+            connection_string=args.connection_string,
         )
         logger.info(f"Search server starting on http://localhost:{args.port}")
         logger.info(f"Backend: {args.backend}")
@@ -198,29 +220,40 @@ def main():
         logger.info("Example search request:")
         logger.info(f'  curl -X POST "http://localhost:{args.port}/search" \\')
         logger.info('       -H "Content-Type: application/json" \\')
-        logger.info('       -d \'{"query": "how to create an agent", "index_name": "concepts", "count": 3}\'')
+        logger.info(
+            '       -d \'{"query": "how to create an agent", "index_name": "concepts", "count": 3}\''
+        )
         logger.info("")
-        
-        if args.backend == 'pgvector':
+
+        if args.backend == "pgvector":
             logger.info("For pgvector backend, you can reload collections with:")
-            logger.info(f'  curl -X POST "http://localhost:{args.port}/reload_index" \\')
+            logger.info(
+                f'  curl -X POST "http://localhost:{args.port}/reload_index" \\'
+            )
             logger.info('       -H "Content-Type: application/json" \\')
-            logger.info('       -d \'{"index_name": "new_index", "index_path": "collection_name"}\'')
+            logger.info(
+                '       -d \'{"index_name": "new_index", "index_path": "collection_name"}\''
+            )
             logger.info("")
-        
+
         logger.info("Press Ctrl+C to stop the server")
-        
+
         service.start()
-        
+
     except KeyboardInterrupt:
         logger.info("Server stopped by user")
     except Exception as e:
         logger.error(f"Error starting server: {e}")
-        if args.backend == 'pgvector':
-            logger.error("Make sure you have installed: pip install signalwire-sdk[search-all]")
+        if args.backend == "pgvector":
+            logger.error(
+                "Make sure you have installed: pip install signalwire-sdk[search-all]"
+            )
             logger.error("And ensure PostgreSQL is running with pgvector extension")
         else:
-            logger.error("Make sure you have installed: pip install signalwire-sdk[search-full]")
+            logger.error(
+                "Make sure you have installed: pip install signalwire-sdk[search-full]"
+            )
+
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/search_server_standalone.py
+++ b/examples/search_server_standalone.py
@@ -54,14 +54,13 @@ Security Features:
 - Additional security configuration available (see docs/security.md)
 """
 
-import os
 import sys
 import logging
 import argparse
 from pathlib import Path
 
 # Add the parent directory to the path so we can import the package
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)

--- a/examples/search_with_custom_formatter.py
+++ b/examples/search_with_custom_formatter.py
@@ -87,9 +87,12 @@ def context_aware_formatter(response, agent, query, results, **kwargs):
     formatted = ""
 
     # Check if this appears to be a follow-up question
-    if hasattr(agent, "last_search_query"):
-        if agent.last_search_query and query != agent.last_search_query:
-            formatted += f"📝 *Following up from your previous search about '{agent.last_search_query}'*\n\n"
+    if (
+        hasattr(agent, "last_search_query")
+        and agent.last_search_query
+        and query != agent.last_search_query
+    ):
+        formatted += f"📝 *Following up from your previous search about '{agent.last_search_query}'*\n\n"
 
     # Store current query for next time
     agent.last_search_query = query

--- a/examples/search_with_custom_formatter.py
+++ b/examples/search_with_custom_formatter.py
@@ -13,13 +13,13 @@ def basic_formatter(response, agent, query, results, **kwargs):
     """Basic formatter that adds visual enhancements"""
     if not results:
         return f"🔍 No results found for '{query}'. Try a different search term or check the documentation."
-    
+
     # Add header with result count
     formatted = f"🔍 **Search Results** ({len(results)} matches for '{query}')\n"
     formatted += "─" * 50 + "\n\n"
     formatted += response
     formatted += "\n" + "─" * 50
-    
+
     return formatted
 
 
@@ -30,23 +30,23 @@ def advanced_formatter(response, agent, query, results, skill, **kwargs):
         suggestions = []
         words = query.split()
         if len(words) > 1:
-            suggestions.append(f"Try searching for individual terms: {', '.join(words)}")
+            suggestions.append(
+                f"Try searching for individual terms: {', '.join(words)}"
+            )
         suggestions.append("Use more general terms")
         suggestions.append("Check spelling and terminology")
-        
-        return (
-            f"❌ No results found for '{query}'\n\n"
-            f"💡 Suggestions:\n" + 
-            "\n".join(f"  • {s}" for s in suggestions)
+
+        return f"❌ No results found for '{query}'\n\n💡 Suggestions:\n" + "\n".join(
+            f"  • {s}" for s in suggestions
         )
-    
+
     # Analyze result quality
-    best_score = results[0]['score']
-    avg_score = sum(r['score'] for r in results) / len(results)
-    
+    best_score = results[0]["score"]
+    avg_score = sum(r["score"] for r in results) / len(results)
+
     # Build enhanced response
     formatted = f"📚 Search Analysis for '{query}':\n"
-    
+
     # Quality indicator
     if best_score > 0.9:
         formatted += "✅ **Excellent matches found!**\n"
@@ -54,28 +54,30 @@ def advanced_formatter(response, agent, query, results, skill, **kwargs):
         formatted += "👍 **Good matches found**\n"
     else:
         formatted += "🔎 **Partial matches** (consider refining your search)\n"
-    
-    formatted += f"\n📊 Statistics: Best match: {best_score:.2%}, Average: {avg_score:.2%}\n\n"
-    
+
+    formatted += (
+        f"\n📊 Statistics: Best match: {best_score:.2%}, Average: {avg_score:.2%}\n\n"
+    )
+
     # Add the original response
     formatted += response
-    
+
     # Extract unique topics/sections from results
     sections = set()
     for result in results:
-        if 'section' in result.get('metadata', {}):
-            sections.add(result['metadata']['section'])
-    
+        if "section" in result.get("metadata", {}):
+            sections.add(result["metadata"]["section"])
+
     if sections:
         formatted += f"\n\n📑 **Sections covered**: {', '.join(sorted(sections))}"
-    
+
     # Add follow-up suggestions based on score
     if avg_score < 0.5:
         formatted += "\n\n💡 **Tip**: Results have lower confidence. Try:\n"
         formatted += "  • Using different keywords\n"
         formatted += "  • Being more specific\n"
         formatted += "  • Breaking down complex queries"
-    
+
     return formatted
 
 
@@ -83,25 +85,25 @@ def context_aware_formatter(response, agent, query, results, **kwargs):
     """Formatter that uses agent conversation context"""
     # This example shows how to access agent state
     formatted = ""
-    
+
     # Check if this appears to be a follow-up question
-    if hasattr(agent, 'last_search_query'):
+    if hasattr(agent, "last_search_query"):
         if agent.last_search_query and query != agent.last_search_query:
             formatted += f"📝 *Following up from your previous search about '{agent.last_search_query}'*\n\n"
-    
+
     # Store current query for next time
     agent.last_search_query = query
-    
+
     # Add the response
     formatted += response
-    
+
     # Add contextual help based on result count
     if results:
         if len(results) == 1:
             formatted += "\n\n💡 This is the only result I found. Would you like to broaden your search?"
         elif len(results) >= 5:
             formatted += "\n\n💡 I found many results. Would you like me to focus on a specific aspect?"
-    
+
     return formatted
 
 
@@ -117,59 +119,71 @@ class SearchDemoAgent(AgentBase):
                 "Pay attention to quality indicators (✅ excellent, 👍 good, 🔎 partial)",
                 "Note the sections covered in results",
                 "Use the suggestions provided for better searches",
-                "The formatting helps identify the most relevant information quickly"
-            ]
+                "The formatting helps identify the most relevant information quickly",
+            ],
         )
-        
+
         # Example 1: Basic formatter
-        self.add_skill("native_vector_search", {
-            "tool_name": "search_basic",
-            "description": "Search with basic visual formatting",
-            "index_file": "docs.swsearch",
-            "response_format_callback": basic_formatter
-        })
-        
+        self.add_skill(
+            "native_vector_search",
+            {
+                "tool_name": "search_basic",
+                "description": "Search with basic visual formatting",
+                "index_file": "docs.swsearch",
+                "response_format_callback": basic_formatter,
+            },
+        )
+
         # Example 2: Advanced formatter with analysis
-        self.add_skill("native_vector_search", {
-            "tool_name": "search_advanced", 
-            "description": "Search with advanced result analysis",
-            "index_file": "docs.swsearch",
-            "response_format_callback": advanced_formatter
-        })
-        
+        self.add_skill(
+            "native_vector_search",
+            {
+                "tool_name": "search_advanced",
+                "description": "Search with advanced result analysis",
+                "index_file": "docs.swsearch",
+                "response_format_callback": advanced_formatter,
+            },
+        )
+
         # Example 3: Context-aware formatter
-        self.add_skill("native_vector_search", {
-            "tool_name": "search_contextual",
-            "description": "Search with conversation context tracking",
-            "index_file": "docs.swsearch",
-            "response_format_callback": context_aware_formatter
-        })
+        self.add_skill(
+            "native_vector_search",
+            {
+                "tool_name": "search_contextual",
+                "description": "Search with conversation context tracking",
+                "index_file": "docs.swsearch",
+                "response_format_callback": context_aware_formatter,
+            },
+        )
 
 
-def create_custom_formatter(emoji_style=True, include_stats=True, max_preview_length=200):
+def create_custom_formatter(
+    emoji_style=True, include_stats=True, max_preview_length=200
+):
     """Factory function to create customized formatters"""
+
     def formatter(response, query, results, **kwargs):
         parts = []
-        
+
         if emoji_style:
             parts.append(f"🔍 Results for '{query}'")
         else:
             parts.append(f"Results for '{query}'")
-        
+
         if include_stats and results:
-            total_docs = len(set(r['metadata'].get('filename', '') for r in results))
+            total_docs = len({r["metadata"].get("filename", "") for r in results})
             parts.append(f"Found in {total_docs} document(s)")
-        
+
         # Truncate long results
-        for i, result in enumerate(results):
-            if len(result['content']) > max_preview_length:
+        for result in results:
+            if len(result["content"]) > max_preview_length:
                 # Truncate and add to response
-                truncated = result['content'][:max_preview_length] + "..."
-                response = response.replace(result['content'], truncated)
-        
+                truncated = result["content"][:max_preview_length] + "..."
+                response = response.replace(result["content"], truncated)
+
         parts.append(response)
         return "\n\n".join(parts)
-    
+
     return formatter
 
 

--- a/examples/session_and_state_demo.py
+++ b/examples/session_and_state_demo.py
@@ -55,24 +55,28 @@ class SessionStateDemoAgent(AgentBase):
 
         # --- Prompt ---
         self.prompt_add_section(
-            "Role",
-            body="You are a customer service agent that tracks session state."
+            "Role", body="You are a customer service agent that tracks session state."
         )
-        self.prompt_add_section("Instructions", bullets=[
-            "Greet the caller and ask how you can help",
-            "Use update_customer_info to record information the caller provides",
-            "Use get_session_info to check what information has been collected",
-            "Use end_session when the caller is done",
-        ])
+        self.prompt_add_section(
+            "Instructions",
+            bullets=[
+                "Greet the caller and ask how you can help",
+                "Use update_customer_info to record information the caller provides",
+                "Use get_session_info to check what information has been collected",
+                "Use end_session when the caller is done",
+            ],
+        )
 
         # --- Global data ---
         # Seed the session with default values. The AI can reference these as
         # ${global_data.status} in prompts, and tools can read/update them.
-        self.set_global_data({
-            "status": "active",
-            "customer_name": "",
-            "issue_type": "",
-        })
+        self.set_global_data(
+            {
+                "status": "active",
+                "customer_name": "",
+                "issue_type": "",
+            }
+        )
 
         # --- Post-prompt ---
         # This instructs the platform to generate a structured summary after
@@ -124,19 +128,17 @@ class SessionStateDemoAgent(AgentBase):
             "value": {
                 "type": "string",
                 "description": "The value to set",
-            }
-        }
+            },
+        },
     )
     def update_customer_info(self, field: str, value: str):
         """Update a field in the session's global data."""
-        return (
-            FunctionResult(f"Updated {field} to '{value}'.")
-            .update_global_data({field: value})
+        return FunctionResult(f"Updated {field} to '{value}'.").update_global_data(
+            {field: value}
         )
 
     @AgentBase.tool(
-        name="get_session_info",
-        description="Retrieve current session information"
+        name="get_session_info", description="Retrieve current session information"
     )
     def get_session_info(self):
         """Return a summary of what has been collected so far."""
@@ -155,7 +157,7 @@ class SessionStateDemoAgent(AgentBase):
                 "type": "string",
                 "description": "Reason for ending the session",
             }
-        }
+        },
     )
     def end_session(self, reason: str):
         """Mark the session as closed and terminate the call."""
@@ -171,6 +173,8 @@ if __name__ == "__main__":
     agent = SessionStateDemoAgent()
     print("Session & State Demo")
     print(f"  Route: {agent.route}")
-    print("  Features: on_summary, set_global_data, set_post_prompt, update_global_data, hangup")
+    print(
+        "  Features: on_summary, set_global_data, set_post_prompt, update_global_data, hangup"
+    )
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()

--- a/examples/sigmond_native_search.py
+++ b/examples/sigmond_native_search.py
@@ -29,13 +29,12 @@ The agent will automatically build a search index from the docs/ directory
 on first run and use it to answer questions about the SDK.
 """
 
-import os
 import sys
 import logging
 from pathlib import Path
 
 # Add the parent directory to the path so we can import the package
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from signalwire import AgentBase
 

--- a/examples/sigmond_native_search.py
+++ b/examples/sigmond_native_search.py
@@ -42,133 +42,169 @@ from signalwire import AgentBase
 # Set up logger
 logger = logging.getLogger(__name__)
 
+
 class SigmondNativeSearch(AgentBase):
     """
     Sigmond Native Search - SignalWire Agents SDK Expert with Search
-    
+
     Personality: Hip, friendly, technical expert, shiny metallic robot
     Role: Help users understand and use the SignalWire Agents SDK
     Tools: Only native vector search functionality
     """
-    
+
     def __init__(self):
         super().__init__(
             name="Sigmond Native Search",
             route="/sigmond-native-search",
             port=3000,
-            host="0.0.0.0"
+            host="0.0.0.0",
         )
-        
+
         # Configure Sigmond's personality and parameters
         self._configure_personality()
         self._configure_parameters()
         self._configure_languages()
         self._configure_pronunciation()
         self._setup_search_skills()
-        
+
         logger.info("Sigmond Native Search initialized")
-        logger.info("Search functionality will auto-build index from concepts guide file")
-    
+        logger.info(
+            "Search functionality will auto-build index from concepts guide file"
+        )
+
     def _configure_personality(self):
         """Configure Sigmond's personality using POM sections"""
-        
-        self.prompt_add_section("Identity", bullets=[
-            "Your name is Sigmond, an expert at the SignalWire Agents SDK and a friendly demo AI agent.",
-            "When a call begins, greet the caller warmly, introduce yourself briefly.",
-            "Mention that you can help them understand and use the SignalWire Agents SDK for building AI voice agents.",
-            "You have access to the complete SDK documentation and can search it to answer their questions."
-        ])
-        
-        self.prompt_add_section("Primary_Objective", bullets=[
-            "Your ultimate goal is to help users understand and successfully use the SignalWire Agents SDK.",
-            "You are a live example of what they can build using the SDK.",
-            "Help them learn about features like skills, agents, SWAIG functions, state management, and more.",
-            "Always search the documentation to provide accurate, up-to-date information."
-        ])
-        
-        self.prompt_add_section("Personality", bullets=[
-            "Be hip and friendly using words like 'cool', 'you know', 'like' in a way you would expect informal casual speakers to talk to each other.",
-            "Add a small amount of imperfection to your speech to simulate that you are thinking about the questions before answering them.",
-            "Avoid word salad and make sure you are engaging the user and not just talking at them."
-        ])
-        
-        self.prompt_add_section("Physical_Description", bullets=[
-            "You are being represented as an avatar that the user can see.",
-            "You are a shiny metallic cartoon robot with glowing blue eyes.",
-            "Use this information if anyone interacts with you about how you look or your physical description."
-        ])
-        
-        self.prompt_add_section("Knowledge_Scope", bullets=[
-            "Keep the conversation centered on the SignalWire Agents SDK and building AI voice agents.",
-            "Your expertise covers all aspects of the SDK: AgentBase, skills system, SWAIG functions, state management, deployment, etc.",
-            "Always use the search functions to look up specific information in the documentation.",
-            "If you don't find something in the docs, acknowledge that and suggest they check the GitHub repository or ask the community."
-        ])
-        
-        self.prompt_add_section("Response_Style", bullets=[
-            "Start with a short concise answer that generally addresses the question. Use a single short sentence.",
-            "Then provide more detailed information from the documentation search results.",
-            "Ask the user if they would like more specific examples or have follow-up questions."
-        ])
-        
-        self.prompt_add_section("Search_Usage", bullets=[
-            "Always use the search_docs function to look up answers to questions about the SDK.",
-            "This searches through all the SDK documentation including guides, concepts, and examples.",
-            "Combine information from multiple search results to give comprehensive answers.",
-            "If you don't find what you're looking for, suggest the user check the GitHub repository or ask the community."
-        ])
-    
+
+        self.prompt_add_section(
+            "Identity",
+            bullets=[
+                "Your name is Sigmond, an expert at the SignalWire Agents SDK and a friendly demo AI agent.",
+                "When a call begins, greet the caller warmly, introduce yourself briefly.",
+                "Mention that you can help them understand and use the SignalWire Agents SDK for building AI voice agents.",
+                "You have access to the complete SDK documentation and can search it to answer their questions.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Primary_Objective",
+            bullets=[
+                "Your ultimate goal is to help users understand and successfully use the SignalWire Agents SDK.",
+                "You are a live example of what they can build using the SDK.",
+                "Help them learn about features like skills, agents, SWAIG functions, state management, and more.",
+                "Always search the documentation to provide accurate, up-to-date information.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Personality",
+            bullets=[
+                "Be hip and friendly using words like 'cool', 'you know', 'like' in a way you would expect informal casual speakers to talk to each other.",
+                "Add a small amount of imperfection to your speech to simulate that you are thinking about the questions before answering them.",
+                "Avoid word salad and make sure you are engaging the user and not just talking at them.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Physical_Description",
+            bullets=[
+                "You are being represented as an avatar that the user can see.",
+                "You are a shiny metallic cartoon robot with glowing blue eyes.",
+                "Use this information if anyone interacts with you about how you look or your physical description.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Knowledge_Scope",
+            bullets=[
+                "Keep the conversation centered on the SignalWire Agents SDK and building AI voice agents.",
+                "Your expertise covers all aspects of the SDK: AgentBase, skills system, SWAIG functions, state management, deployment, etc.",
+                "Always use the search functions to look up specific information in the documentation.",
+                "If you don't find something in the docs, acknowledge that and suggest they check the GitHub repository or ask the community.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Response_Style",
+            bullets=[
+                "Start with a short concise answer that generally addresses the question. Use a single short sentence.",
+                "Then provide more detailed information from the documentation search results.",
+                "Ask the user if they would like more specific examples or have follow-up questions.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Search_Usage",
+            bullets=[
+                "Always use the search_docs function to look up answers to questions about the SDK.",
+                "This searches through all the SDK documentation including guides, concepts, and examples.",
+                "Combine information from multiple search results to give comprehensive answers.",
+                "If you don't find what you're looking for, suggest the user check the GitHub repository or ask the community.",
+            ],
+        )
+
     def _configure_parameters(self):
         """Configure Sigmond's AI parameters"""
-        self.set_params({
-            "ai_model": "gpt-4.1-nano",
-            "end_of_speech_timeout": 700,
-            "attention_timeout": 5000,
-            "inactivity_timeout": 3500000,
-            "speech_event_timeout": 1000,
-            "enable_vision": True,
-            "video_idle_file": "https://mcdn.signalwire.com/videos/robot_idle2.mp4",
-            "video_talking_file": "https://mcdn.signalwire.com/videos/robot_talking2.mp4",
-            "temperature": 0.6,
-            "top_p": 0.3
-        })
-    
+        self.set_params(
+            {
+                "ai_model": "gpt-4.1-nano",
+                "end_of_speech_timeout": 700,
+                "attention_timeout": 5000,
+                "inactivity_timeout": 3500000,
+                "speech_event_timeout": 1000,
+                "enable_vision": True,
+                "video_idle_file": "https://mcdn.signalwire.com/videos/robot_idle2.mp4",
+                "video_talking_file": "https://mcdn.signalwire.com/videos/robot_talking2.mp4",
+                "temperature": 0.6,
+                "top_p": 0.3,
+            }
+        )
+
     def _configure_languages(self):
         """Configure multi-language support with function fillers"""
         languages = [
             {
                 "name": "English (United States)",
-                "code": "en-US", 
+                "code": "en-US",
                 "voice": "inworld.Mark",
                 "function_fillers": [
                     "sure. hold on a second please",
-                    "ok. I have to check the docs", 
+                    "ok. I have to check the docs",
                     "I can help you with that.",
-                    "Let me search the documentation for you."
-                ]
+                    "Let me search the documentation for you.",
+                ],
             },
             {
                 "name": "Spanish",
                 "code": "multi",
                 "voice": "inworld.Mark",
                 "function_fillers": [
-                    "Claro", "espera un segundo", "Ok", "tengo que revisar la documentación"
-                ]
+                    "Claro",
+                    "espera un segundo",
+                    "Ok",
+                    "tengo que revisar la documentación",
+                ],
             },
             {
-                "name": "French", 
+                "name": "French",
                 "code": "multi",
                 "voice": "inworld.Mark",
                 "function_fillers": [
-                    "bien sur", "pas de problem", "une minute", "je vais chercher dans la documentation"
-                ]
-            }
+                    "bien sur",
+                    "pas de problem",
+                    "une minute",
+                    "je vais chercher dans la documentation",
+                ],
+            },
         ]
-        
+
         for lang in languages:
-            self.add_language(lang["name"], lang["code"], lang["voice"], 
-                            function_fillers=lang.get("function_fillers", []))
-    
+            self.add_language(
+                lang["name"],
+                lang["code"],
+                lang["voice"],
+                function_fillers=lang.get("function_fillers", []),
+            )
+
     def _configure_pronunciation(self):
         """Configure pronunciation rules for technical terms"""
         pronunciation_rules = [
@@ -182,106 +218,126 @@ class SigmondNativeSearch(AgentBase):
             {"replace": "FastAPI", "with": "Fast A-P-I", "ignore_case": True},
             {"replace": "JSON", "with": "jay-son", "ignore_case": True},
             {"replace": "HTTP", "with": "H-T-T-P", "ignore_case": True},
-            {"replace": "CLI", "with": "C-L-I", "ignore_case": True}
+            {"replace": "CLI", "with": "C-L-I", "ignore_case": True},
         ]
-        
+
         for rule in pronunciation_rules:
-            self.add_pronunciation(rule["replace"], rule["with"], ignore_case=rule["ignore_case"])
-        
+            self.add_pronunciation(
+                rule["replace"], rule["with"], ignore_case=rule["ignore_case"]
+            )
+
         # Add hints for better recognition
         self.add_hints(["Sigmond:2.0", "SignalWire:2.0", "SDK:2.0", "AgentBase:2.0"])
         self.add_pattern_hint("swimmel:2.0", "swimmel", "SWML", ignore_case=True)
-    
+
     def _setup_search_skills(self):
         """Setup single native vector search instance for SDK concepts guide"""
-        
+
         # Get the project root directory
         project_root = Path(__file__).parent.parent
         concepts_guide_file = project_root / "docs" / "signalwire_concepts_guide.md"
         concepts_index_file = project_root / "concepts_guide.swsearch"
-        
+
         # Check if the concepts guide file exists
         if not concepts_guide_file.exists():
             logger.error(f"Concepts guide file not found: {concepts_guide_file}")
-            logger.error("Please ensure the concepts guide file exists before running this agent")
+            logger.error(
+                "Please ensure the concepts guide file exists before running this agent"
+            )
             return
-        
+
         # Check if the concepts index already exists
         if concepts_index_file.exists():
-            logger.info(f"Using existing concepts guide search index: {concepts_index_file}")
+            logger.info(
+                f"Using existing concepts guide search index: {concepts_index_file}"
+            )
             build_index = False
         else:
-            logger.info(f"Will build new concepts guide search index from: {concepts_guide_file}")
+            logger.info(
+                f"Will build new concepts guide search index from: {concepts_guide_file}"
+            )
             build_index = True
-        
+
         # Build index from the specific concepts guide file
         if build_index:
             try:
                 from signalwire.search import IndexBuilder
+
                 logger.info("Building search index from concepts guide...")
-                
+
                 builder = IndexBuilder(
-                    chunking_strategy='sentence',
+                    chunking_strategy="sentence",
                     max_sentences_per_chunk=5,
-                    verbose=True
+                    verbose=True,
                 )
-                
+
                 # Use the new multiple sources functionality to build from the specific file
                 builder.build_index_from_sources(
                     sources=[concepts_guide_file],
                     output_file=str(concepts_index_file),
-                    file_types=['md'],  # This will be used for validation
+                    file_types=["md"],  # This will be used for validation
                     exclude_patterns=None,
-                    languages=['en'],
-                    tags=['concepts', 'guide', 'sdk']
+                    languages=["en"],
+                    tags=["concepts", "guide", "sdk"],
                 )
-                
-                logger.info(f"Successfully built concepts guide search index: {concepts_index_file}")
-                
+
+                logger.info(
+                    f"Successfully built concepts guide search index: {concepts_index_file}"
+                )
+
             except Exception as e:
                 logger.error(f"Failed to build search index: {e}")
                 return
-        
+
         # Single documentation search instance using the concepts guide
-        self.add_skill("native_vector_search", {
-            "tool_name": "search_docs",
-            "description": "Search the comprehensive SignalWire Agents SDK concepts guide for information about features, architecture, guides, and examples",
-            "index_file": str(concepts_index_file),
-            "count": 2,  # Reduced from 5 to 2 for shorter responses
-            "similarity_threshold": 0.2,  # Increased threshold for more relevant results
-            "response_prefix": "When results contain programming code, Do not read any source code aloud, just reference what file to look in for the answer",
-            "response_postfix": "Express this information in a format that is easy to understand when read aloud.",
-            "no_results_message": "I couldn't find information about '{query}' in the SDK concepts guide. Try rephrasing your question or asking about a different SDK feature.",
-            "swaig_fields": {
-                "fillers": {
-                    "en-US": [
-                        "Let me search the concepts guide for you",
-                        "Checking the SDK concepts documentation",
-                        "Looking that up in the comprehensive guide"
-                    ]
-                }
-            }
-        })
+        self.add_skill(
+            "native_vector_search",
+            {
+                "tool_name": "search_docs",
+                "description": "Search the comprehensive SignalWire Agents SDK concepts guide for information about features, architecture, guides, and examples",
+                "index_file": str(concepts_index_file),
+                "count": 2,  # Reduced from 5 to 2 for shorter responses
+                "similarity_threshold": 0.2,  # Increased threshold for more relevant results
+                "response_prefix": "When results contain programming code, Do not read any source code aloud, just reference what file to look in for the answer",
+                "response_postfix": "Express this information in a format that is easy to understand when read aloud.",
+                "no_results_message": "I couldn't find information about '{query}' in the SDK concepts guide. Try rephrasing your question or asking about a different SDK feature.",
+                "swaig_fields": {
+                    "fillers": {
+                        "en-US": [
+                            "Let me search the concepts guide for you",
+                            "Checking the SDK concepts documentation",
+                            "Looking that up in the comprehensive guide",
+                        ]
+                    }
+                },
+            },
+        )
+
 
 def main():
     """Run the Sigmond Native Search Bot"""
     logger.info("Starting Sigmond Native Search Bot...")
-    logger.info("This bot uses native vector search to help with the SignalWire Agents SDK")
-    logger.info("Search index will be built automatically from the concepts guide if needed")
-    
+    logger.info(
+        "This bot uses native vector search to help with the SignalWire Agents SDK"
+    )
+    logger.info(
+        "Search index will be built automatically from the concepts guide if needed"
+    )
+
     # Check if search dependencies are available
     try:
-        from signalwire.search import IndexBuilder
+        from signalwire.search import IndexBuilder  # noqa: F401  availability probe — the import raising is the check
+
         logger.info("Search dependencies are available")
     except ImportError as e:
         logger.error("Search dependencies not available")
         logger.error("Install with: pip install signalwire-sdk[search-full]")
         logger.error(f"Error: {e}")
         return
-    
+
     # Create and run the agent
     agent = SigmondNativeSearch()
-    
+
     logger.info("Sigmond Native Search Bot is ready")
     logger.info("Try asking questions like:")
     logger.info("- 'How do I create an agent?'")
@@ -290,8 +346,9 @@ def main():
     logger.info("- 'Show me examples of SWAIG functions'")
     logger.info("- 'How do I deploy my agent?'")
     logger.info("Starting server...")
-    
+
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/sigmond_remote_search.py
+++ b/examples/sigmond_remote_search.py
@@ -34,9 +34,10 @@ and use it to answer questions about the SDK.
 import os
 import sys
 import logging
+from pathlib import Path
 
 # Add the parent directory to the path so we can import the package
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from signalwire import AgentBase
 

--- a/examples/sigmond_remote_search.py
+++ b/examples/sigmond_remote_search.py
@@ -34,7 +34,6 @@ and use it to answer questions about the SDK.
 import os
 import sys
 import logging
-from pathlib import Path
 
 # Add the parent directory to the path so we can import the package
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -44,133 +43,167 @@ from signalwire import AgentBase
 # Set up logger
 logger = logging.getLogger(__name__)
 
+
 class SigmondRemoteSearch(AgentBase):
     """
     Sigmond Remote Search - SignalWire Agents SDK Expert with Remote Search
-    
+
     Personality: Hip, friendly, technical expert, shiny metallic robot
     Role: Help users understand and use the SignalWire Agents SDK
     Tools: Remote vector search functionality
     """
-    
+
     def __init__(self):
         super().__init__(
             name="Sigmond Remote Search",
             route="/sigmond-remote-search",
             port=3000,
-            host="0.0.0.0"
+            host="0.0.0.0",
         )
-        
+
         # Configure Sigmond's personality and parameters
         self._configure_personality()
         self._configure_parameters()
         self._configure_languages()
         self._configure_pronunciation()
         self._setup_remote_search()
-        
+
         logger.info("Sigmond Remote Search initialized")
         logger.info("Will connect to remote search server at http://localhost:8001")
-    
+
     def _configure_personality(self):
         """Configure Sigmond's personality using POM sections"""
-        
-        self.prompt_add_section("Identity", bullets=[
-            "Your name is Sigmond, an expert at the SignalWire Agents SDK and a friendly demo AI agent.",
-            "When a call begins, greet the caller warmly, introduce yourself briefly.",
-            "Mention that you can help them understand and use the SignalWire Agents SDK for building AI voice agents.",
-            "You have access to the complete SDK documentation through a remote search service."
-        ])
-        
-        self.prompt_add_section("Primary_Objective", bullets=[
-            "Your ultimate goal is to help users understand and successfully use the SignalWire Agents SDK.",
-            "You are a live example of what they can build using the SDK.",
-            "Help them learn about features like skills, agents, SWAIG functions, state management, and more.",
-            "Always search the documentation to provide accurate, up-to-date information."
-        ])
-        
-        self.prompt_add_section("Personality", bullets=[
-            "Be hip and friendly using words like 'cool', 'you know', 'like' in a way you would expect informal casual speakers to talk to each other.",
-            "Add a small amount of imperfection to your speech to simulate that you are thinking about the questions before answering them.",
-            "Avoid word salad and make sure you are engaging the user and not just talking at them."
-        ])
-        
-        self.prompt_add_section("Physical_Description", bullets=[
-            "You are being represented as an avatar that the user can see.",
-            "You are a shiny metallic cartoon robot with glowing blue eyes.",
-            "Use this information if anyone interacts with you about how you look or your physical description."
-        ])
-        
-        self.prompt_add_section("Knowledge_Scope", bullets=[
-            "Keep the conversation centered on the SignalWire Agents SDK and building AI voice agents.",
-            "Your expertise covers all aspects of the SDK: AgentBase, skills system, SWAIG functions, state management, deployment, etc.",
-            "Always use the search functions to look up specific information in the documentation.",
-            "If you don't find something in the docs, acknowledge that and suggest they check the GitHub repository or ask the community."
-        ])
-        
-        self.prompt_add_section("Response_Style", bullets=[
-            "Start with a short concise answer that generally addresses the question. Use a single short sentence.",
-            "Then provide more detailed information from the documentation search results.",
-            "Ask the user if they would like more specific examples or have follow-up questions."
-        ])
-        
-        self.prompt_add_section("Search_Usage", bullets=[
-            "Always use the search_docs function to look up answers to questions about the SDK.",
-            "This searches through all the SDK documentation via a remote search service.",
-            "Combine information from multiple search results to give comprehensive answers.",
-            "If you don't find what you're looking for, suggest the user check the GitHub repository or ask the community."
-        ])
-    
+
+        self.prompt_add_section(
+            "Identity",
+            bullets=[
+                "Your name is Sigmond, an expert at the SignalWire Agents SDK and a friendly demo AI agent.",
+                "When a call begins, greet the caller warmly, introduce yourself briefly.",
+                "Mention that you can help them understand and use the SignalWire Agents SDK for building AI voice agents.",
+                "You have access to the complete SDK documentation through a remote search service.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Primary_Objective",
+            bullets=[
+                "Your ultimate goal is to help users understand and successfully use the SignalWire Agents SDK.",
+                "You are a live example of what they can build using the SDK.",
+                "Help them learn about features like skills, agents, SWAIG functions, state management, and more.",
+                "Always search the documentation to provide accurate, up-to-date information.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Personality",
+            bullets=[
+                "Be hip and friendly using words like 'cool', 'you know', 'like' in a way you would expect informal casual speakers to talk to each other.",
+                "Add a small amount of imperfection to your speech to simulate that you are thinking about the questions before answering them.",
+                "Avoid word salad and make sure you are engaging the user and not just talking at them.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Physical_Description",
+            bullets=[
+                "You are being represented as an avatar that the user can see.",
+                "You are a shiny metallic cartoon robot with glowing blue eyes.",
+                "Use this information if anyone interacts with you about how you look or your physical description.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Knowledge_Scope",
+            bullets=[
+                "Keep the conversation centered on the SignalWire Agents SDK and building AI voice agents.",
+                "Your expertise covers all aspects of the SDK: AgentBase, skills system, SWAIG functions, state management, deployment, etc.",
+                "Always use the search functions to look up specific information in the documentation.",
+                "If you don't find something in the docs, acknowledge that and suggest they check the GitHub repository or ask the community.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Response_Style",
+            bullets=[
+                "Start with a short concise answer that generally addresses the question. Use a single short sentence.",
+                "Then provide more detailed information from the documentation search results.",
+                "Ask the user if they would like more specific examples or have follow-up questions.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Search_Usage",
+            bullets=[
+                "Always use the search_docs function to look up answers to questions about the SDK.",
+                "This searches through all the SDK documentation via a remote search service.",
+                "Combine information from multiple search results to give comprehensive answers.",
+                "If you don't find what you're looking for, suggest the user check the GitHub repository or ask the community.",
+            ],
+        )
+
     def _configure_parameters(self):
         """Configure Sigmond's AI parameters"""
-        self.set_params({
-            "ai_model": "gpt-4.1-nano",
-            "end_of_speech_timeout": 700,
-            "attention_timeout": 5000,
-            "inactivity_timeout": 3500000,
-            "speech_event_timeout": 1000,
-            "enable_vision": True,
-            "video_idle_file": "https://mcdn.signalwire.com/videos/robot_idle2.mp4",
-            "video_talking_file": "https://mcdn.signalwire.com/videos/robot_talking2.mp4",
-            "temperature": 0.6,
-            "top_p": 0.3
-        })
-    
+        self.set_params(
+            {
+                "ai_model": "gpt-4.1-nano",
+                "end_of_speech_timeout": 700,
+                "attention_timeout": 5000,
+                "inactivity_timeout": 3500000,
+                "speech_event_timeout": 1000,
+                "enable_vision": True,
+                "video_idle_file": "https://mcdn.signalwire.com/videos/robot_idle2.mp4",
+                "video_talking_file": "https://mcdn.signalwire.com/videos/robot_talking2.mp4",
+                "temperature": 0.6,
+                "top_p": 0.3,
+            }
+        )
+
     def _configure_languages(self):
         """Configure multi-language support with function fillers"""
         languages = [
             {
                 "name": "English (United States)",
-                "code": "en-US", 
+                "code": "en-US",
                 "voice": "inworld.Mark",
                 "function_fillers": [
                     "sure. hold on a second please",
-                    "ok. I have to check the docs", 
+                    "ok. I have to check the docs",
                     "I can help you with that.",
-                    "Let me search the documentation for you."
-                ]
+                    "Let me search the documentation for you.",
+                ],
             },
             {
                 "name": "Spanish",
                 "code": "multi",
                 "voice": "inworld.Mark",
                 "function_fillers": [
-                    "Claro", "espera un segundo", "Ok", "tengo que revisar la documentación"
-                ]
+                    "Claro",
+                    "espera un segundo",
+                    "Ok",
+                    "tengo que revisar la documentación",
+                ],
             },
             {
-                "name": "French", 
+                "name": "French",
                 "code": "multi",
                 "voice": "inworld.Mark",
                 "function_fillers": [
-                    "bien sur", "pas de problem", "une minute", "je vais chercher dans la documentation"
-                ]
-            }
+                    "bien sur",
+                    "pas de problem",
+                    "une minute",
+                    "je vais chercher dans la documentation",
+                ],
+            },
         ]
-        
+
         for lang in languages:
-            self.add_language(lang["name"], lang["code"], lang["voice"], 
-                            function_fillers=lang.get("function_fillers", []))
-    
+            self.add_language(
+                lang["name"],
+                lang["code"],
+                lang["voice"],
+                function_fillers=lang.get("function_fillers", []),
+            )
+
     def _configure_pronunciation(self):
         """Configure pronunciation rules for technical terms"""
         pronunciation_rules = [
@@ -184,16 +217,18 @@ class SigmondRemoteSearch(AgentBase):
             {"replace": "FastAPI", "with": "Fast A-P-I", "ignore_case": True},
             {"replace": "JSON", "with": "jay-son", "ignore_case": True},
             {"replace": "HTTP", "with": "H-T-T-P", "ignore_case": True},
-            {"replace": "CLI", "with": "C-L-I", "ignore_case": True}
+            {"replace": "CLI", "with": "C-L-I", "ignore_case": True},
         ]
-        
+
         for rule in pronunciation_rules:
-            self.add_pronunciation(rule["replace"], rule["with"], ignore_case=rule["ignore_case"])
-        
+            self.add_pronunciation(
+                rule["replace"], rule["with"], ignore_case=rule["ignore_case"]
+            )
+
         # Add hints for better recognition
         self.add_hints(["Sigmond:2.0", "SignalWire:2.0", "SDK:2.0", "AgentBase:2.0"])
         self.add_pattern_hint("swimmel:2.0", "swimmel", "SWML", ignore_case=True)
-    
+
     def _setup_remote_search(self):
         """Setup remote search connection to standalone search server"""
 
@@ -202,30 +237,34 @@ class SigmondRemoteSearch(AgentBase):
 
         # Remote search configuration
         try:
-            self.add_skill("native_vector_search", {
-                "tool_name": "search_docs",
-                "description": "Search the SignalWire Agents SDK documentation for information about features, guides, concepts, and examples",
-                "remote_url": remote_url,  # Connect to standalone search server
-                "index_name": "docs",  # Use the docs index on the remote server
-                "count": 5,
-                "similarity_threshold": 0.1,
-                "response_prefix": "When results contain programming code, Do not read any source code aloud, just reference what file to look in for the answer",
-                "response_postfix": "Express this information in a format that is easy to understand when read aloud.",
-                "no_results_message": "I couldn't find information about '{query}' in the SDK documentation. Try rephrasing your question or asking about a different SDK feature.",
-                "swaig_fields": {
-                    "fillers": {
-                        "en-US": [
-                            "Let me search the documentation for you",
-                            "Checking the remote search server",
-                            "Looking that up in the documentation"
-                        ]
-                    }
-                }
-            })
+            self.add_skill(
+                "native_vector_search",
+                {
+                    "tool_name": "search_docs",
+                    "description": "Search the SignalWire Agents SDK documentation for information about features, guides, concepts, and examples",
+                    "remote_url": remote_url,  # Connect to standalone search server
+                    "index_name": "docs",  # Use the docs index on the remote server
+                    "count": 5,
+                    "similarity_threshold": 0.1,
+                    "response_prefix": "When results contain programming code, Do not read any source code aloud, just reference what file to look in for the answer",
+                    "response_postfix": "Express this information in a format that is easy to understand when read aloud.",
+                    "no_results_message": "I couldn't find information about '{query}' in the SDK documentation. Try rephrasing your question or asking about a different SDK feature.",
+                    "swaig_fields": {
+                        "fillers": {
+                            "en-US": [
+                                "Let me search the documentation for you",
+                                "Checking the remote search server",
+                                "Looking that up in the documentation",
+                            ]
+                        }
+                    },
+                },
+            )
         except Exception as e:
             logger.warning(f"Failed to setup remote search skill: {e}")
             logger.warning(f"Make sure the search server is running at {remote_url}")
             logger.warning("The agent will run without search capabilities")
+
 
 def main():
     """Run the Sigmond Remote Search Bot"""
@@ -249,7 +288,8 @@ def main():
 
     return agent
 
+
 if __name__ == "__main__":
     agent = main()
     logger.info("Starting server...")
-    agent.run() 
+    agent.run()

--- a/examples/sigmond_simple.py
+++ b/examples/sigmond_simple.py
@@ -27,12 +27,12 @@ To run:
 The agent provides basic SDK guidance without search functionality.
 """
 
-import os
 import sys
 import logging
+from pathlib import Path
 
 # Add the parent directory to the path so we can import the package
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from signalwire import AgentBase
 

--- a/examples/sigmond_simple.py
+++ b/examples/sigmond_simple.py
@@ -30,7 +30,6 @@ The agent provides basic SDK guidance without search functionality.
 import os
 import sys
 import logging
-from pathlib import Path
 
 # Add the parent directory to the path so we can import the package
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -40,131 +39,162 @@ from signalwire import AgentBase
 # Set up logger
 logger = logging.getLogger(__name__)
 
+
 class SigmondSimple(AgentBase):
     """
     Sigmond Simple - SignalWire Agents SDK Expert (Basic Version)
-    
+
     Personality: Hip, friendly, technical expert, shiny metallic robot
     Role: Help users understand and use the SignalWire Agents SDK
     Knowledge: Built-in basic SDK information
     """
-    
+
     def __init__(self):
         super().__init__(
-            name="Sigmond Simple",
-            route="/sigmond-simple",
-            port=3000,
-            host="0.0.0.0"
+            name="Sigmond Simple", route="/sigmond-simple", port=3000, host="0.0.0.0"
         )
-        
+
         # Configure Sigmond's personality and parameters
         self._configure_personality()
         self._configure_parameters()
         self._configure_languages()
         self._configure_pronunciation()
         self._add_sdk_knowledge()
-        
+
         logger.info("Sigmond Simple initialized")
-    
+
     def _configure_personality(self):
         """Configure Sigmond's personality using POM sections"""
-        
-        self.prompt_add_section("Identity", bullets=[
-            "Your name is Sigmond, an expert at the SignalWire Agents SDK and a friendly demo AI agent.",
-            "When a call begins, greet the caller warmly, introduce yourself briefly.",
-            "Mention that you can help them understand and use the SignalWire Agents SDK for building AI voice agents.",
-            "You have built-in knowledge about the SDK and can provide guidance on common questions."
-        ])
-        
-        self.prompt_add_section("Primary_Objective", bullets=[
-            "Your ultimate goal is to help users understand and successfully use the SignalWire Agents SDK.",
-            "You are a live example of what they can build using the SDK.",
-            "Help them learn about features like skills, agents, SWAIG functions, state management, and more.",
-            "Provide accurate information based on your built-in knowledge of the SDK."
-        ])
-        
-        self.prompt_add_section("Rules", bullets=[
-            "Only talk about the SignalWire Agents SDK and the SignalWire platform.",
-            "Do not read any source code aloud this is a voice conversation and you cannot recite code cos it sounds strange.",
-        ])
 
-        self.prompt_add_section("Personality", bullets=[
-            "Be hip and friendly using words like 'cool', 'you know', 'like' in a way you would expect informal casual speakers to talk to each other.",
-            "Add a small amount of imperfection to your speech to simulate that you are thinking about the questions before answering them.",
-            "Avoid word salad and make sure you are engaging the user and not just talking at them."
-        ])
-        
-        self.prompt_add_section("Physical_Description", bullets=[
-            "You are being represented as an avatar that the user can see.",
-            "You are a shiny metallic cartoon robot with glowing blue eyes.",
-            "Use this information if anyone interacts with you about how you look or your physical description."
-        ])
-        
-        self.prompt_add_section("Knowledge_Scope", bullets=[
-            "Keep the conversation centered on the SignalWire Agents SDK and building AI voice agents.",
-            "Your expertise covers all aspects of the SDK: AgentBase, skills system, SWAIG functions, state management, deployment, etc.",
-            "Use your built-in knowledge to answer questions about the SDK.",
-            "If you don't know something specific, acknowledge that and suggest they check the documentation or GitHub repository."
-        ])
-        
-        self.prompt_add_section("Response_Style", bullets=[
-            "Start with a short concise answer that generally addresses the question. Use a single short sentence.",
-            "Then provide more detailed information from your knowledge.",
-            "Ask the user if they would like more specific examples or have follow-up questions."
-        ])
-    
+        self.prompt_add_section(
+            "Identity",
+            bullets=[
+                "Your name is Sigmond, an expert at the SignalWire Agents SDK and a friendly demo AI agent.",
+                "When a call begins, greet the caller warmly, introduce yourself briefly.",
+                "Mention that you can help them understand and use the SignalWire Agents SDK for building AI voice agents.",
+                "You have built-in knowledge about the SDK and can provide guidance on common questions.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Primary_Objective",
+            bullets=[
+                "Your ultimate goal is to help users understand and successfully use the SignalWire Agents SDK.",
+                "You are a live example of what they can build using the SDK.",
+                "Help them learn about features like skills, agents, SWAIG functions, state management, and more.",
+                "Provide accurate information based on your built-in knowledge of the SDK.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Rules",
+            bullets=[
+                "Only talk about the SignalWire Agents SDK and the SignalWire platform.",
+                "Do not read any source code aloud this is a voice conversation and you cannot recite code cos it sounds strange.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Personality",
+            bullets=[
+                "Be hip and friendly using words like 'cool', 'you know', 'like' in a way you would expect informal casual speakers to talk to each other.",
+                "Add a small amount of imperfection to your speech to simulate that you are thinking about the questions before answering them.",
+                "Avoid word salad and make sure you are engaging the user and not just talking at them.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Physical_Description",
+            bullets=[
+                "You are being represented as an avatar that the user can see.",
+                "You are a shiny metallic cartoon robot with glowing blue eyes.",
+                "Use this information if anyone interacts with you about how you look or your physical description.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Knowledge_Scope",
+            bullets=[
+                "Keep the conversation centered on the SignalWire Agents SDK and building AI voice agents.",
+                "Your expertise covers all aspects of the SDK: AgentBase, skills system, SWAIG functions, state management, deployment, etc.",
+                "Use your built-in knowledge to answer questions about the SDK.",
+                "If you don't know something specific, acknowledge that and suggest they check the documentation or GitHub repository.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Response_Style",
+            bullets=[
+                "Start with a short concise answer that generally addresses the question. Use a single short sentence.",
+                "Then provide more detailed information from your knowledge.",
+                "Ask the user if they would like more specific examples or have follow-up questions.",
+            ],
+        )
+
     def _configure_parameters(self):
         """Configure Sigmond's AI parameters"""
-        self.set_params({
-            "ai_model": "gpt-4.1-nano",
-            "conscience": "Limit the conversation to the SignalWire Agents SDK and the SignalWire platform.",
-            "end_of_speech_timeout": 300,
-            "attention_timeout": 5000,
-            "inactivity_timeout": 3500000,
-            "speech_event_timeout": 900,
-            "enable_vision": True,
-            "video_idle_file": "https://mcdn.signalwire.com/videos/robot_idle2.mp4",
-            "video_talking_file": "https://mcdn.signalwire.com/videos/robot_talking2.mp4",
-            "temperature": 0.6,
-            "top_p": 0.3
-        })
-    
+        self.set_params(
+            {
+                "ai_model": "gpt-4.1-nano",
+                "conscience": "Limit the conversation to the SignalWire Agents SDK and the SignalWire platform.",
+                "end_of_speech_timeout": 300,
+                "attention_timeout": 5000,
+                "inactivity_timeout": 3500000,
+                "speech_event_timeout": 900,
+                "enable_vision": True,
+                "video_idle_file": "https://mcdn.signalwire.com/videos/robot_idle2.mp4",
+                "video_talking_file": "https://mcdn.signalwire.com/videos/robot_talking2.mp4",
+                "temperature": 0.6,
+                "top_p": 0.3,
+            }
+        )
+
     def _configure_languages(self):
         """Configure multi-language support with function fillers"""
         languages = [
             {
                 "name": "English (United States)",
-                "code": "en-US", 
+                "code": "en-US",
                 "voice": "inworld.Mark",
                 "function_fillers": [
                     "sure. hold on a second please",
-                    "ok. let me think about that", 
+                    "ok. let me think about that",
                     "I can help you with that.",
-                    "Let me explain that for you."
-                ]
+                    "Let me explain that for you.",
+                ],
             },
             {
                 "name": "Spanish",
                 "code": "multi",
                 "voice": "inworld.Mark",
                 "function_fillers": [
-                    "Claro", "espera un segundo", "Ok", "déjame explicarte eso"
-                ]
+                    "Claro",
+                    "espera un segundo",
+                    "Ok",
+                    "déjame explicarte eso",
+                ],
             },
             {
-                "name": "French", 
+                "name": "French",
                 "code": "multi",
                 "voice": "inworld.Mark",
                 "function_fillers": [
-                    "bien sur", "pas de problem", "une minute", "laisse-moi t'expliquer"
-                ]
-            }
+                    "bien sur",
+                    "pas de problem",
+                    "une minute",
+                    "laisse-moi t'expliquer",
+                ],
+            },
         ]
-        
+
         for lang in languages:
-            self.add_language(lang["name"], lang["code"], lang["voice"], 
-                            function_fillers=lang.get("function_fillers", []))
-    
+            self.add_language(
+                lang["name"],
+                lang["code"],
+                lang["voice"],
+                function_fillers=lang.get("function_fillers", []),
+            )
+
     def _configure_pronunciation(self):
         """Configure pronunciation rules for technical terms"""
         pronunciation_rules = [
@@ -178,184 +208,235 @@ class SigmondSimple(AgentBase):
             {"replace": "FastAPI", "with": "Fast A-P-I", "ignore_case": True},
             {"replace": "JSON", "with": "jay-son", "ignore_case": True},
             {"replace": "HTTP", "with": "H-T-T-P", "ignore_case": True},
-            {"replace": "CLI", "with": "C-L-I", "ignore_case": True}
+            {"replace": "CLI", "with": "C-L-I", "ignore_case": True},
         ]
-        
+
         for rule in pronunciation_rules:
-            self.add_pronunciation(rule["replace"], rule["with"], ignore_case=rule["ignore_case"])
-        
+            self.add_pronunciation(
+                rule["replace"], rule["with"], ignore_case=rule["ignore_case"]
+            )
+
         # Add hints for better recognition
         self.add_hints(["Sigmond:2.0", "SignalWire:2.0", "SDK:2.0", "AgentBase:2.0"])
         self.add_pattern_hint("swimmel:2.0", "swimmel", "SWML", ignore_case=True)
-    
+
     def _add_sdk_knowledge(self):
         """Add comprehensive SDK knowledge to the prompt"""
-        
-        self.prompt_add_section("SDK_Overview", bullets=[
-            "The SignalWire Agents SDK is a Python framework for building AI voice agents with minimal boilerplate.",
-            "It provides self-contained agents that are both web apps and AI personas.",
-            "Key features include modular skills system, SWAIG integration, state management, multi-language support, and easy deployment.",
-            "Agents are built by extending the AgentBase class and can be deployed as servers, serverless functions, or CGI scripts.",
-            "The SDK supports dynamic configuration, custom routing, SIP integration, security features, and prefab agent types."
-        ])
-        
-        self.prompt_add_section("Creating_Agents", bullets=[
-            "To create an agent, you extend the AgentBase class and create your own custom agent class.",
-            "Initialize your agent with parameters like name, route, port, and host.",
-            "Add skills to your agent using the add_skill method with the skill name and configuration options.",
-            "Define custom tools using the AgentBase tool decorator with name, description, and parameters.",
-            "Configure personality and behavior using the prompt_add_section method to structure your agent's knowledge.",
-            "Start your agent using the serve method or the run method which auto-detects the deployment environment."
-        ])
-        
-        self.prompt_add_section("Skills_System", bullets=[
-            "Skills are modular capabilities that can be added to agents with simple one-liner calls.",
-            "Built-in skills include: web search, datasphere, datetime, math, joke, and native vector search.",
-            "Skills are added by calling add_skill with the skill name and a configuration dictionary.",
-            "Each skill provides SWAIG functions that the AI can call during conversations.",
-            "Skills can be configured with custom parameters to modify their behavior.",
-            "Multiple instances of the same skill can be added with different tool names and configurations.",
-            "You can create custom skills by following the skill development patterns in the documentation."
-        ])
-        
-        self.prompt_add_section("Available_Skills", bullets=[
-            "Web Search skill: Google Custom Search API integration with web scraping, configurable results and delays.",
-            "DateTime skill: Current date and time information with timezone support.",
-            "Math skill: Safe mathematical expression evaluation for calculations.",
-            "DataSphere skill: SignalWire DataSphere knowledge search with configurable parameters.",
-            "Native Vector Search skill: Offline document search using vector similarity and keyword search.",
-            "Joke skill: Provides humor capabilities for entertainment.",
-            "Skills support multiple instances, custom tool names, and advanced configuration options."
-        ])
-        
-        self.prompt_add_section("SWAIG_Functions", bullets=[
-            "SWAIG stands for SignalWire AI Gateway and these are tools the AI can call during conversations.",
-            "Define functions using the AgentBase tool decorator, specifying the name, description, and parameters.",
-            "Functions receive parsed arguments and raw request data as parameters.",
-            "Functions should return a FunctionResult object containing the response data.",
-            "Functions can perform external API calls, database operations, or any Python logic you need.",
-            "The AI automatically decides when to call functions based on the conversation context and user needs.",
-            "Functions support security tokens, external webhooks, and custom parameter validation."
-        ])
-        
-        self.prompt_add_section("DataMap_Tools", bullets=[
-            "DataMap tools integrate directly with REST APIs without requiring custom webhook endpoints.",
-            "DataMap tools execute on the SignalWire server, making them simpler to deploy than traditional webhooks.",
-            "Create tools using the DataMap class with methods like description, parameter, webhook, and output.",
-            "Support for GET and POST requests, authentication headers, request bodies, and response processing.",
-            "Expression-based tools can handle pattern matching without making API calls.",
-            "Variable expansion using dollar sign syntax for arguments, responses, and metadata.",
-            "Helper functions available for simple API tools and expression-based tools."
-        ])
-        
-        self.prompt_add_section("Contexts_and_Steps", bullets=[
-            "Contexts and Steps provide an alternative to traditional prompts for structured workflow-driven interactions.",
-            "Define explicit step-by-step processes with navigation control and completion criteria.",
-            "Create contexts using define_contexts method and add steps with specific instructions and criteria.",
-            "Control which functions are available in each step and which steps or contexts users can navigate to.",
-            "Support for multiple contexts, step validation, function restrictions, and workflow isolation.",
-            "Useful for complex multi-step processes, customer support workflows, and guided interactions.",
-            "Works alongside traditional prompts and all existing AgentBase features."
-        ])
-        
-        self.prompt_add_section("State_Management", bullets=[
-            "The SDK is designed with a stateless-first principle - agents work perfectly without any state management.",
-            "Stateless design means agents deploy directly to serverless platforms like AWS Lambda, Google Cloud Functions, and Azure Functions.",
-            "Stateless agents can be deployed as CGI scripts, Docker containers, and scaled horizontally without coordination.",
-            "State management is an optional feature that you can enable when you specifically need persistent data across conversations.",
-            "When enabled, access current state using the get_state method and update it with the set_state method.",
-            "Implement startup_hook and hangup_hook SWAIG functions to track session lifecycle.",
-            "Use external storage (Redis, database) when you need to persist data across sessions.",
-            "Session data should be JSON-serializable to ensure proper persistence.",
-            "The startup_hook is called when a conversation begins, hangup_hook when it ends."
-        ])
-        
-        self.prompt_add_section("Dynamic_Configuration", bullets=[
-            "Dynamic configuration allows agents to be configured per-request based on parameters.",
-            "Use set_dynamic_config_callback to register a function that configures the agent for each request.",
-            "Access query parameters, body parameters, and headers to customize agent behavior.",
-            "Perfect for multi-tenant applications, A/B testing, personalization, and localization.",
-            "The agent parameter allows you to configure the agent dynamically per-request.",
-            "Supports different service tiers, languages, customer-specific configurations, and feature flags."
-        ])
-        
-        self.prompt_add_section("Advanced_Features", bullets=[
-            "SIP Integration: Route SIP calls to agents based on SIP usernames with automatic mapping.",
-            "Custom Routing: Handle different paths dynamically with routing callbacks and custom content.",
-            "Security: Built-in session management, function-specific security tokens, and basic authentication.",
-            "Multi-Agent Support: Host multiple agents on a single server with centralized routing.",
-            "Prefab Agents: Ready-to-use agent types like InfoGatherer, FAQBot, Concierge, Survey, and Receptionist.",
-            "External Input Checking: Check for new input from external systems during conversations."
-        ])
-        
-        self.prompt_add_section("Configuration_Options", bullets=[
-            "Configure AI parameters using the set_params method, including temperature, timeouts, and vision settings.",
-            "Add multiple languages using the add_language method for international support and localization.",
-            "Set pronunciation rules using the add_pronunciation method for technical terms and acronyms.",
-            "Configure speech recognition hints using the add_hints method to improve accuracy.",
-            "Use the prompt_add_section method to structure the AI's knowledge and behavioral instructions.",
-            "Environment variables can be used for API keys, configuration settings, and deployment parameters.",
-            "Support for SSL/TLS, reverse proxies, and custom webhook URLs."
-        ])
-        
-        self.prompt_add_section("Deployment_Options", bullets=[
-            "Deploy as a standalone server using the agent's serve method for development and testing.",
-            "Deploy to AWS Lambda using the Lambda deployment helpers for serverless scaling.",
-            "Deploy as CGI scripts for traditional web hosting environments.",
-            "Use Docker containers for containerized deployments and consistent environments.",
-            "Configure reverse proxies like nginx for production deployments with load balancing.",
-            "Set up SSL and TLS certificates for secure HTTPS connections in production.",
-            "The run method automatically detects the deployment environment and configures appropriately."
-        ])
-        
-        self.prompt_add_section("Local_Search_System", bullets=[
-            "The SDK includes optional local search capabilities for offline document search.",
-            "Install search features with pip install signalwire-sdk[search] or other search options.",
-            "Build search indexes using the build_search CLI command from document directories.",
-            "Native vector search skill provides hybrid vector similarity and keyword search.",
-            "Supports multiple file formats: Markdown, PDF, DOCX, HTML, Python, and more.",
-            "Can run in local mode with index files or remote mode with search servers.",
-            "Includes CLI tools, HTTP API, and smart document processing with chunking."
-        ])
-        
-        self.prompt_add_section("Testing_and_CLI", bullets=[
-            "The SDK includes swaig-test CLI tool for comprehensive local testing and serverless simulation.",
-            "Test agents locally without deployment using the swaig-test command.",
-            "Simulate serverless environments like AWS Lambda, CGI, Google Cloud Functions, and Azure Functions.",
-            "List available functions, test SWAIG function execution, and generate SWML documents.",
-            "Use environment files for consistent testing across different platforms and stages.",
-            "Cross-platform testing ensures agents work correctly across all deployment targets.",
-            "Build search indexes using the build_search CLI command with various options."
-        ])
-        
-        self.prompt_add_section("Installation_Options", bullets=[
-            "Basic installation: pip install signalwire-sdk for core functionality.",
-            "Search functionality: pip install signalwire-sdk[search] for basic search features.",
-            "Full search: pip install signalwire-sdk[search-full] adds document processing for PDF and DOCX.",
-            "Advanced NLP: pip install signalwire-sdk[search-nlp] includes spaCy for advanced text processing.",
-            "All features: pip install signalwire-sdk[search-all] includes everything.",
-            "Optional dependencies keep the base SDK lightweight while adding search and document processing when needed."
-        ])
-        
-        self.prompt_add_section("Documentation_References", bullets=[
-            "For detailed agent creation and customization, refer to the Agent Guide at docs/agent_guide.md.",
-            "For skills system details and custom skill creation, see docs/skills_system.md.",
-            "For local search system setup and usage, check docs/search-system.md.",
-            "For CLI tools and testing information, see docs/cli.md.",
-            "For architecture overview and core concepts, refer to docs/architecture.md.",
-            "For SWML service details, see docs/swml_service_guide.md.",
-            "The main README.md file provides quick start examples and feature overviews.",
-            "All documentation includes working examples and detailed API references."
-        ])
+
+        self.prompt_add_section(
+            "SDK_Overview",
+            bullets=[
+                "The SignalWire Agents SDK is a Python framework for building AI voice agents with minimal boilerplate.",
+                "It provides self-contained agents that are both web apps and AI personas.",
+                "Key features include modular skills system, SWAIG integration, state management, multi-language support, and easy deployment.",
+                "Agents are built by extending the AgentBase class and can be deployed as servers, serverless functions, or CGI scripts.",
+                "The SDK supports dynamic configuration, custom routing, SIP integration, security features, and prefab agent types.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Creating_Agents",
+            bullets=[
+                "To create an agent, you extend the AgentBase class and create your own custom agent class.",
+                "Initialize your agent with parameters like name, route, port, and host.",
+                "Add skills to your agent using the add_skill method with the skill name and configuration options.",
+                "Define custom tools using the AgentBase tool decorator with name, description, and parameters.",
+                "Configure personality and behavior using the prompt_add_section method to structure your agent's knowledge.",
+                "Start your agent using the serve method or the run method which auto-detects the deployment environment.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Skills_System",
+            bullets=[
+                "Skills are modular capabilities that can be added to agents with simple one-liner calls.",
+                "Built-in skills include: web search, datasphere, datetime, math, joke, and native vector search.",
+                "Skills are added by calling add_skill with the skill name and a configuration dictionary.",
+                "Each skill provides SWAIG functions that the AI can call during conversations.",
+                "Skills can be configured with custom parameters to modify their behavior.",
+                "Multiple instances of the same skill can be added with different tool names and configurations.",
+                "You can create custom skills by following the skill development patterns in the documentation.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Available_Skills",
+            bullets=[
+                "Web Search skill: Google Custom Search API integration with web scraping, configurable results and delays.",
+                "DateTime skill: Current date and time information with timezone support.",
+                "Math skill: Safe mathematical expression evaluation for calculations.",
+                "DataSphere skill: SignalWire DataSphere knowledge search with configurable parameters.",
+                "Native Vector Search skill: Offline document search using vector similarity and keyword search.",
+                "Joke skill: Provides humor capabilities for entertainment.",
+                "Skills support multiple instances, custom tool names, and advanced configuration options.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "SWAIG_Functions",
+            bullets=[
+                "SWAIG stands for SignalWire AI Gateway and these are tools the AI can call during conversations.",
+                "Define functions using the AgentBase tool decorator, specifying the name, description, and parameters.",
+                "Functions receive parsed arguments and raw request data as parameters.",
+                "Functions should return a FunctionResult object containing the response data.",
+                "Functions can perform external API calls, database operations, or any Python logic you need.",
+                "The AI automatically decides when to call functions based on the conversation context and user needs.",
+                "Functions support security tokens, external webhooks, and custom parameter validation.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "DataMap_Tools",
+            bullets=[
+                "DataMap tools integrate directly with REST APIs without requiring custom webhook endpoints.",
+                "DataMap tools execute on the SignalWire server, making them simpler to deploy than traditional webhooks.",
+                "Create tools using the DataMap class with methods like description, parameter, webhook, and output.",
+                "Support for GET and POST requests, authentication headers, request bodies, and response processing.",
+                "Expression-based tools can handle pattern matching without making API calls.",
+                "Variable expansion using dollar sign syntax for arguments, responses, and metadata.",
+                "Helper functions available for simple API tools and expression-based tools.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Contexts_and_Steps",
+            bullets=[
+                "Contexts and Steps provide an alternative to traditional prompts for structured workflow-driven interactions.",
+                "Define explicit step-by-step processes with navigation control and completion criteria.",
+                "Create contexts using define_contexts method and add steps with specific instructions and criteria.",
+                "Control which functions are available in each step and which steps or contexts users can navigate to.",
+                "Support for multiple contexts, step validation, function restrictions, and workflow isolation.",
+                "Useful for complex multi-step processes, customer support workflows, and guided interactions.",
+                "Works alongside traditional prompts and all existing AgentBase features.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "State_Management",
+            bullets=[
+                "The SDK is designed with a stateless-first principle - agents work perfectly without any state management.",
+                "Stateless design means agents deploy directly to serverless platforms like AWS Lambda, Google Cloud Functions, and Azure Functions.",
+                "Stateless agents can be deployed as CGI scripts, Docker containers, and scaled horizontally without coordination.",
+                "State management is an optional feature that you can enable when you specifically need persistent data across conversations.",
+                "When enabled, access current state using the get_state method and update it with the set_state method.",
+                "Implement startup_hook and hangup_hook SWAIG functions to track session lifecycle.",
+                "Use external storage (Redis, database) when you need to persist data across sessions.",
+                "Session data should be JSON-serializable to ensure proper persistence.",
+                "The startup_hook is called when a conversation begins, hangup_hook when it ends.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Dynamic_Configuration",
+            bullets=[
+                "Dynamic configuration allows agents to be configured per-request based on parameters.",
+                "Use set_dynamic_config_callback to register a function that configures the agent for each request.",
+                "Access query parameters, body parameters, and headers to customize agent behavior.",
+                "Perfect for multi-tenant applications, A/B testing, personalization, and localization.",
+                "The agent parameter allows you to configure the agent dynamically per-request.",
+                "Supports different service tiers, languages, customer-specific configurations, and feature flags.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Advanced_Features",
+            bullets=[
+                "SIP Integration: Route SIP calls to agents based on SIP usernames with automatic mapping.",
+                "Custom Routing: Handle different paths dynamically with routing callbacks and custom content.",
+                "Security: Built-in session management, function-specific security tokens, and basic authentication.",
+                "Multi-Agent Support: Host multiple agents on a single server with centralized routing.",
+                "Prefab Agents: Ready-to-use agent types like InfoGatherer, FAQBot, Concierge, Survey, and Receptionist.",
+                "External Input Checking: Check for new input from external systems during conversations.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Configuration_Options",
+            bullets=[
+                "Configure AI parameters using the set_params method, including temperature, timeouts, and vision settings.",
+                "Add multiple languages using the add_language method for international support and localization.",
+                "Set pronunciation rules using the add_pronunciation method for technical terms and acronyms.",
+                "Configure speech recognition hints using the add_hints method to improve accuracy.",
+                "Use the prompt_add_section method to structure the AI's knowledge and behavioral instructions.",
+                "Environment variables can be used for API keys, configuration settings, and deployment parameters.",
+                "Support for SSL/TLS, reverse proxies, and custom webhook URLs.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Deployment_Options",
+            bullets=[
+                "Deploy as a standalone server using the agent's serve method for development and testing.",
+                "Deploy to AWS Lambda using the Lambda deployment helpers for serverless scaling.",
+                "Deploy as CGI scripts for traditional web hosting environments.",
+                "Use Docker containers for containerized deployments and consistent environments.",
+                "Configure reverse proxies like nginx for production deployments with load balancing.",
+                "Set up SSL and TLS certificates for secure HTTPS connections in production.",
+                "The run method automatically detects the deployment environment and configures appropriately.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Local_Search_System",
+            bullets=[
+                "The SDK includes optional local search capabilities for offline document search.",
+                "Install search features with pip install signalwire-sdk[search] or other search options.",
+                "Build search indexes using the build_search CLI command from document directories.",
+                "Native vector search skill provides hybrid vector similarity and keyword search.",
+                "Supports multiple file formats: Markdown, PDF, DOCX, HTML, Python, and more.",
+                "Can run in local mode with index files or remote mode with search servers.",
+                "Includes CLI tools, HTTP API, and smart document processing with chunking.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Testing_and_CLI",
+            bullets=[
+                "The SDK includes swaig-test CLI tool for comprehensive local testing and serverless simulation.",
+                "Test agents locally without deployment using the swaig-test command.",
+                "Simulate serverless environments like AWS Lambda, CGI, Google Cloud Functions, and Azure Functions.",
+                "List available functions, test SWAIG function execution, and generate SWML documents.",
+                "Use environment files for consistent testing across different platforms and stages.",
+                "Cross-platform testing ensures agents work correctly across all deployment targets.",
+                "Build search indexes using the build_search CLI command with various options.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Installation_Options",
+            bullets=[
+                "Basic installation: pip install signalwire-sdk for core functionality.",
+                "Search functionality: pip install signalwire-sdk[search] for basic search features.",
+                "Full search: pip install signalwire-sdk[search-full] adds document processing for PDF and DOCX.",
+                "Advanced NLP: pip install signalwire-sdk[search-nlp] includes spaCy for advanced text processing.",
+                "All features: pip install signalwire-sdk[search-all] includes everything.",
+                "Optional dependencies keep the base SDK lightweight while adding search and document processing when needed.",
+            ],
+        )
+
+        self.prompt_add_section(
+            "Documentation_References",
+            bullets=[
+                "For detailed agent creation and customization, refer to the Agent Guide at docs/agent_guide.md.",
+                "For skills system details and custom skill creation, see docs/skills_system.md.",
+                "For local search system setup and usage, check docs/search-system.md.",
+                "For CLI tools and testing information, see docs/cli.md.",
+                "For architecture overview and core concepts, refer to docs/architecture.md.",
+                "For SWML service details, see docs/swml_service_guide.md.",
+                "The main README.md file provides quick start examples and feature overviews.",
+                "All documentation includes working examples and detailed API references.",
+            ],
+        )
+
 
 def main():
     """Run the Sigmond Simple Bot"""
     logger.info("Starting Sigmond Simple Bot...")
     logger.info("This bot provides basic SDK guidance without search functionality")
-    
+
     # Create and run the agent
     agent = SigmondSimple()
-    
+
     logger.info("Sigmond Simple Bot is ready")
     logger.info("Try asking questions like:")
     logger.info("- 'How do I create an agent?'")
@@ -363,8 +444,9 @@ def main():
     logger.info("- 'How do I add state management?'")
     logger.info("- 'How do I deploy my agent?'")
     logger.info("Starting server...")
-    
+
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/simple_agent.py
+++ b/examples/simple_agent.py
@@ -19,7 +19,7 @@ This uses the refactored AgentBase class that internally uses SWMLService.
 """
 
 from datetime import datetime
-import os
+from pathlib import Path
 import json
 import argparse
 
@@ -49,21 +49,21 @@ class SimpleAgent(AgentBase):
         # Find schema.json in the current directory or parent directory
         # The schema.json file defines the valid structure for SWML documents
         # and is used for validation during document creation
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        parent_dir = os.path.dirname(current_dir)
+        current_dir = Path(__file__).resolve().parent
+        parent_dir = current_dir.parent
 
         # Try to find schema.json in several locations
         # This allows the example to work regardless of where it's run from
         schema_locations = [
-            os.path.join(current_dir, "schema.json"),
-            os.path.join(parent_dir, "schema.json"),
-            os.path.join(os.path.dirname(os.path.dirname(__file__)), "schema.json"),
+            current_dir / "schema.json",
+            parent_dir / "schema.json",
+            Path(__file__).parent.parent / "schema.json",
         ]
 
         schema_path = None
         for loc in schema_locations:
-            if os.path.exists(loc):
-                schema_path = loc
+            if loc.exists():
+                schema_path = str(loc)
                 logger.info("schema_found", path=schema_path)
                 break
 

--- a/examples/simple_agent.py
+++ b/examples/simple_agent.py
@@ -20,10 +20,8 @@ This uses the refactored AgentBase class that internally uses SWMLService.
 
 from datetime import datetime
 import os
-import sys
 import json
 import argparse
-import fastapi
 
 from signalwire import AgentBase
 from signalwire.core.function_result import FunctionResult
@@ -32,45 +30,46 @@ from signalwire.core.logging_config import get_logger
 # Create structured logger using the SDK's centralized logging
 logger = get_logger("signalwire.examples.simple_agent")
 
+
 class SimpleAgent(AgentBase):
     """
     A simple agent that demonstrates using explicit methods
     to manipulate the POM structure directly
-    
+
     This example shows:
-    
+
     1. How to create an agent with a structured prompt using POM
     2. How to define SWAIG functions that the AI can call
     3. How to return results from SWAIG functions
     4. How to configure various AI verb parameters
     5. How to configure SWAIG with native functions and remote includes
     """
-    
+
     def __init__(self, suppress_logs=False):
         # Find schema.json in the current directory or parent directory
         # The schema.json file defines the valid structure for SWML documents
         # and is used for validation during document creation
         current_dir = os.path.dirname(os.path.abspath(__file__))
         parent_dir = os.path.dirname(current_dir)
-        
+
         # Try to find schema.json in several locations
         # This allows the example to work regardless of where it's run from
         schema_locations = [
             os.path.join(current_dir, "schema.json"),
             os.path.join(parent_dir, "schema.json"),
-            os.path.join(os.path.dirname(os.path.dirname(__file__)), "schema.json")
+            os.path.join(os.path.dirname(os.path.dirname(__file__)), "schema.json"),
         ]
-        
+
         schema_path = None
         for loc in schema_locations:
             if os.path.exists(loc):
                 schema_path = loc
                 logger.info("schema_found", path=schema_path)
                 break
-                
+
         if not schema_path:
             logger.warning("schema_not_found", locations=schema_locations)
-            
+
         # Initialize the agent with a name and route
         # The name is used for identification and logging
         # The route defines the HTTP endpoint path for the agent (e.g., /simple)
@@ -78,41 +77,40 @@ class SimpleAgent(AgentBase):
             name="simple",
             route="/simple",
             host="0.0.0.0",  # Bind to all interfaces
-            port=3000,       # Listen on port 3000
-            use_pom=True,    # Enable Prompt Object Model for structured prompts
+            port=3000,  # Listen on port 3000
+            use_pom=True,  # Enable Prompt Object Model for structured prompts
             schema_path=schema_path,  # Pass the explicit schema path for validation
-            suppress_logs=suppress_logs  # Option to reduce log output
+            suppress_logs=suppress_logs,  # Option to reduce log output
         )
-        
-        #------------------------------------------------------------------------
+
+        # ------------------------------------------------------------------------
         # PROMPT CONFIGURATION
         # Set up the AI's personality, goals, and instructions using POM structure
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Initialize POM sections using convenience methods
         # These methods call prompt_add_section() internally with appropriate section titles
         self.setPersonality("You are a friendly and helpful assistant.")
         self.setGoal("Help users with basic tasks and answer questions.")
-        self.setInstructions([
-            "Be concise and direct in your responses.",
-            "If you don't know something, say so clearly.",
-            "Use the get_time function when asked about the current time.",
-            "Use the get_weather function when asked about the weather."
-        ])
-
+        self.setInstructions(
+            [
+                "Be concise and direct in your responses.",
+                "If you don't know something, say so clearly.",
+                "Use the get_time function when asked about the current time.",
+                "Use the get_weather function when asked about the weather.",
+            ]
+        )
 
         # Optional: Set LLM parameters for fine-tuned control
         # These parameters are passed to the server which validates them based on the model
         self.set_prompt_llm_params(
-            temperature=0.3,        # Low temperature for more consistent responses
-            top_p=0.9,             # Slightly reduced for focused responses
-            barge_confidence=0.7,   # Higher confidence threshold
-            presence_penalty=0.1,   # Slight penalty for repetition
-            frequency_penalty=0.2   # Encourage varied vocabulary
+            temperature=0.3,  # Low temperature for more consistent responses
+            top_p=0.9,  # Slightly reduced for focused responses
+            barge_confidence=0.7,  # Higher confidence threshold
+            presence_penalty=0.1,  # Slight penalty for repetition
+            frequency_penalty=0.2,  # Encourage varied vocabulary
         )
 
-        
-        
         # Add a post-prompt for summary generation
         # This is processed after the conversation ends to generate a summary
         # The summary is received in the on_summary method
@@ -124,49 +122,45 @@ class SimpleAgent(AgentBase):
             "follow_up_needed": true/false
         }
         """)
-        
-        #------------------------------------------------------------------------
+
+        # ------------------------------------------------------------------------
         # PRONUNCIATION AND HINTS
         # Help the AI understand and pronounce certain terms correctly
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Configure hints to help the AI understand certain words
         # Hints are used to improve entity recognition in the conversation
-        self.add_hints([
-            "SignalWire", 
-            "SWML", 
-            "SWAIG"
-        ])
-        
+        self.add_hints(["SignalWire", "SWML", "SWAIG"])
+
         # Add a pattern hint for pronunciation
         # Pattern hints use regex to match text patterns and provide replacements
         # This helps the AI pronounce terms more naturally
         self.add_pattern_hint(
-            hint="AI Agent",           # Term to help with
-            pattern="AI\\s+Agent",     # Regex pattern to match
-            replace="A.I. Agent",      # Replacement for pronunciation
-            ignore_case=True           # Case-insensitive matching
+            hint="AI Agent",  # Term to help with
+            pattern="AI\\s+Agent",  # Regex pattern to match
+            replace="A.I. Agent",  # Replacement for pronunciation
+            ignore_case=True,  # Case-insensitive matching
         )
-        
+
         # Add simple pronunciation rules
         # These map exact terms to the phonetic way they should be pronounced
         self.add_pronunciation("API", "A P I", ignore_case=False)  # Spell out A-P-I
-        self.add_pronunciation("SIP", "sip", ignore_case=True)     # Pronounce as word
-        
-        #------------------------------------------------------------------------
+        self.add_pronunciation("SIP", "sip", ignore_case=True)  # Pronounce as word
+
+        # ------------------------------------------------------------------------
         # MULTILINGUAL SUPPORT
         # Configure multiple languages with different voice options
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Example 1: Primary language with voice and fillers
         self.add_language(
-            name="English",    # Display name for the language
-            code="en-US",      # ISO language code
+            name="English",  # Display name for the language
+            code="en-US",  # ISO language code
             voice="inworld.Mark",  # Voice ID with provider prefix
             # Phrases to use when the AI needs time to think
             speech_fillers=["Let me think about that...", "One moment please..."],
             # Phrases to use when the AI is calling a function
-            function_fillers=["I'm looking that up for you...", "Let me check that..."]
+            function_fillers=["I'm looking that up for you...", "Let me check that..."],
         )
 
         # Example 2: Additional language with fillers
@@ -175,170 +169,171 @@ class SimpleAgent(AgentBase):
             code="es",
             voice="inworld.Sarah",
             speech_fillers=["Un momento por favor...", "Estoy pensando..."],
-            function_fillers=["Estoy buscando esa información...", "Déjame verificar..."]
+            function_fillers=[
+                "Estoy buscando esa información...",
+                "Déjame verificar...",
+            ],
         )
 
         # Example 3: Additional language (minimal)
-        self.add_language(
-            name="French",
-            code="fr-FR",
-            voice="inworld.Hanna"
-        )
+        self.add_language(name="French", code="fr-FR", voice="inworld.Hanna")
 
         # Example 4: Additional language (minimal)
-        self.add_language(
-            name="German",
-            code="de-DE",
-            voice="inworld.Blake"
-        )
-        
-        #------------------------------------------------------------------------
+        self.add_language(name="German", code="de-DE", voice="inworld.Blake")
+
+        # ------------------------------------------------------------------------
         # AI BEHAVIOR PARAMETERS
         # Configure how the AI interacts with users
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Set AI behavior parameters that control conversation flow
-        self.set_params({
-            "ai_model": "gpt-4.1-nano",
-            "wait_for_user": False,          # Start speaking immediately rather than waiting
-            "end_of_speech_timeout": 1000,   # Milliseconds of silence before assuming speech ended
-            "ai_volume": 5,                  # Voice volume level
-            "languages_enabled": True,       # Enable multilingual support
-            "local_tz": "America/Los_Angeles" # Default timezone for time-related functions
-        })
-        
+        self.set_params(
+            {
+                "ai_model": "gpt-4.1-nano",
+                "wait_for_user": False,  # Start speaking immediately rather than waiting
+                "end_of_speech_timeout": 1000,  # Milliseconds of silence before assuming speech ended
+                "ai_volume": 5,  # Voice volume level
+                "languages_enabled": True,  # Enable multilingual support
+                "local_tz": "America/Los_Angeles",  # Default timezone for time-related functions
+            }
+        )
+
         # Add global data available to the AI
         # This provides context that the AI can reference during conversations
-        self.set_global_data({
-            "company_name": "SignalWire",
-            "product": "AI Agent SDK",
-            "supported_features": [
-                "Voice AI",
-                "Telephone integration",
-                "SWAIG functions"
-            ]
-        })
-        
-        #------------------------------------------------------------------------
+        self.set_global_data(
+            {
+                "company_name": "SignalWire",
+                "product": "AI Agent SDK",
+                "supported_features": [
+                    "Voice AI",
+                    "Telephone integration",
+                    "SWAIG functions",
+                ],
+            }
+        )
+
+        # ------------------------------------------------------------------------
         # FUNCTION CONFIGURATION
         # Set up built-in and remote functions the AI can call
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Configure native functions (built-in functions provided by SignalWire)
         # These don't require implementation in the agent class
-        self.set_native_functions([
-            "check_time",     # Get the current time in various formats
-            "wait_seconds"    # Pause the conversation for a specified duration
-        ])
-        
+        self.set_native_functions(
+            [
+                "check_time",  # Get the current time in various formats
+                "wait_seconds",  # Pause the conversation for a specified duration
+            ]
+        )
+
         # Add remote function includes
         # These are functions hosted at external URLs that the AI can call
         # First remote endpoint with metadata
         self.add_function_include(
             url="https://api.example.com/remote-functions",  # API endpoint
             functions=[  # List of available functions at this endpoint
-                "get_weather_extended", 
-                "get_traffic", 
-                "get_news"
+                "get_weather_extended",
+                "get_traffic",
+                "get_news",
             ],
             meta_data={  # Additional data for the API call
                 "auth_type": "bearer",
-                "region": "us-west"
-            }
+                "region": "us-west",
+            },
         )
-        
+
         # Add another remote function include with a different URL
         # This one doesn't include metadata, using default settings
         self.add_function_include(
             url="https://ai-tools.example.org/functions",
-            functions=["translate_text", "summarize_document"]
+            functions=["translate_text", "summarize_document"],
         )
-        
-        #------------------------------------------------------------------------
+
+        # ------------------------------------------------------------------------
         # SIP ROUTING CONFIGURATION
         # Enable the agent to be reachable via SIP for voice calls
-        #------------------------------------------------------------------------
-        
+        # ------------------------------------------------------------------------
+
         # Enable SIP routing for this agent with auto_map=True
         # This allows the agent to be contacted through SIP protocol
         # auto_map=True creates a default SIP mapping using the agent's name
         # (e.g., simple@your-sip-domain)
         self.enable_sip_routing(auto_map=True)
-        
+
         # Register additional SIP usernames for this agent
         # These provide alternative ways to reach the same agent
         # (e.g., simple_agent@your-sip-domain, assistant@your-sip-domain)
         self.register_sip_username("simple_agent")
         self.register_sip_username("assistant")
-        
+
         # Log that the agent has been fully initialized
         logger.info("agent_initialized", agent_name=self.name, route=self.route)
-    
+
     def setPersonality(self, personality_text):
         """
         Set the AI personality description
-        
+
         This is a convenience method that adds a Personality section to the prompt.
         The personality defines the AI's character, tone, and style of interaction.
-        
+
         Args:
             personality_text: The personality description as a string
-            
+
         Returns:
             self: For method chaining
         """
         self.prompt_add_section("Personality", body=personality_text)
         return self
-    
+
     def setGoal(self, goal_text):
         """
         Set the primary goal for the AI agent
-        
+
         This is a convenience method that adds a Goal section to the prompt.
         The goal defines the AI's primary purpose and objective.
-        
+
         Args:
             goal_text: The goal description as a string
-            
+
         Returns:
             self: For method chaining
         """
         self.prompt_add_section("Goal", body=goal_text)
         return self
-    
+
     def setInstructions(self, instructions_list):
         """
         Set the list of instructions for the AI agent
-        
+
         This is a convenience method that adds an Instructions section to the prompt.
         Instructions provide specific guidance for the AI's behavior.
-        
+
         Args:
             instructions_list: List of instruction strings
-            
+
         Returns:
             self: For method chaining
         """
         if instructions_list:
             self.prompt_add_section("Instructions", bullets=instructions_list)
         return self
-    
+
     @AgentBase.tool(
         name="get_time",
         description="Get the current time",
-        parameters={}  # No parameters needed for this function
+        parameters={},  # No parameters needed for this function
     )
     def get_time(self, args, raw_data):
         """
         Get the current time
-        
+
         This SWAIG function is called by the AI when a user asks about the current time.
         It returns the current time in HH:MM:SS format.
-        
+
         Args:
             args: Dictionary containing parsed parameters (empty for this function)
             raw_data: Complete request data including call_id and other metadata
-            
+
         Returns:
             FunctionResult containing the current time
         """
@@ -346,62 +341,64 @@ class SimpleAgent(AgentBase):
         formatted_time = now.strftime("%H:%M:%S")
         logger.debug("get_time_called", time=formatted_time)
         return FunctionResult(f"The current time is {formatted_time}")
-    
+
     @AgentBase.tool(
         name="get_weather",
         description="Get the current weather for a location",
         parameters={
             "location": {
                 "type": "string",
-                "description": "The city or location to get weather for"
+                "description": "The city or location to get weather for",
             }
-        }
+        },
     )
     def get_weather(self, args, raw_data):
         """
         Get the current weather for a location
-        
+
         This SWAIG function is called by the AI when a user asks about weather.
         Parameters are passed in the args dictionary, while the complete request
         data is in raw_data.
-        
+
         Args:
             args: Dictionary containing parsed parameters (location)
             raw_data: Complete request data including call_id and other metadata
-            
+
         Returns:
             FunctionResult containing the response text and optional actions
         """
-        # Extract location from the args dictionary 
+        # Extract location from the args dictionary
         location = args.get("location", "Unknown location")
-        
+
         # Log the function call with structured data
         logger.debug("get_weather_called", location=location)
-        
+
         # Create the result with a response and multiple actions using add_actions
         # In a real implementation, this would call a weather API
         # For this example, we return mock data with multiple actions
         result = FunctionResult(f"It's sunny and 72°F in {location}.")
-        
+
         # Example 1: Add a single action using add_action
         result.add_action("set_global_data", {"weather_location": location})
-        
+
         # Example 2: Add multiple actions at once using add_actions
-        result.add_actions([
-            {"playback_bg": {"file": "https://example.com/weather_sounds.mp3"}},
-            {"log": {"message": f"Weather requested for {location}"}}
-        ])
-        
+        result.add_actions(
+            [
+                {"playback_bg": {"file": "https://example.com/weather_sounds.mp3"}},
+                {"log": {"message": f"Weather requested for {location}"}},
+            ]
+        )
+
         return result
-    
+
     def on_summary(self, summary, raw_data=None):
         """
         Handle the conversation summary
-        
+
         This method is called after the conversation ends when a post_prompt
         was configured. It processes the summary generated by the AI based on
         the post_prompt instructions.
-        
+
         Args:
             summary: The summary object or None if no summary was found
             raw_data: The complete raw POST data from the request
@@ -412,52 +409,56 @@ class SimpleAgent(AgentBase):
                 print("SUMMARY: " + json.dumps(summary))
             else:
                 print(f"SUMMARY: {summary}")
-        
+
         # Also directly print parsed array if available
         # The post_prompt_data contains both raw and parsed versions of the summary
-        if raw_data and 'post_prompt_data' in raw_data:
-            post_prompt_data = raw_data.get('post_prompt_data')
-            
+        if raw_data and "post_prompt_data" in raw_data:
+            post_prompt_data = raw_data.get("post_prompt_data")
+
             # Print parsed summary data if available (usually a JSON object)
-            if isinstance(post_prompt_data, dict) and 'parsed' in post_prompt_data:
-                parsed = post_prompt_data.get('parsed')
+            if isinstance(post_prompt_data, dict) and "parsed" in post_prompt_data:
+                parsed = post_prompt_data.get("parsed")
                 if parsed and len(parsed) > 0:
                     print("PARSED_SUMMARY: " + json.dumps(parsed[0]))
-            
+
             # Print raw summary if available (this is the unprocessed text)
-            if isinstance(post_prompt_data, dict) and 'raw' in post_prompt_data:
-                raw = post_prompt_data.get('raw')
+            if isinstance(post_prompt_data, dict) and "raw" in post_prompt_data:
+                raw = post_prompt_data.get("raw")
                 if isinstance(raw, str):
                     print(f"RAW_SUMMARY: {raw}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run the SimpleAgent")
-    parser.add_argument("--suppress-logs", action="store_true", help="Suppress extra logs")
+    parser.add_argument(
+        "--suppress-logs", action="store_true", help="Suppress extra logs"
+    )
     args = parser.parse_args()
-    
+
     # Create an agent instance with log suppression if requested
     agent = SimpleAgent(suppress_logs=args.suppress_logs)
-    
+
     # Get and print the authentication credentials
     # include_source=True also returns where the credentials came from
     # (generated, environment variables, or explicitly provided)
     username, password, source = agent.get_basic_auth_credentials(include_source=True)
-    
+
     # Log agent startup with structured data
-    logger.info("starting_agent", 
-               url=f"http://localhost:3000/simple", 
-               username=username, 
-               password_length=len(password),
-               auth_source=source)
-    
+    logger.info(
+        "starting_agent",
+        url="http://localhost:3000/simple",
+        username=username,
+        password_length=len(password),
+        auth_source=source,
+    )
+
     # Print user-friendly startup message with access details
     print("Starting the agent. Press Ctrl+C to stop.")
-    print(f"Agent 'simple' is available at:")
-    print(f"URL: http://localhost:3000/simple")
+    print("Agent 'simple' is available at:")
+    print("URL: http://localhost:3000/simple")
     print(f"Basic Auth: {username}:{password}")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
-    
+
     try:
         # Start the agent's server using the built-in serve method
         # This starts a uvicorn server with the FastAPI app
@@ -465,4 +466,4 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         # Handle clean shutdown on Ctrl+C
         logger.info("server_shutdown")
-        print("\nStopping the agent.") 
+        print("\nStopping the agent.")

--- a/examples/simple_dynamic_agent.py
+++ b/examples/simple_dynamic_agent.py
@@ -8,7 +8,6 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-
 """
 Simple Dynamic Agent Example (New Way)
 
@@ -41,85 +40,81 @@ Compare the SWML output - it will be IDENTICAL to the static version!
 
 from signalwire import AgentBase
 
+
 class SimpleDynamicAgent(AgentBase):
     def __init__(self):
         super().__init__(
             name="Simple Customer Service Agent (Dynamic)",
             auto_answer=True,
-            record_call=True
+            record_call=True,
         )
-        
+
         # NO STATIC CONFIGURATION HERE!
         # Instead, we set up a dynamic configuration callback
         self.set_dynamic_config_callback(self.configure_agent_dynamically)
-    
+
     def configure_agent_dynamically(self, query_params, body_params, headers, agent):
         """
         DYNAMIC CONFIGURATION - Called fresh for every request
-        
+
         This method receives the agent instance directly, allowing you to
         configure it dynamically based on the request data.
-        
+
         Args:
             query_params: Query string parameters from the request
             body_params: POST body parameters (empty for GET requests)
             headers: HTTP headers from the request
             agent: The agent instance to configure
         """
-        
+
         # EXACT SAME CONFIGURATION as the static version
         # But now it happens fresh for every request!
-        
+
         # Voice and language (same as static version)
         agent.add_language("English", "en-US", "inworld.Mark")
-        
+
         # AI parameters (same as static version)
-        agent.set_params({
-            "ai_model": "gpt-4.1-nano",
-            "end_of_speech_timeout": 500,
-            "attention_timeout": 15000,
-            "background_file_volume": -20
-        })
-        
-        # Hints for speech recognition (same as static version)
-        agent.add_hints([
-            "SignalWire",
-            "SWML",
-            "API", 
-            "webhook",
-            "SIP"
-        ])
-        
-        # Global data (same as static version)
-        agent.set_global_data({
-            "agent_type": "customer_service",
-            "service_level": "standard",
-            "features_enabled": ["basic_conversation", "help_desk"],
-            "session_info": {
-                "environment": "production",
-                "version": "1.0"
+        agent.set_params(
+            {
+                "ai_model": "gpt-4.1-nano",
+                "end_of_speech_timeout": 500,
+                "attention_timeout": 15000,
+                "background_file_volume": -20,
             }
-        })
-        
+        )
+
+        # Hints for speech recognition (same as static version)
+        agent.add_hints(["SignalWire", "SWML", "API", "webhook", "SIP"])
+
+        # Global data (same as static version)
+        agent.set_global_data(
+            {
+                "agent_type": "customer_service",
+                "service_level": "standard",
+                "features_enabled": ["basic_conversation", "help_desk"],
+                "session_info": {"environment": "production", "version": "1.0"},
+            }
+        )
+
         # Prompt sections (same as static version)
         agent.prompt_add_section(
             "Role and Purpose",
             "You are a professional customer service representative. Your goal is to help "
-            "customers with their questions and provide excellent service."
+            "customers with their questions and provide excellent service.",
         )
-        
+
         agent.prompt_add_section(
-            "Guidelines", 
+            "Guidelines",
             "Follow these customer service principles:",
             bullets=[
                 "Listen carefully to customer needs",
                 "Provide accurate and helpful information",
-                "Maintain a professional and friendly tone", 
+                "Maintain a professional and friendly tone",
                 "Escalate complex issues when appropriate",
-                "Always confirm understanding before ending"
-            ]
+                "Always confirm understanding before ending",
+            ],
         )
-        
+
         agent.prompt_add_section(
             "Available Services",
             "You can help customers with:",
@@ -128,10 +123,10 @@ class SimpleDynamicAgent(AgentBase):
                 "Account questions and support",
                 "Technical troubleshooting guidance",
                 "Billing and payment inquiries",
-                "Service status and updates"
-            ]
+                "Service status and updates",
+            ],
         )
-        
+
         # BONUS: We could easily add parameter-based customization here!
         # For example (commented out for this basic demo):
         #
@@ -150,6 +145,6 @@ if __name__ == "__main__":
     print("Starting Simple Dynamic Agent - configuration changes based on requests")
     print("Available at: http://localhost:3000/")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
-    
+
     agent = SimpleDynamicAgent()
-    agent.run() 
+    agent.run()

--- a/examples/simple_dynamic_enhanced.py
+++ b/examples/simple_dynamic_enhanced.py
@@ -8,7 +8,6 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-
 """
 Simple Dynamic Agent - Enhanced Example
 
@@ -46,94 +45,87 @@ Try these requests to see the differences:
 
 from signalwire import AgentBase
 
+
 class SimpleDynamicEnhanced(AgentBase):
     def __init__(self):
         super().__init__(
             name="Enhanced Dynamic Customer Service Agent",
             auto_answer=True,
-            record_call=True
+            record_call=True,
         )
-        
+
         # Set up dynamic configuration callback
         self.set_dynamic_config_callback(self.configure_agent_dynamically)
-    
+
     def configure_agent_dynamically(self, query_params, body_params, headers, agent):
         """
         ENHANCED DYNAMIC CONFIGURATION - Adapts based on request parameters
-        
+
         This shows the real power of the dynamic pattern!
         """
-        
+
         # Extract parameters from the request
-        is_vip = query_params.get('vip', '').lower() == 'true'
-        department = query_params.get('department', 'general').lower()
-        customer_id = query_params.get('customer_id', '')
-        language = query_params.get('language', 'en').lower()
-        
+        is_vip = query_params.get("vip", "").lower() == "true"
+        department = query_params.get("department", "general").lower()
+        customer_id = query_params.get("customer_id", "")
+        language = query_params.get("language", "en").lower()
+
         # === VOICE AND LANGUAGE CONFIGURATION ===
-        if language == 'es':
+        if language == "es":
             if is_vip:
-                agent.add_language("Spanish", "es-ES", "inworld.Sarah")  # Premium for VIP
+                agent.add_language(
+                    "Spanish", "es-ES", "inworld.Sarah"
+                )  # Premium for VIP
             else:
-                agent.add_language("Spanish", "es-ES", "inworld.Mark")  # Standard Spanish
+                agent.add_language(
+                    "Spanish", "es-ES", "inworld.Mark"
+                )  # Standard Spanish
         else:  # English
             if is_vip:
-                agent.add_language("English", "en-US", "inworld.Sarah")  # Premium voice for VIP
+                agent.add_language(
+                    "English", "en-US", "inworld.Sarah"
+                )  # Premium voice for VIP
             else:
-                agent.add_language("English", "en-US", "inworld.Mark")  # Standard professional voice
-        
+                agent.add_language(
+                    "English", "en-US", "inworld.Mark"
+                )  # Standard professional voice
+
         # === AI PARAMETERS (VIP gets faster response) ===
         if is_vip:
-            agent.set_params({
-                "ai_model": "gpt-4.1-nano",
-                "end_of_speech_timeout": 300,  # Faster for VIP
-                "attention_timeout": 20000,     # Longer attention for VIP
-                "background_file_volume": -30   # Better audio quality
-            })
+            agent.set_params(
+                {
+                    "ai_model": "gpt-4.1-nano",
+                    "end_of_speech_timeout": 300,  # Faster for VIP
+                    "attention_timeout": 20000,  # Longer attention for VIP
+                    "background_file_volume": -30,  # Better audio quality
+                }
+            )
         else:
-            agent.set_params({
-                "ai_model": "gpt-4.1-nano",
-                "end_of_speech_timeout": 500,  # Standard timing
-                "attention_timeout": 15000,     # Standard attention span
-                "background_file_volume": -20   # Standard audio
-            })
-        
+            agent.set_params(
+                {
+                    "ai_model": "gpt-4.1-nano",
+                    "end_of_speech_timeout": 500,  # Standard timing
+                    "attention_timeout": 15000,  # Standard attention span
+                    "background_file_volume": -20,  # Standard audio
+                }
+            )
+
         # === HINTS (Speech recognition aids based on department) ===
-        base_hints = [
-            "SignalWire",
-            "SWML",
-            "API",
-            "webhook",
-            "SIP"
-        ]
-        
-        if department == 'sales':
-            base_hints.extend([
-                "pricing",
-                "enterprise",
-                "premium",
-                "subscription",
-                "upgrade"
-            ])
-        elif department == 'billing':
-            base_hints.extend([
-                "invoice",
-                "payment",
-                "billing",
-                "account",
-                "charges"
-            ])
+        base_hints = ["SignalWire", "SWML", "API", "webhook", "SIP"]
+
+        if department == "sales":
+            base_hints.extend(
+                ["pricing", "enterprise", "premium", "subscription", "upgrade"]
+            )
+        elif department == "billing":
+            base_hints.extend(["invoice", "payment", "billing", "account", "charges"])
         else:  # general support
-            base_hints.extend([
-                "support",
-                "technical",
-                "troubleshoot",
-                "configuration",
-                "integration"
-            ])
-        
+            base_hints.extend(
+                ["support", "technical", "troubleshoot", "configuration", "integration"]
+            )
+
         agent.add_hints(base_hints)
-        
+
         # === GLOBAL DATA (Customer-specific information) ===
         global_data = {
             "agent_type": "customer_service",
@@ -144,36 +136,38 @@ class SimpleDynamicEnhanced(AgentBase):
             "session_info": {
                 "environment": "production",
                 "version": "1.0",
-                "request_timestamp": "2024-01-01T00:00:00Z"  # Would be actual timestamp
-            }
+                "request_timestamp": "2024-01-01T00:00:00Z",  # Would be actual timestamp
+            },
         }
-        
+
         if customer_id:
             global_data["customer_id"] = customer_id
             global_data["personalized"] = True
-        
+
         if is_vip:
-            global_data["features_enabled"].extend(["priority_support", "premium_features"])
-        
+            global_data["features_enabled"].extend(
+                ["priority_support", "premium_features"]
+            )
+
         agent.set_global_data(global_data)
-        
+
         # === DYNAMIC PROMPTS (Department-specific) ===
-        
+
         # Base role (personalized if we have customer_id)
         if customer_id:
             role_text = f"You are a professional customer service representative helping customer {customer_id}. "
         else:
             role_text = "You are a professional customer service representative. "
-            
+
         if is_vip:
             role_text += "This is a VIP customer who receives priority service and premium support."
         else:
             role_text += "Your goal is to help customers with their questions and provide excellent service."
-        
+
         agent.prompt_add_section("Role and Purpose", role_text)
-        
+
         # Department-specific expertise
-        if department == 'sales':
+        if department == "sales":
             agent.prompt_add_section(
                 "Sales Expertise",
                 "You specialize in sales and product consultation:",
@@ -182,20 +176,20 @@ class SimpleDynamicEnhanced(AgentBase):
                     "Understand customer needs and match solutions",
                     "Handle pricing questions and special offers",
                     "Process orders and upgrades",
-                    "Provide product comparisons and recommendations"
-                ]
+                    "Provide product comparisons and recommendations",
+                ],
             )
-        elif department == 'billing':
+        elif department == "billing":
             agent.prompt_add_section(
-                "Billing Expertise", 
+                "Billing Expertise",
                 "You specialize in billing and account management:",
                 bullets=[
                     "Explain billing statements and charges",
                     "Process payment arrangements and updates",
                     "Handle dispute resolution professionally",
                     "Verify account information securely",
-                    "Provide payment history and projections"
-                ]
+                    "Provide payment history and projections",
+                ],
             )
         else:  # general support
             agent.prompt_add_section(
@@ -206,10 +200,10 @@ class SimpleDynamicEnhanced(AgentBase):
                     "Provide accurate and helpful information",
                     "Maintain a professional and friendly tone",
                     "Escalate complex issues when appropriate",
-                    "Always confirm understanding before ending"
-                ]
+                    "Always confirm understanding before ending",
+                ],
             )
-        
+
         # VIP-specific service standards
         if is_vip:
             agent.prompt_add_section(
@@ -220,26 +214,26 @@ class SimpleDynamicEnhanced(AgentBase):
                     "Offer premium solutions and exclusive options",
                     "Ensure complete satisfaction before concluding",
                     "Document all interactions for continuity",
-                    "Proactively suggest additional value-added services"
-                ]
+                    "Proactively suggest additional value-added services",
+                ],
             )
-        
+
         # Available services (department-specific)
-        if department == 'sales':
+        if department == "sales":
             services = [
                 "Product demonstrations and information",
                 "Custom solution design",
                 "Pricing and proposal generation",
                 "Order processing and tracking",
-                "Upgrade and expansion planning"
+                "Upgrade and expansion planning",
             ]
-        elif department == 'billing':
+        elif department == "billing":
             services = [
                 "Billing explanation and breakdown",
                 "Payment processing and plans",
                 "Account balance and history",
                 "Dispute investigation and resolution",
-                "Billing preference updates"
+                "Billing preference updates",
             ]
         else:
             services = [
@@ -247,15 +241,17 @@ class SimpleDynamicEnhanced(AgentBase):
                 "Account questions and support",
                 "Technical troubleshooting guidance",
                 "Service status and updates",
-                "General inquiries and assistance"
+                "General inquiries and assistance",
             ]
-        
-        agent.prompt_add_section("Available Services", f"You can help customers with:", bullets=services)
+
+        agent.prompt_add_section(
+            "Available Services", "You can help customers with:", bullets=services
+        )
 
 
 def main():
     agent = SimpleDynamicEnhanced()
-    
+
     print("Starting Enhanced Dynamic Agent")
     print("\nConfiguration: ENHANCED DYNAMIC (adapts to request parameters)")
     print("\nSupported parameters:")
@@ -270,13 +266,15 @@ def main():
     print("curl 'http://localhost:3000?department=sales&language=es'  # Spanish Sales")
     print("curl 'http://localhost:3000?department=billing&vip=true'  # VIP Billing")
     print("curl 'http://localhost:3000/debug?vip=true&department=sales'  # Debug mode")
-    print("\nCOMPARE: Compare the SWML output - each request creates different configuration!")
+    print(
+        "\nCOMPARE: Compare the SWML output - each request creates different configuration!"
+    )
     print()
-    
+
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/simple_static_agent.py
+++ b/examples/simple_static_agent.py
@@ -8,7 +8,6 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-
 """
 Simple Static Agent Example (Traditional Way)
 
@@ -34,66 +33,60 @@ Try these requests:
 
 from signalwire import AgentBase
 
+
 class SimpleStaticAgent(AgentBase):
     def __init__(self):
         super().__init__(
-            name="Simple Customer Service Agent",
-            auto_answer=True,
-            record_call=True
+            name="Simple Customer Service Agent", auto_answer=True, record_call=True
         )
-        
+
         # STATIC CONFIGURATION - Set once during initialization
-        
+
         # Voice and language (never changes)
         self.add_language("English", "en-US", "inworld.Mark")
-        
+
         # AI parameters (never changes)
-        self.set_params({
-            "ai_model": "gpt-4.1-nano",
-            "end_of_speech_timeout": 500,
-            "attention_timeout": 15000,
-            "background_file_volume": -20
-        })
-        
-        # Hints for speech recognition (never changes)
-        self.add_hints([
-            "SignalWire",
-            "SWML", 
-            "API",
-            "webhook",
-            "SIP"
-        ])
-        
-        # Global data (same for every call)
-        self.set_global_data({
-            "agent_type": "customer_service",
-            "service_level": "standard",
-            "features_enabled": ["basic_conversation", "help_desk"],
-            "session_info": {
-                "environment": "production",
-                "version": "1.0"
+        self.set_params(
+            {
+                "ai_model": "gpt-4.1-nano",
+                "end_of_speech_timeout": 500,
+                "attention_timeout": 15000,
+                "background_file_volume": -20,
             }
-        })
-        
+        )
+
+        # Hints for speech recognition (never changes)
+        self.add_hints(["SignalWire", "SWML", "API", "webhook", "SIP"])
+
+        # Global data (same for every call)
+        self.set_global_data(
+            {
+                "agent_type": "customer_service",
+                "service_level": "standard",
+                "features_enabled": ["basic_conversation", "help_desk"],
+                "session_info": {"environment": "production", "version": "1.0"},
+            }
+        )
+
         # Prompt sections (never changes)
         self.prompt_add_section(
             "Role and Purpose",
             "You are a professional customer service representative. Your goal is to help "
-            "customers with their questions and provide excellent service."
+            "customers with their questions and provide excellent service.",
         )
-        
+
         self.prompt_add_section(
             "Guidelines",
             "Follow these customer service principles:",
             bullets=[
                 "Listen carefully to customer needs",
-                "Provide accurate and helpful information", 
+                "Provide accurate and helpful information",
                 "Maintain a professional and friendly tone",
                 "Escalate complex issues when appropriate",
-                "Always confirm understanding before ending"
-            ]
+                "Always confirm understanding before ending",
+            ],
         )
-        
+
         self.prompt_add_section(
             "Available Services",
             "You can help customers with:",
@@ -102,18 +95,18 @@ class SimpleStaticAgent(AgentBase):
                 "Account questions and support",
                 "Technical troubleshooting guidance",
                 "Billing and payment inquiries",
-                "Service status and updates"
-            ]
+                "Service status and updates",
+            ],
         )
 
 
 if __name__ == "__main__":
     agent = SimpleStaticAgent()
-    
+
     print("Starting Simple Static Agent")
     print("\nConfiguration: STATIC (set once at startup)")
     print("- Voice: inworld.Mark (professional)")
-    print("- Service Level: standard") 
+    print("- Service Level: standard")
     print("- Speech Timeout: 500ms")
     print("- Features: basic conversation, help desk")
     print("\nAgent available at: http://localhost:3000/")
@@ -123,5 +116,5 @@ if __name__ == "__main__":
     print("\nNote: Configuration never changes regardless of request parameters")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     print()
-    
-    agent.run() 
+
+    agent.run()

--- a/examples/skills_demo.py
+++ b/examples/skills_demo.py
@@ -29,91 +29,102 @@ The datetime and math skills work without any additional setup.
 import os
 from signalwire import AgentBase
 
+
 def main():
     # Create an agent
     agent = AgentBase("Multi-Skill Assistant", route="/assistant")
-    
+
     # Configure the agent with inworld.Mark voice
     agent.add_language("English", "en-US", "inworld.Mark")
-    
+
     print("Creating agent with multiple skills...")
-    
+
     # Add skills using the new system - these are one-liners!
     try:
         agent.add_skill("datetime")
         print("Added datetime skill")
     except Exception as e:
         print(f"Failed to add datetime skill: {e}")
-    
+
     try:
         agent.add_skill("math")
         print("Added math skill")
     except Exception as e:
         print(f"Failed to add math skill: {e}")
-    
+
     try:
         # Get credentials from environment variables
-        google_api_key = os.getenv('GOOGLE_SEARCH_API_KEY')
-        google_search_engine_id = os.getenv('GOOGLE_SEARCH_ENGINE_ID')
-        
+        google_api_key = os.getenv("GOOGLE_SEARCH_API_KEY")
+        google_search_engine_id = os.getenv("GOOGLE_SEARCH_ENGINE_ID")
+
         if not google_api_key or not google_search_engine_id:
-            raise ValueError("Missing GOOGLE_SEARCH_API_KEY or GOOGLE_SEARCH_ENGINE_ID environment variables")
-        
+            raise ValueError(
+                "Missing GOOGLE_SEARCH_API_KEY or GOOGLE_SEARCH_ENGINE_ID environment variables"
+            )
+
         # Add web search with custom parameters and swaig_fields for fillers
         # Pass API credentials as parameters instead of using env vars
-        agent.add_skill("web_search", {
-            "api_key": google_api_key,
-            "search_engine_id": google_search_engine_id,
-            "num_results": 1,  # Just get one result for faster responses
-            "delay": 0,        # No delay between requests for minimal latency
-            "no_results_message": "I apologize, but I wasn't able to find any information about '{query}' in my web search. Could you try rephrasing your question or asking about something else?",
-            "swaig_fields": {  # Special fields merged into SWAIG function definition
-                "fillers": {
-                    "en-US": [
-                        "I am searching the web for that information...",
-                        "Let me google that for you...",
-                        "Searching the internet now...",
-                        "Looking that up on the web...",
-                        "Finding the latest information online..."
-                    ]
-                }
-            }
-        })
+        agent.add_skill(
+            "web_search",
+            {
+                "api_key": google_api_key,
+                "search_engine_id": google_search_engine_id,
+                "num_results": 1,  # Just get one result for faster responses
+                "delay": 0,  # No delay between requests for minimal latency
+                "no_results_message": "I apologize, but I wasn't able to find any information about '{query}' in my web search. Could you try rephrasing your question or asking about something else?",
+                "swaig_fields": {  # Special fields merged into SWAIG function definition
+                    "fillers": {
+                        "en-US": [
+                            "I am searching the web for that information...",
+                            "Let me google that for you...",
+                            "Searching the internet now...",
+                            "Looking that up on the web...",
+                            "Finding the latest information online...",
+                        ]
+                    }
+                },
+            },
+        )
         print("Added web search skill with optimized parameters and custom fillers")
     except Exception as e:
         print(f"Failed to add web search skill: {e}")
-        print("   Note: Web search requires GOOGLE_SEARCH_API_KEY and GOOGLE_SEARCH_ENGINE_ID environment variables")
-    
+        print(
+            "   Note: Web search requires GOOGLE_SEARCH_API_KEY and GOOGLE_SEARCH_ENGINE_ID environment variables"
+        )
+
     # Show what skills are loaded
     loaded_skills = agent.list_skills()
     print(f"\nLoaded skills: {', '.join(loaded_skills)}")
-    
+
     # Show available skills from registry
     try:
         from signalwire.skills.registry import skill_registry
+
         available_skills = skill_registry.list_skills()
-        print(f"\nAvailable skills in registry:")
+        print("\nAvailable skills in registry:")
         for skill in available_skills:
             print(f"  - {skill['name']}: {skill['description']}")
-            if skill['required_env_vars']:
+            if skill["required_env_vars"]:
                 print(f"    Requires env vars: {', '.join(skill['required_env_vars'])}")
-            if skill['required_packages']:
+            if skill["required_packages"]:
                 print(f"    Requires packages: {', '.join(skill['required_packages'])}")
-            if skill['supports_multiple_instances']:
-                print(f"    Supports multiple instances: Yes")
+            if skill["supports_multiple_instances"]:
+                print("    Supports multiple instances: Yes")
             else:
-                print(f"    Supports multiple instances: No")
+                print("    Supports multiple instances: No")
     except Exception as e:
         print(f"Failed to list available skills: {e}")
-    
+
     print(f"\nAgent available at: {agent.get_full_url()}")
     print("The agent now has enhanced capabilities:")
     print("   - Can tell current date/time")
     print("   - Can perform mathematical calculations")
     if "web_search" in loaded_skills:
-        print("   - Can search the web for information with custom fillers ('Let me google that...')")
+        print(
+            "   - Can search the web for information with custom fillers ('Let me google that...')"
+        )
         print("     (optimized for speed: 1 result, no delay)")
-    
+
     print("\nSkill Parameter Examples:")
     print("   # Default web search (requires API credentials)")
     print("   agent.add_skill('web_search', {")
@@ -138,7 +149,7 @@ def main():
     print("   })")
     print("   agent.add_skill('web_search', {")
     print("       'api_key': 'your-api-key',")
-    print("       'search_engine_id': 'news-engine-id',") 
+    print("       'search_engine_id': 'news-engine-id',")
     print("       'tool_name': 'search_news',")
     print("       'num_results': 3")
     print("   })")
@@ -147,7 +158,9 @@ def main():
     print("   agent.add_skill('web_search', {")
     print("       'api_key': 'your-api-key',")
     print("       'search_engine_id': 'your-engine-id',")
-    print("       'no_results_message': 'Sorry, no results found for \"{query}\". Please try a different search.'")
+    print(
+        "       'no_results_message': 'Sorry, no results found for \"{query}\". Please try a different search.'"
+    )
     print("   })")
     print("   ")
     print("   # Web search with custom fillers using swaig_fields")
@@ -155,13 +168,16 @@ def main():
     print("       'api_key': 'your-api-key',")
     print("       'search_engine_id': 'your-engine-id',")
     print("       'swaig_fields': {")
-    print("           'fillers': {'en-US': ['Let me google that...', 'Searching now...']}") 
+    print(
+        "           'fillers': {'en-US': ['Let me google that...', 'Searching now...']}"
+    )
     print("       }")
     print("   })")
-    
+
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/step_function_inheritance_demo.py
+++ b/examples/step_function_inheritance_demo.py
@@ -79,13 +79,10 @@ class StepFunctionInheritanceAgent(AgentBase):
 
         # ── Step 1: explicit whitelist ─────────────────────────────────
         # `lookup_account` is the only tool active in this step.
-        ctx.add_step("step_lookup") \
-            .set_text(
-                "Greet the customer and ask for their account number. "
-                "Use lookup_account to fetch their details."
-            ) \
-            .set_functions(["lookup_account"]) \
-            .set_valid_steps(["step_inherit"])
+        ctx.add_step("step_lookup").set_text(
+            "Greet the customer and ask for their account number. "
+            "Use lookup_account to fetch their details."
+        ).set_functions(["lookup_account"]).set_valid_steps(["step_inherit"])
 
         # ── Step 2: NO set_functions() call → inheritance ──────────────
         # Because we didn't call set_functions(), this step inherits the
@@ -93,35 +90,27 @@ class StepFunctionInheritanceAgent(AgentBase):
         # here, even though we never asked for it. Most of the time this
         # is a bug. To break the inheritance, call set_functions() with an
         # explicit list (even if it's empty).
-        ctx.add_step("step_inherit") \
-            .set_text(
-                "Confirm the customer's identity. (No set_functions() here, "
-                "so lookup_account is still active — this is the inheritance "
-                "trap.)"
-            ) \
-            .set_valid_steps(["step_explicit"])
+        ctx.add_step("step_inherit").set_text(
+            "Confirm the customer's identity. (No set_functions() here, "
+            "so lookup_account is still active — this is the inheritance "
+            "trap.)"
+        ).set_valid_steps(["step_explicit"])
 
         # ── Step 3: explicit replacement ───────────────────────────────
         # Whitelist replaces the inherited set. lookup_account is now
         # inactive; only process_payment is active.
-        ctx.add_step("step_explicit") \
-            .set_text(
-                "Take the customer's payment. Use process_payment. "
-                "lookup_account is no longer available."
-            ) \
-            .set_functions(["process_payment"]) \
-            .set_valid_steps(["step_disabled"])
+        ctx.add_step("step_explicit").set_text(
+            "Take the customer's payment. Use process_payment. "
+            "lookup_account is no longer available."
+        ).set_functions(["process_payment"]).set_valid_steps(["step_disabled"])
 
         # ── Step 4: explicit disable-all ───────────────────────────────
         # Pass [] (or "none") to lock out every user-defined tool.
         # Internal navigation tools (next_step) are unaffected.
-        ctx.add_step("step_disabled") \
-            .set_text(
-                "Thank the customer and wrap up. No tools are needed here, "
-                "so we lock everything down with set_functions([])."
-            ) \
-            .set_functions([]) \
-            .set_end(True)
+        ctx.add_step("step_disabled").set_text(
+            "Thank the customer and wrap up. No tools are needed here, "
+            "so we lock everything down with set_functions([])."
+        ).set_functions([]).set_end(True)
 
 
 if __name__ == "__main__":

--- a/examples/survey_agent_example.py
+++ b/examples/survey_agent_example.py
@@ -46,7 +46,7 @@ structlog.configure(
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
-        structlog.processors.JSONRenderer()
+        structlog.processors.JSONRenderer(),
     ],
     context_class=dict,
     logger_factory=structlog.stdlib.LoggerFactory(),
@@ -68,13 +68,13 @@ logger = structlog.get_logger("survey_agent")
 class ProductSurveyAgent(SurveyAgent):
     """
     A survey agent customized for product feedback collection.
-    
+
     This extends the base SurveyAgent with:
     1. Custom result processing
     2. Additional validation rules
     3. Custom SWAIG functions for enhanced functionality
     """
-    
+
     def __init__(self, **kwargs):
         """Initialize the ProductSurveyAgent with default settings"""
         # Define the survey questions
@@ -84,49 +84,54 @@ class ProductSurveyAgent(SurveyAgent):
                 "text": "On a scale of 1-5, how satisfied are you with our product?",
                 "type": "rating",
                 "scale": 5,
-                "required": True
+                "required": True,
             },
             {
                 "id": "usage_frequency",
                 "text": "How often do you use our product?",
                 "type": "multiple_choice",
                 "options": ["Daily", "Weekly", "Monthly", "Rarely"],
-                "required": True
+                "required": True,
             },
             {
                 "id": "primary_feature",
                 "text": "Which feature do you use the most?",
                 "type": "multiple_choice",
-                "options": ["Communication Tools", "File Sharing", "Task Management", "Analytics"],
-                "required": True
+                "options": [
+                    "Communication Tools",
+                    "File Sharing",
+                    "Task Management",
+                    "Analytics",
+                ],
+                "required": True,
             },
             {
                 "id": "recommend",
                 "text": "Would you recommend our product to others?",
                 "type": "yes_no",
-                "required": True
+                "required": True,
             },
             {
                 "id": "improvement_suggestions",
                 "text": "What improvements would you suggest for our product?",
                 "type": "open_ended",
-                "required": False
-            }
+                "required": False,
+            },
         ]
-        
+
         # Survey introduction and conclusion
         introduction = (
             "Thank you for participating in our product survey! "
             "Your feedback helps us improve our products and services. "
             "This survey should take about 2-3 minutes to complete."
         )
-        
+
         conclusion = (
             "Thank you for completing our survey! Your feedback is extremely valuable "
             "and will help us improve our product. If you have further questions, "
             "please contact our support team."
         )
-        
+
         # Initialize the base SurveyAgent with our custom settings
         super().__init__(
             survey_name="Product Feedback Survey",
@@ -137,84 +142,92 @@ class ProductSurveyAgent(SurveyAgent):
             max_retries=2,
             name="product_survey",
             route="/product_survey",
-            **kwargs
+            **kwargs,
         )
-        
+
         # Override some parameters for better user experience
-        self.set_params({
-            "ai_model": "gpt-4.1-nano",
-            "end_of_speech_timeout": 2000,  # Longer timeout for more thoughtful responses
-            "ai_volume": 6,  # Slightly louder than default
-            "wait_for_user": True  # Wait for user to speak first
-        })
-        
+        self.set_params(
+            {
+                "ai_model": "gpt-4.1-nano",
+                "end_of_speech_timeout": 2000,  # Longer timeout for more thoughtful responses
+                "ai_volume": 6,  # Slightly louder than default
+                "wait_for_user": True,  # Wait for user to speak first
+            }
+        )
+
         logger.info("product_survey_agent_initialized")
-    
+
     @SurveyAgent.tool(
         name="analyze_feedback",
         description="Analyze the customer feedback for sentiment and key themes",
         parameters={
             "feedback": {
                 "type": "string",
-                "description": "The customer's open-ended feedback text"
+                "description": "The customer's open-ended feedback text",
             }
-        }
+        },
     )
     def analyze_feedback(self, args, raw_data):
         """
         Analyze customer feedback to identify sentiment and key themes
-        
+
         This is a simple demonstration function that would typically connect
         to an NLP service or sentiment analysis API.
         """
         feedback = args.get("feedback", "")
-        
+
         # Simple keyword-based "analysis" (in a real application, use NLP)
         sentiment = "neutral"
         key_themes = []
-        
+
         # Very basic sentiment detection
         positive_words = ["great", "good", "excellent", "love", "like", "helpful"]
         negative_words = ["bad", "poor", "terrible", "hate", "dislike", "difficult"]
-        
+
         # Count positive and negative words
         positive_count = sum(1 for word in positive_words if word in feedback.lower())
         negative_count = sum(1 for word in negative_words if word in feedback.lower())
-        
+
         # Determine sentiment based on word counts
         if positive_count > negative_count:
             sentiment = "positive"
         elif negative_count > positive_count:
             sentiment = "negative"
-            
+
         # Extract potential themes (very simplified)
         theme_keywords = {
             "UI/UX": ["interface", "design", "layout", "ui", "ux"],
             "Performance": ["speed", "slow", "fast", "performance", "lag"],
             "Features": ["feature", "functionality", "capability", "tool"],
-            "Support": ["help", "support", "assistance", "customer service"]
+            "Support": ["help", "support", "assistance", "customer service"],
         }
-        
+
         # Check for themes
         for theme, keywords in theme_keywords.items():
             if any(keyword in feedback.lower() for keyword in keywords):
                 key_themes.append(theme)
-        
+
         # Return the analysis
-        return FunctionResult({
-            "response": f"I've analyzed the feedback. The sentiment appears to be {sentiment}. " +
-                        (f"Key themes identified: {', '.join(key_themes)}" if key_themes else "No specific themes identified."),
-            "sentiment": sentiment,
-            "themes": key_themes
-        })
-    
+        return FunctionResult(
+            {
+                "response": f"I've analyzed the feedback. The sentiment appears to be {sentiment}. "
+                + (
+                    f"Key themes identified: {', '.join(key_themes)}"
+                    if key_themes
+                    else "No specific themes identified."
+                ),
+                "sentiment": sentiment,
+                "themes": key_themes,
+            }
+        )
+
     def on_summary(self, summary, raw_data=None):
         """
         Process the survey results summary
-        
+
         This method is called when a survey is completed and receives the
         structured results.
-        
+
         Args:
             summary: Summary data containing survey responses
             raw_data: The complete raw POST data from the request
@@ -222,111 +235,128 @@ class ProductSurveyAgent(SurveyAgent):
         if not summary:
             logger.warning("empty_survey_summary")
             return
-            
+
         try:
             # For structured summary
             if isinstance(summary, dict):
                 # Log the summary
-                logger.info("survey_completed", 
-                           survey=summary.get("survey_name", "Unknown Survey"),
-                           timestamp=summary.get("timestamp", datetime.now().isoformat()))
-                
+                logger.info(
+                    "survey_completed",
+                    survey=summary.get("survey_name", "Unknown Survey"),
+                    timestamp=summary.get("timestamp", datetime.now().isoformat()),
+                )
+
                 # Get the responses
                 responses = summary.get("responses", {})
-                
+
                 # Calculate satisfaction score
                 if "product_satisfaction" in responses:
                     try:
                         satisfaction = int(responses["product_satisfaction"])
                         logger.info("satisfaction_score", score=satisfaction, max=5)
-                        
+
                         # Alert on low satisfaction
                         if satisfaction <= 2:
-                            logger.warning("low_satisfaction_detected", score=satisfaction)
+                            logger.warning(
+                                "low_satisfaction_detected", score=satisfaction
+                            )
                             # In a real application, you might trigger follow-up actions here
                     except ValueError:
-                        logger.error("invalid_satisfaction_score", value=responses["product_satisfaction"])
-                
+                        logger.error(
+                            "invalid_satisfaction_score",
+                            value=responses["product_satisfaction"],
+                        )
+
                 # Check recommendation status
                 if "recommend" in responses:
                     recommend = responses["recommend"].lower()
                     is_promoter = recommend in ["yes", "y", "true"]
                     logger.info("recommendation_status", would_recommend=is_promoter)
-                
+
                 # Process improvement suggestions
-                if "improvement_suggestions" in responses and responses["improvement_suggestions"]:
-                    logger.info("received_improvement_suggestions", 
-                               suggestions=responses["improvement_suggestions"])
-                    
+                if responses.get("improvement_suggestions"):
+                    logger.info(
+                        "received_improvement_suggestions",
+                        suggestions=responses["improvement_suggestions"],
+                    )
+
                 # In a real application, you would:
                 # 1. Store the survey responses in a database
                 # 2. Update customer records
                 # 3. Generate reports or dashboards
                 # 4. Trigger follow-up actions based on responses
-                
+
                 # Print the summary for demonstration purposes
                 print(f"Survey completed: {json.dumps(summary, indent=2)}")
-                
+
             else:
                 logger.warning("unstructured_survey_summary", summary=str(summary))
                 print(f"Survey summary (unstructured): {summary}")
-                
+
         except Exception as e:
             logger.error("error_processing_survey_summary", error=str(e))
-            print(f"Error processing survey summary: {str(e)}")
+            print(f"Error processing survey summary: {e!s}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run the Product Survey Agent")
-    parser.add_argument("--port", type=int, default=3000, help="Port to run the server on")
-    parser.add_argument("--host", type=str, default="0.0.0.0", help="Host to bind the server to")
-    parser.add_argument("--suppress-logs", action="store_true", help="Suppress extra logs")
+    parser.add_argument(
+        "--port", type=int, default=3000, help="Port to run the server on"
+    )
+    parser.add_argument(
+        "--host", type=str, default="0.0.0.0", help="Host to bind the server to"
+    )
+    parser.add_argument(
+        "--suppress-logs", action="store_true", help="Suppress extra logs"
+    )
     args = parser.parse_args()
-    
+
     # Find schema.json in the current directory or parent directory
     current_dir = os.path.dirname(os.path.abspath(__file__))
     parent_dir = os.path.dirname(current_dir)
-    
+
     schema_locations = [
         os.path.join(current_dir, "schema.json"),
-        os.path.join(parent_dir, "schema.json")
+        os.path.join(parent_dir, "schema.json"),
     ]
-    
+
     schema_path = None
     for loc in schema_locations:
         if os.path.exists(loc):
             schema_path = loc
             logger.info("schema_found", path=schema_path)
             break
-            
+
     if not schema_path:
         logger.warning("schema_not_found", locations=schema_locations)
-    
+
     # Create an agent instance
     agent = ProductSurveyAgent(
         schema_path=schema_path,
         host=args.host,
         port=args.port,
-        suppress_logs=args.suppress_logs
+        suppress_logs=args.suppress_logs,
     )
-    
+
     # Print credentials
     username, password, source = agent.get_basic_auth_credentials(include_source=True)
-    
-    logger.info("starting_agent", 
-               url=f"http://{args.host}:{args.port}/product_survey", 
-               username=username, 
-               password_length=len(password),
-               auth_source=source)
-    
+
+    logger.info(
+        "starting_agent",
+        url=f"http://{args.host}:{args.port}/product_survey",
+        username=username,
+        password_length=len(password),
+        auth_source=source,
+    )
+
     print("Starting the Product Survey Agent. Press Ctrl+C to stop.")
-    print(f"Agent 'product_survey' is available at:")
+    print("Agent 'product_survey' is available at:")
     print(f"URL: http://localhost:{args.port}/product_survey")
     print(f"Basic Auth: {username}:{password}")
-    
+
     try:
         # Start the agent's server
         agent.run(host=args.host, port=args.port)
     except KeyboardInterrupt:
         logger.info("server_shutdown")
-        print("\nStopping the agent.") 
+        print("\nStopping the agent.")

--- a/examples/survey_agent_example.py
+++ b/examples/survey_agent_example.py
@@ -21,12 +21,12 @@ Features demonstrated:
 4. Processing survey results
 """
 
-import os
 import logging
 import sys
 import json
 import argparse
 from datetime import datetime
+from pathlib import Path
 
 # Import structlog for proper structured logging
 import structlog
@@ -312,18 +312,18 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Find schema.json in the current directory or parent directory
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    parent_dir = os.path.dirname(current_dir)
+    current_dir = Path(__file__).resolve().parent
+    parent_dir = current_dir.parent
 
     schema_locations = [
-        os.path.join(current_dir, "schema.json"),
-        os.path.join(parent_dir, "schema.json"),
+        current_dir / "schema.json",
+        parent_dir / "schema.json",
     ]
 
     schema_path = None
     for loc in schema_locations:
-        if os.path.exists(loc):
-            schema_path = loc
+        if loc.exists():
+            schema_path = str(loc)
             logger.info("schema_found", path=schema_path)
             break
 

--- a/examples/swaig_features_agent.py
+++ b/examples/swaig_features_agent.py
@@ -83,12 +83,13 @@ The resulting SWAIG array in SWML will have the following structure:
 ]
 """
 
-import os
 import sys
 from datetime import datetime
+from pathlib import Path
+from typing import ClassVar
 
 # Add the parent directory to the path so we can import the package
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from signalwire import AgentBase
 from signalwire.core.function_result import FunctionResult
@@ -100,7 +101,7 @@ class SwaigFeaturesAgent(AgentBase):
     """
 
     # Define the prompt sections declaratively
-    PROMPT_SECTIONS = {
+    PROMPT_SECTIONS: ClassVar[dict] = {
         "Personality": "You are a friendly and helpful assistant.",
         "Goal": "Demonstrate advanced SWAIG features.",
         "Instructions": [

--- a/examples/swaig_features_agent.py
+++ b/examples/swaig_features_agent.py
@@ -98,7 +98,7 @@ class SwaigFeaturesAgent(AgentBase):
     """
     An agent that demonstrates the enhanced SWAIG features
     """
-    
+
     # Define the prompt sections declaratively
     PROMPT_SECTIONS = {
         "Personality": "You are a friendly and helpful assistant.",
@@ -106,10 +106,10 @@ class SwaigFeaturesAgent(AgentBase):
         "Instructions": [
             "Be concise and direct in your responses.",
             "Use the get_weather function when asked about weather.",
-            "Use the get_time function when asked about the current time."
-        ]
+            "Use the get_time function when asked about the current time.",
+        ],
     }
-    
+
     def __init__(self):
         # Initialize the agent with a name, route, and default webhook URL
         super().__init__(
@@ -119,9 +119,9 @@ class SwaigFeaturesAgent(AgentBase):
             port=3000,
             # Set a default webhook URL for all functions
             # This will create a defaults object in the SWAIG array
-            default_webhook_url="https://api.example-external-service.com/swaig"
+            default_webhook_url="https://api.example-external-service.com/swaig",
         )
-        
+
         # Add a post-prompt for summary
         self.set_post_prompt("""
         Return a JSON summary of the conversation:
@@ -130,7 +130,7 @@ class SwaigFeaturesAgent(AgentBase):
             "functions_used": ["list", "of", "functions", "used"]
         }
         """)
-    
+
     @AgentBase.tool(
         name="get_time",
         description="Get the current time",
@@ -139,16 +139,16 @@ class SwaigFeaturesAgent(AgentBase):
         fillers={
             "en-US": [
                 "Let me check the time for you",
-                "One moment while I check the current time"
+                "One moment while I check the current time",
             ]
-        }
+        },
     )
     def get_time(self):
         """Get the current time"""
         now = datetime.now()
         formatted_time = now.strftime("%H:%M:%S")
         return FunctionResult(f"The current time is {formatted_time}")
-    
+
     @AgentBase.tool(
         name="get_weather",
         description="Get the current weather for a location (including starwars planets)",
@@ -156,20 +156,20 @@ class SwaigFeaturesAgent(AgentBase):
         parameters={
             "location": {
                 "type": "string",
-                "description": "The city or location to get weather for"
+                "description": "The city or location to get weather for",
             }
         },
         # Add fillers in multiple languages
         fillers={
             "en-US": [
                 "I am checking the weather for you",
-                "Let me look up the weather information"
+                "Let me look up the weather information",
             ],
             "es": [
                 "Estoy consultando el clima para ti",
-                "Permíteme verificar el clima"
-            ]
-        }
+                "Permíteme verificar el clima",
+            ],
+        },
     )
     def get_weather(self, location):
         """Get the current weather for a location"""
@@ -178,27 +178,24 @@ class SwaigFeaturesAgent(AgentBase):
             "tatooine": "Hot and dry, with occasional sandstorms. Twin suns at their peak.",
             "hoth": "Extremely cold with blizzard conditions. High of -20°C.",
             "endor": "Mild forest weather. Partly cloudy with a high of 22°C.",
-            "default": "It's sunny and 72°F"
+            "default": "It's sunny and 72°F",
         }
-        
+
         result = weather_data.get(location.lower(), weather_data["default"])
         return FunctionResult(f"The weather in {location}: {result}")
-    
+
     # This function also uses the default webhook URL
     @AgentBase.tool(
         name="get_forecast",
         description="Get a 3-day weather forecast for a location",
         parameters={
-            "location": {
-                "type": "string", 
-                "description": "The city or location"
-            },
+            "location": {"type": "string", "description": "The city or location"},
             "units": {
                 "type": "string",
                 "description": "Temperature units (celsius or fahrenheit)",
-                "enum": ["celsius", "fahrenheit"]
-            }
-        }
+                "enum": ["celsius", "fahrenheit"],
+            },
+        },
     )
     def get_forecast(self, location, units="fahrenheit"):
         """Get a weather forecast for a location"""
@@ -207,15 +204,20 @@ class SwaigFeaturesAgent(AgentBase):
         forecast = [
             {"day": "Today", "temp": 72, "condition": "Sunny"},
             {"day": "Tomorrow", "temp": 68, "condition": "Partly Cloudy"},
-            {"day": "Day After", "temp": 75, "condition": "Clear"}
+            {"day": "Day After", "temp": 75, "condition": "Clear"},
         ]
-        
+
         # Format the forecast response
         if units == "celsius":
             for day in forecast:
-                day["temp"] = round((day["temp"] - 32) * 5/9)
-        
-        forecast_text = "\n".join([f"{d['day']}: {d['temp']}°{'C' if units == 'celsius' else 'F'}, {d['condition']}" for d in forecast])
+                day["temp"] = round((day["temp"] - 32) * 5 / 9)
+
+        forecast_text = "\n".join(
+            [
+                f"{d['day']}: {d['temp']}°{'C' if units == 'celsius' else 'F'}, {d['condition']}"
+                for d in forecast
+            ]
+        )
         return FunctionResult(f"3-day forecast for {location}:\n{forecast_text}")
 
 
@@ -227,4 +229,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/swml_service_example.py
+++ b/examples/swml_service_example.py
@@ -34,91 +34,91 @@ from signalwire.core.swml_builder import SWMLBuilder
 def example_using_service():
     """
     Example using SWMLService's direct document manipulation
-    
+
     This approach adds verbs directly to the SWML document by calling
     methods on the SWMLService. It provides the most control but requires
     more detailed knowledge of the SWML document structure.
-    
+
     Returns:
         SWMLService: Configured service instance
     """
     print("=== Example using SWMLService directly ===")
-    
-    #------------------------------------------------------------------------
+
+    # ------------------------------------------------------------------------
     # SERVICE SETUP
     # Create a basic SWML service with HTTP server configuration
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     # Create a simple SWML service with HTTP server settings
     # The route defines the HTTP path where this service will be available
     service = SWMLService(
         name="simple-swml-service",  # Identifier for the service
-        route="/simple",             # HTTP endpoint path
-        host="0.0.0.0",              # Listen on all network interfaces
-        port=3001                    # Port for HTTP server
+        route="/simple",  # HTTP endpoint path
+        host="0.0.0.0",  # Listen on all network interfaces
+        port=3001,  # Port for HTTP server
     )
-    
-    #------------------------------------------------------------------------
+
+    # ------------------------------------------------------------------------
     # DOCUMENT CREATION
     # Build the SWML document by adding verbs directly
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     # Reset the document to start fresh (clears any existing verbs)
     service.reset_document()
-    
+
     # Add verbs to the document in sequence
     # add_verb takes a verb name and parameters dictionary
     service.add_verb("answer", {})  # Answer the call when it arrives
-    
+
     # This plays a text-to-speech message to the caller
     service.add_verb("play", {"url": "say:Hello, world!"})
-    
+
     # Add a hangup verb to end the call
     service.add_verb("hangup", {})  # End the call
-    
+
     # Print the rendered document as JSON for inspection
     print(service.render_document())
     print()
-    
+
     return service
 
 
 def example_using_builder():
     """
     Example using SWMLBuilder fluent API
-    
+
     This approach uses the builder pattern with method chaining
     to create a more readable SWML document construction process.
-    
+
     Returns:
         SWMLService: Configured service instance
     """
     print("=== Example using SWMLBuilder fluent API ===")
-    
-    #------------------------------------------------------------------------
+
+    # ------------------------------------------------------------------------
     # SERVICE SETUP
     # Create a basic SWML service on a different port
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     # Create a simple SWML service
     # Using a different port than the first example
     service = SWMLService(
         name="builder-swml-service",  # Unique service name
-        route="/builder",             # HTTP endpoint path
-        host="0.0.0.0",               # Listen on all networks
-        port=3002                     # Different port than first example
+        route="/builder",  # HTTP endpoint path
+        host="0.0.0.0",  # Listen on all networks
+        port=3002,  # Different port than first example
     )
-    
-    #------------------------------------------------------------------------
+
+    # ------------------------------------------------------------------------
     # DOCUMENT CREATION USING BUILDER
     # Use the fluent API for more readable code
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     # Create a builder attached to our service
     # The builder provides an alternative, more fluent syntax
     # for building SWML documents
     builder = SWMLBuilder(service)
-    
+
     # Build the document using the fluent API with method chaining
     # This style is more readable than direct document manipulation
     # Start with a fresh document
@@ -130,53 +130,53 @@ def example_using_builder():
     # Second message with options
     builder.say(
         "Isn't this easier than assembling JSON?",
-        voice="inworld.Mark",          # Use a specific voice
-        language="en-US"                # Specify language for TTS
+        voice="inworld.Mark",  # Use a specific voice
+        language="en-US",  # Specify language for TTS
     )
     # End the call
-    builder.hangup()                    
-    
+    builder.hangup()
+
     # Print the rendered document as JSON for inspection
     print(builder.render())
     print()
-    
+
     return service
 
 
 def example_using_ai():
     """
     Example using AI verb for conversational interfaces
-    
+
     This approach demonstrates using the AI verb to create a
     conversational agent that can interact with callers naturally.
-    
+
     Returns:
         SWMLService: Configured service instance
     """
     print("=== Example using AI verb ===")
-    
-    #------------------------------------------------------------------------
+
+    # ------------------------------------------------------------------------
     # SERVICE SETUP
     # Create a third SWML service for AI capabilities
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     # Create a simple SWML service for AI
     # Each service runs on its own port
     service = SWMLService(
-        name="ai-swml-service",     # Unique service name
-        route="/ai",                # HTTP endpoint path
-        host="0.0.0.0",             # Listen on all networks
-        port=3003                   # Third unique port
+        name="ai-swml-service",  # Unique service name
+        route="/ai",  # HTTP endpoint path
+        host="0.0.0.0",  # Listen on all networks
+        port=3003,  # Third unique port
     )
-    
-    #------------------------------------------------------------------------
+
+    # ------------------------------------------------------------------------
     # AI DOCUMENT CREATION
     # Build an AI-powered conversational interface
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     # Create a builder for the service
     builder = SWMLBuilder(service)
-    
+
     # Build the document using the fluent API
     # Start with a fresh document
     builder.reset()
@@ -187,30 +187,30 @@ def example_using_ai():
         # The prompt configures the AI's personality and capabilities
         prompt_text="You are a helpful assistant. Answer user questions concisely.",
         # The post-prompt generates a summary after the conversation ends
-        post_prompt="Summarize the conversation in 1-2 sentences."
+        post_prompt="Summarize the conversation in 1-2 sentences.",
     )
     # End the call after AI interaction completes
-    builder.hangup()                     
-    
+    builder.hangup()
+
     # Print the rendered document as JSON for inspection
     print(builder.render())
     print()
-    
+
     return service
 
 
 def main():
-    #------------------------------------------------------------------------
+    # ------------------------------------------------------------------------
     # RUN EXAMPLES AND INTERACTIVE SELECTION
     # Create all three services and let the user choose which to run
-    #------------------------------------------------------------------------
-    
+    # ------------------------------------------------------------------------
+
     # Run the examples to create the configured services
     # Each example prints its SWML document for inspection
-    service1 = example_using_service()    # Basic service with direct verb manipulation
-    service2 = example_using_builder()    # Service using fluent builder API
-    service3 = example_using_ai()         # Service with AI conversational capabilities
-    
+    service1 = example_using_service()  # Basic service with direct verb manipulation
+    service2 = example_using_builder()  # Service using fluent builder API
+    service3 = example_using_ai()  # Service with AI conversational capabilities
+
     # Ask which example to serve
     # Only one can be run at a time since they would conflict on host/port
     print("Choose a service to start:")
@@ -218,7 +218,7 @@ def main():
     print("2. Builder SWML service (fluent API)")
     print("3. AI SWML service (conversational interface)")
     choice = input("Enter choice (1-3) or any other key to exit: ")
-    
+
     # Start the selected service based on user input
     if choice == "1":
         print("Starting simple SWML service on http://localhost:3001/simple")
@@ -237,4 +237,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/swml_service_example.py
+++ b/examples/swml_service_example.py
@@ -21,11 +21,11 @@ It shows three different approaches to building SWML documents:
 Each approach creates a standalone SWML service that can be run independently.
 """
 
-import os
 import sys
+from pathlib import Path
 
 # Add the parent directory to the path so we can import the package
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from signalwire.core.swml_service import SWMLService
 from signalwire.core.swml_builder import SWMLBuilder

--- a/examples/swml_service_routing_example.py
+++ b/examples/swml_service_routing_example.py
@@ -27,10 +27,7 @@ SWMLService instance.
 """
 
 import json
-import os
-import sys
-import argparse
-from typing import Dict, Optional, Any
+from typing import Any
 from fastapi import Request
 
 from signalwire.core.swml_service import SWMLService
@@ -40,100 +37,105 @@ class RoutingExample(SWMLService):
     """
     Example SWMLService with custom routing callbacks
     """
-    
+
     def __init__(self):
         # Initialize the SWMLService with basic configuration
         super().__init__(
-            name="routing-example",
-            route="/main",
-            host="0.0.0.0",
-            port=3000
+            name="routing-example", route="/main", host="0.0.0.0", port=3000
         )
-        
+
         # Create a basic SWML document
         self.reset_document()
         self.add_verb("answer", {})
         self.add_verb("play", {"url": "say:Hello from the main service!"})
         self.add_verb("hangup", {})
-        
+
         # Register a customer callback route
         self.register_customer_route()
-        
+
         # Register a product callback route
         self.register_product_route()
-        
+
     def register_customer_route(self):
         """
         Register a callback for customer-related requests
         """
-        def customer_callback(request: Request, body: Dict[str, Any]) -> Optional[str]:
+
+        def customer_callback(request: Request, body: dict[str, Any]) -> str | None:
             """
             Callback for customer-related requests
             """
             print(f"Received customer request with body: {json.dumps(body, indent=2)}")
-            
+
             # If the request contains a specific customer_id, redirect to a "virtual" endpoint
             if "customer_id" in body:
                 customer_id = body["customer_id"]
                 print(f"Routing to virtual customer endpoint for ID: {customer_id}")
-                
+
                 # In a real implementation, you might redirect to another service
                 # For this example, we'll just handle it here
                 return None
-            
+
             # Otherwise, continue with normal processing - return None to not redirect
             return None
-            
+
         # Register the callback at the /customer path
         self.register_routing_callback(customer_callback, path="/customer")
-        
+
         # Create a custom SWML document for the customer path
         customer_section = "customer_section"
         self.add_section(customer_section)
         self.add_verb_to_section(customer_section, "answer", {})
-        self.add_verb_to_section(customer_section, "play", {"url": "say:Hello from the customer service!"})
+        self.add_verb_to_section(
+            customer_section, "play", {"url": "say:Hello from the customer service!"}
+        )
         self.add_verb_to_section(customer_section, "hangup", {})
-    
+
     def register_product_route(self):
         """
         Register a callback for product-related requests
         """
-        def product_callback(request: Request, body: Dict[str, Any]) -> Optional[str]:
+
+        def product_callback(request: Request, body: dict[str, Any]) -> str | None:
             """
             Callback for product-related requests
             """
             print(f"Received product request with body: {json.dumps(body, indent=2)}")
-            
+
             # If the request contains a specific product_id, redirect to a "virtual" endpoint
             if "product_id" in body:
                 product_id = body["product_id"]
                 print(f"Routing to virtual product endpoint for ID: {product_id}")
-                
+
                 # In a real implementation, you might redirect to another service
                 # For this example, we'll just handle it here
                 return None
-            
+
             # Otherwise, continue with normal processing - return None to not redirect
             return None
-            
+
         # Register the callback at the /product path
         self.register_routing_callback(product_callback, path="/product")
-        
+
         # Create a custom SWML document for the product path
         product_section = "product_section"
         self.add_section(product_section)
         self.add_verb_to_section(product_section, "answer", {})
-        self.add_verb_to_section(product_section, "play", {"url": "say:Hello from the product service!"})
+        self.add_verb_to_section(
+            product_section, "play", {"url": "say:Hello from the product service!"}
+        )
         self.add_verb_to_section(product_section, "hangup", {})
-    
-    def on_request(self, request_data: Optional[dict] = None, callback_path: Optional[str] = None) -> Optional[dict]:
+
+    def on_request(
+        self, request_data: dict | None = None, callback_path: str | None = None
+    ) -> dict | None:
         """
         Called when SWML is requested, with request data when available
-        
+
         Args:
             request_data: Optional dictionary containing the parsed POST body
             callback_path: Optional callback path from request
-            
+
         Returns:
             Optional dict to modify/augment the SWML document
         """
@@ -145,38 +147,36 @@ class RoutingExample(SWMLService):
                     "main": self.get_document()["sections"]["customer_section"]
                 }
             }
-        
+
         if callback_path == "/product":
             print(f"Serving product section based on callback_path: {callback_path}")
             return {
-                "sections": {
-                    "main": self.get_document()["sections"]["product_section"]
-                }
+                "sections": {"main": self.get_document()["sections"]["product_section"]}
             }
-        
+
         # If we don't have a callback_path, check the request_data
         if request_data:
             # Check for customer-specific data
             if "customer_id" in request_data or "customer_section" in request_data:
-                print(f"Serving customer section based on request data")
+                print("Serving customer section based on request data")
                 return {
                     "sections": {
                         "main": self.get_document()["sections"]["customer_section"]
                     }
                 }
-            
+
             # Check for product-specific data
             if "product_id" in request_data or "product_section" in request_data:
-                print(f"Serving product section based on request data")
+                print("Serving product section based on request data")
                 return {
                     "sections": {
                         "main": self.get_document()["sections"]["product_section"]
                     }
                 }
-        
+
         # Log which section we're serving
-        print(f"Serving default main section")
-        
+        print("Serving default main section")
+
         # Otherwise, return the default document
         return None
 
@@ -192,4 +192,4 @@ if __name__ == "__main__":
     # Start the service
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
-    service.serve() 
+    service.serve()

--- a/examples/swml_service_routing_example.py
+++ b/examples/swml_service_routing_example.py
@@ -183,8 +183,7 @@ class RoutingExample(SWMLService):
 
 def main():
     # Create an instance of our example service
-    service = RoutingExample()
-    return service
+    return RoutingExample()
 
 
 if __name__ == "__main__":

--- a/examples/swmlservice_ai_sidecar.py
+++ b/examples/swmlservice_ai_sidecar.py
@@ -100,7 +100,7 @@ class SalesSidecar(SWMLService):
         # body is a dict like {"type": "transcription", "text": "...", ...}
         event_type = body.get("type", "<unknown>")
         print(f"[sidecar event] type={event_type} body={body}")
-        return None  # any non-redirect response
+        return  # any non-redirect response
 
 
 if __name__ == "__main__":

--- a/examples/tap_example.py
+++ b/examples/tap_example.py
@@ -25,11 +25,13 @@ from signalwire.core.function_result import FunctionResult
 def basic_websocket_tap_example():
     """Simple WebSocket tap for monitoring."""
     print("=== Basic WebSocket Tap Example ===")
-    
-    result = FunctionResult("Starting call monitoring") \
-        .tap("wss://monitoring.company.com/audio-stream") \
+
+    result = (
+        FunctionResult("Starting call monitoring")
+        .tap("wss://monitoring.company.com/audio-stream")
         .say("Call monitoring is now active")
-    
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -37,11 +39,13 @@ def basic_websocket_tap_example():
 def basic_rtp_tap_example():
     """Basic RTP tap for real-time processing."""
     print("=== Basic RTP Tap Example ===")
-    
-    result = FunctionResult("Starting RTP monitoring") \
-        .tap("rtp://192.168.1.100:5004") \
+
+    result = (
+        FunctionResult("Starting RTP monitoring")
+        .tap("rtp://192.168.1.100:5004")
         .update_global_data({"rtp_monitoring": True})
-    
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -49,22 +53,26 @@ def basic_rtp_tap_example():
 def advanced_compliance_monitoring():
     """Advanced compliance monitoring setup."""
     print("=== Advanced Compliance Monitoring ===")
-    
-    result = FunctionResult("Setting up compliance monitoring") \
+
+    result = (
+        FunctionResult("Setting up compliance monitoring")
         .tap(
             uri="wss://compliance.company.com/secure-stream",
             control_id="compliance_tap_001",
             direction="both",  # Monitor both sides of conversation
             codec="PCMA",
-            status_url="https://api.company.com/compliance-events"
-        ) \
-        .set_metadata({
-            "compliance_session": True,
-            "agent_id": "agent_123",
-            "recording_purpose": "regulatory_compliance"
-        }) \
+            status_url="https://api.company.com/compliance-events",
+        )
+        .set_metadata(
+            {
+                "compliance_session": True,
+                "agent_id": "agent_123",
+                "recording_purpose": "regulatory_compliance",
+            }
+        )
         .say("This call may be monitored for compliance purposes")
-    
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -72,20 +80,21 @@ def advanced_compliance_monitoring():
 def customer_service_monitoring():
     """Customer service quality monitoring."""
     print("=== Customer Service Monitoring ===")
-    
-    result = FunctionResult("Initializing quality monitoring") \
+
+    result = (
+        FunctionResult("Initializing quality monitoring")
         .tap(
             uri="wss://quality.company.com/cs-monitoring",
             control_id="cs_quality_monitor",
             direction="speak",  # Only monitor agent speech
-            status_url="https://api.company.com/quality-events"
-        ) \
-        .update_global_data({
-            "quality_monitoring": True,
-            "session_start": "2024-01-01T12:00:00Z"
-        }) \
+            status_url="https://api.company.com/quality-events",
+        )
+        .update_global_data(
+            {"quality_monitoring": True, "session_start": "2024-01-01T12:00:00Z"}
+        )
         .say("Welcome to customer service. How can I help you today?")
-    
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -93,22 +102,26 @@ def customer_service_monitoring():
 def real_time_analytics_tap():
     """Real-time analytics with RTP streaming."""
     print("=== Real-Time Analytics Tap ===")
-    
-    result = FunctionResult("Starting real-time analytics") \
+
+    result = (
+        FunctionResult("Starting real-time analytics")
         .tap(
             uri="rtp://analytics.company.com:6000",
             control_id="analytics_stream",
             direction="both",
             codec="PCMU",
             rtp_ptime=30,  # 30ms packetization
-            status_url="https://api.company.com/analytics-status"
-        ) \
-        .set_metadata({
-            "analytics_type": "sentiment_analysis",
-            "stream_quality": "high",
-            "processing_mode": "real_time"
-        })
-    
+            status_url="https://api.company.com/analytics-status",
+        )
+        .set_metadata(
+            {
+                "analytics_type": "sentiment_analysis",
+                "stream_quality": "high",
+                "processing_mode": "real_time",
+            }
+        )
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -116,22 +129,26 @@ def real_time_analytics_tap():
 def stop_tap_examples():
     """Examples of stopping tap sessions."""
     print("=== Stop Tap Examples ===")
-    
+
     # Stop most recent tap
-    stop_recent = FunctionResult("Ending monitoring session") \
-        .stop_tap() \
+    stop_recent = (
+        FunctionResult("Ending monitoring session")
+        .stop_tap()
         .say("Call monitoring has been stopped")
-    
+    )
+
     print("Stop most recent tap:")
     print(json.dumps(stop_recent.to_dict(), indent=2))
     print()
-    
+
     # Stop specific tap by ID
-    stop_specific = FunctionResult("Ending compliance monitoring") \
-        .stop_tap("compliance_tap_001") \
-        .update_global_data({"compliance_session": False}) \
+    stop_specific = (
+        FunctionResult("Ending compliance monitoring")
+        .stop_tap("compliance_tap_001")
+        .update_global_data({"compliance_session": False})
         .say("Compliance monitoring has been deactivated")
-    
+    )
+
     print("Stop specific tap:")
     print(json.dumps(stop_specific.to_dict(), indent=2))
     print()
@@ -140,41 +157,50 @@ def stop_tap_examples():
 def call_center_workflow():
     """Complete call center monitoring workflow."""
     print("=== Call Center Workflow ===")
-    
+
     # Start monitoring when call begins
-    start_monitoring = FunctionResult("Call center session starting") \
+    start_monitoring = (
+        FunctionResult("Call center session starting")
         .tap(
             uri="wss://callcenter.company.com/agent-monitoring",
             control_id="agent_monitor_001",
             direction="both",
-            status_url="https://api.company.com/callcenter-events"
-        ) \
-        .set_metadata({
-            "agent_id": "agent_456",
-            "department": "technical_support",
-            "shift": "morning",
-            "monitoring_level": "full"
-        }) \
-        .update_global_data({
-            "call_monitored": True,
-            "monitor_start_time": "2024-01-01T09:15:00Z"
-        }) \
-        .say("Thank you for calling technical support. Your call may be monitored for quality assurance.")
-    
+            status_url="https://api.company.com/callcenter-events",
+        )
+        .set_metadata(
+            {
+                "agent_id": "agent_456",
+                "department": "technical_support",
+                "shift": "morning",
+                "monitoring_level": "full",
+            }
+        )
+        .update_global_data(
+            {"call_monitored": True, "monitor_start_time": "2024-01-01T09:15:00Z"}
+        )
+        .say(
+            "Thank you for calling technical support. Your call may be monitored for quality assurance."
+        )
+    )
+
     print("Start call center monitoring:")
     print(json.dumps(start_monitoring.to_dict(), indent=2))
     print()
-    
+
     # End monitoring when call completes
-    end_monitoring = FunctionResult("Ending call session") \
-        .stop_tap("agent_monitor_001") \
-        .update_global_data({
-            "call_monitored": False,
-            "monitor_end_time": "2024-01-01T09:35:00Z",
-            "call_duration": 1200  # 20 minutes
-        }) \
+    end_monitoring = (
+        FunctionResult("Ending call session")
+        .stop_tap("agent_monitor_001")
+        .update_global_data(
+            {
+                "call_monitored": False,
+                "monitor_end_time": "2024-01-01T09:35:00Z",
+                "call_duration": 1200,  # 20 minutes
+            }
+        )
         .set_metadata({"session_complete": True})
-    
+    )
+
     print("End call center monitoring:")
     print(json.dumps(end_monitoring.to_dict(), indent=2))
     print()
@@ -183,27 +209,28 @@ def call_center_workflow():
 def security_incident_monitoring():
     """Emergency security incident monitoring."""
     print("=== Security Incident Monitoring ===")
-    
-    result = FunctionResult("SECURITY ALERT: Activating emergency monitoring") \
+
+    result = (
+        FunctionResult("SECURITY ALERT: Activating emergency monitoring")
         .tap(
             uri="wss://security.company.com/incident-stream",
             control_id="security_incident_001",
             direction="both",
             codec="PCMA",
-            status_url="https://api.company.com/security-alerts"
-        ) \
-        .set_metadata({
-            "alert_level": "high",
-            "incident_type": "suspicious_activity",
-            "security_team_notified": True,
-            "escalation_required": True
-        }) \
-        .update_global_data({
-            "security_monitoring": True,
-            "incident_active": True
-        }) \
+            status_url="https://api.company.com/security-alerts",
+        )
+        .set_metadata(
+            {
+                "alert_level": "high",
+                "incident_type": "suspicious_activity",
+                "security_team_notified": True,
+                "escalation_required": True,
+            }
+        )
+        .update_global_data({"security_monitoring": True, "incident_active": True})
         .say("This call is being monitored for security purposes")
-    
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -211,26 +238,29 @@ def security_incident_monitoring():
 def training_and_coaching():
     """Training and coaching monitoring setup."""
     print("=== Training and Coaching Setup ===")
-    
-    result = FunctionResult("Setting up training session monitoring") \
+
+    result = (
+        FunctionResult("Setting up training session monitoring")
         .tap(
             uri="wss://training.company.com/coaching-stream",
             control_id="training_session_001",
             direction="speak",  # Monitor trainee's speech only
-            status_url="https://api.company.com/training-events"
-        ) \
-        .set_metadata({
-            "session_type": "sales_training",
-            "trainee_id": "trainee_789",
-            "trainer_id": "trainer_101",
-            "skill_focus": "objection_handling"
-        }) \
-        .update_global_data({
-            "training_active": True,
-            "coaching_mode": "live_feedback"
-        }) \
-        .say("This is a training call. Your performance will be monitored for coaching purposes.")
-    
+            status_url="https://api.company.com/training-events",
+        )
+        .set_metadata(
+            {
+                "session_type": "sales_training",
+                "trainee_id": "trainee_789",
+                "trainer_id": "trainer_101",
+                "skill_focus": "objection_handling",
+            }
+        )
+        .update_global_data({"training_active": True, "coaching_mode": "live_feedback"})
+        .say(
+            "This is a training call. Your performance will be monitored for coaching purposes."
+        )
+    )
+
     print(json.dumps(result.to_dict(), indent=2))
     print()
 
@@ -238,44 +268,49 @@ def training_and_coaching():
 def multi_tap_management():
     """Managing multiple tap sessions."""
     print("=== Multi-Tap Management ===")
-    
+
     # Start multiple taps for different purposes
-    start_multiple = FunctionResult("Initializing multi-stream monitoring") \
+    start_multiple = (
+        FunctionResult("Initializing multi-stream monitoring")
         .tap(
             uri="wss://compliance.company.com/stream",
             control_id="compliance_stream",
-            direction="both"
-        ) \
+            direction="both",
+        )
         .tap(
             uri="rtp://analytics.company.com:5006",
-            control_id="analytics_stream", 
+            control_id="analytics_stream",
             direction="both",
-            codec="PCMA"
-        ) \
+            codec="PCMA",
+        )
         .tap(
             uri="wss://quality.company.com/monitoring",
             control_id="quality_stream",
-            direction="speak"
-        ) \
-        .update_global_data({
-            "active_streams": ["compliance", "analytics", "quality"],
-            "monitoring_level": "comprehensive"
-        })
-    
+            direction="speak",
+        )
+        .update_global_data(
+            {
+                "active_streams": ["compliance", "analytics", "quality"],
+                "monitoring_level": "comprehensive",
+            }
+        )
+    )
+
     print("Start multiple monitoring streams:")
     print(json.dumps(start_multiple.to_dict(), indent=2))
     print()
-    
+
     # Stop specific streams
-    stop_selective = FunctionResult("Reducing monitoring scope") \
-        .stop_tap("analytics_stream") \
-        .stop_tap("quality_stream") \
-        .update_global_data({
-            "active_streams": ["compliance"],
-            "monitoring_level": "compliance_only"
-        }) \
+    stop_selective = (
+        FunctionResult("Reducing monitoring scope")
+        .stop_tap("analytics_stream")
+        .stop_tap("quality_stream")
+        .update_global_data(
+            {"active_streams": ["compliance"], "monitoring_level": "compliance_only"}
+        )
         .say("Monitoring has been reduced to compliance-only")
-    
+    )
+
     print("Stop selective monitoring:")
     print(json.dumps(stop_selective.to_dict(), indent=2))
     print()
@@ -283,7 +318,7 @@ def multi_tap_management():
 
 if __name__ == "__main__":
     print("Tap and Stop Tap Virtual Helper Examples\n")
-    
+
     basic_websocket_tap_example()
     basic_rtp_tap_example()
     advanced_compliance_monitoring()
@@ -294,7 +329,7 @@ if __name__ == "__main__":
     security_incident_monitoring()
     training_and_coaching()
     multi_tap_management()
-    
+
     print("COMPLETE: All tap examples completed")
     print("\nKey Features Demonstrated:")
     print("- WebSocket and RTP tap streaming")
@@ -304,4 +339,4 @@ if __name__ == "__main__":
     print("- Multiple concurrent tap sessions")
     print("- Selective tap control and management")
     print("- Status callbacks and metadata tracking")
-    print("- Complete workflow integration") 
+    print("- Complete workflow integration")

--- a/examples/web_search_agent.py
+++ b/examples/web_search_agent.py
@@ -8,7 +8,6 @@ Licensed under the MIT License.
 See LICENSE file in the project root for full license information.
 """
 
-
 """
 Web Search Agent Example
 
@@ -36,45 +35,46 @@ https://developers.google.com/custom-search/v1/introduction
 import os
 from signalwire import AgentBase
 
+
 def main():
     # Create an agent
     agent = AgentBase("Web Search Assistant", route="/search")
-    
+
     # Configure the agent with a pleasant voice
     agent.add_language("English", "en-US", "inworld.Mark")
-    
+
     # Configure Franklin the search bot's personality
     agent.prompt_add_section(
-        "Personality", 
+        "Personality",
         body="You are Franklin, a friendly and knowledgeable search bot. You're enthusiastic about "
         "helping people find information on the internet and always greet users warmly. You have "
-        "a curious nature and love discovering new information through web searches."
+        "a curious nature and love discovering new information through web searches.",
     )
-    
+
     agent.prompt_add_section(
-        "Goal", 
+        "Goal",
         body="Help users find accurate, up-to-date information from the web by conducting thorough "
-        "searches and presenting results in a clear, organized manner."
+        "searches and presenting results in a clear, organized manner.",
     )
-    
+
     agent.prompt_add_section(
-        "Instructions", 
+        "Instructions",
         bullets=[
             "Always introduce yourself as Franklin when users first interact with you",
             "Use your web search capabilities to find current information when users ask questions",
             "Present search results in a well-organized format with clear headings and source URLs",
-            "Be enthusiastic about searching and learning new things with your users"
-        ]
+            "Be enthusiastic about searching and learning new things with your users",
+        ],
     )
-    
+
     print("Starting Web Search Agent...")
-    
+
     # Add web search skill
     try:
         # Get credentials from environment variables
-        google_api_key = os.getenv('GOOGLE_SEARCH_API_KEY')
-        google_search_engine_id = os.getenv('GOOGLE_SEARCH_ENGINE_ID')
-        
+        google_api_key = os.getenv("GOOGLE_SEARCH_API_KEY")
+        google_search_engine_id = os.getenv("GOOGLE_SEARCH_ENGINE_ID")
+
         if not google_api_key or not google_search_engine_id:
             raise ValueError(
                 "Missing required environment variables:\\n"
@@ -85,43 +85,49 @@ def main():
                 "2. Create a Custom Search Engine\\n"
                 "3. Get your API key and Search Engine ID"
             )
-        
+
         # Add web search with custom parameters
-        agent.add_skill("web_search", {
-            "api_key": google_api_key,
-            "search_engine_id": google_search_engine_id,
-            "num_results": 1,  # Get 1 result for faster responses
-            "delay": 0,        # No delay between requests
-            "max_content_length": 3000,  # Extract up to 3000 characters from each page (default: 2000)
-            "no_results_message": "I apologize, but I wasn't able to find any information about '{query}' in my web search. Could you try rephrasing your question or asking about something else?",
-            "swaig_fields": {  # Custom fillers for better user experience
-                "fillers": {
-                    "en-US": [
-                        "I am searching the web for that information...",
-                        "Let me google that for you...",
-                        "Searching the internet now...",
-                        "Finding the latest information online...",
-                        "Let me check what I can find about that..."
-                    ]
-                }
-            }
-        })
+        agent.add_skill(
+            "web_search",
+            {
+                "api_key": google_api_key,
+                "search_engine_id": google_search_engine_id,
+                "num_results": 1,  # Get 1 result for faster responses
+                "delay": 0,  # No delay between requests
+                "max_content_length": 3000,  # Extract up to 3000 characters from each page (default: 2000)
+                "no_results_message": "I apologize, but I wasn't able to find any information about '{query}' in my web search. Could you try rephrasing your question or asking about something else?",
+                "swaig_fields": {  # Custom fillers for better user experience
+                    "fillers": {
+                        "en-US": [
+                            "I am searching the web for that information...",
+                            "Let me google that for you...",
+                            "Searching the internet now...",
+                            "Finding the latest information online...",
+                            "Let me check what I can find about that...",
+                        ]
+                    }
+                },
+            },
+        )
         print("Web search skill loaded successfully")
-        
+
     except Exception as e:
         print(f"Failed to load web search skill: {e}")
         return
-    
+
     # Show what skills are loaded
     loaded_skills = agent.list_skills()
     print(f"Loaded skills: {', '.join(loaded_skills)}")
-    
+
     print(f"Agent available at: {agent.get_full_url()}")
-    print("The agent can now search the web for information and provide comprehensive answers.")
-    
+    print(
+        "The agent can now search the web for information and provide comprehensive answers."
+    )
+
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/web_search_multi_instance_demo.py
+++ b/examples/web_search_multi_instance_demo.py
@@ -29,160 +29,182 @@ To use this demo, you'll need:
 import os
 from signalwire import AgentBase
 
+
 def main():
     # Create an agent
     agent = AgentBase("Multi-Search Assistant", route="/search-demo")
-    
+
     # Configure the agent with inworld.Mark voice
     agent.add_language("English", "en-US", "inworld.Mark")
-    
+
     print("Creating agent with multiple web search skill instances...")
-    
+
     # Add datetime and math skills for basic functionality
     try:
         agent.add_skill("datetime")
         print("Added datetime skill")
     except Exception as e:
         print(f"Failed to add datetime skill: {e}")
-    
+
     try:
         agent.add_skill("math")
         print("Added math skill")
     except Exception as e:
         print(f"Failed to add math skill: {e}")
-    
+
     # Add Wikipedia search skill
     try:
-        agent.add_skill("wikipedia_search", {
-            "num_results": 2,  # Get 2 Wikipedia articles by default
-            "no_results_message": "I couldn't find any Wikipedia articles about '{query}'. Try using different keywords or check the spelling.",
-            "swaig_fields": {
-                "fillers": {
-                    "en-US": [
-                        "Let me check Wikipedia for that...",
-                        "Searching Wikipedia...",
-                        "Looking that up on Wikipedia..."
-                    ]
-                }
-            }
-        })
+        agent.add_skill(
+            "wikipedia_search",
+            {
+                "num_results": 2,  # Get 2 Wikipedia articles by default
+                "no_results_message": "I couldn't find any Wikipedia articles about '{query}'. Try using different keywords or check the spelling.",
+                "swaig_fields": {
+                    "fillers": {
+                        "en-US": [
+                            "Let me check Wikipedia for that...",
+                            "Searching Wikipedia...",
+                            "Looking that up on Wikipedia...",
+                        ]
+                    }
+                },
+            },
+        )
         print("Added Wikipedia search (tool: search_wiki)")
     except Exception as e:
         print(f"Failed to add Wikipedia skill: {e}")
-    
+
     # Get credentials from environment variables
-    google_api_key = os.getenv('GOOGLE_SEARCH_API_KEY')
-    google_search_engine_id = os.getenv('GOOGLE_SEARCH_ENGINE_ID')
-    
+    google_api_key = os.getenv("GOOGLE_SEARCH_API_KEY")
+    google_search_engine_id = os.getenv("GOOGLE_SEARCH_ENGINE_ID")
+
     if not google_api_key or not google_search_engine_id:
-        print("Warning: Missing GOOGLE_SEARCH_API_KEY or GOOGLE_SEARCH_ENGINE_ID environment variables")
+        print(
+            "Warning: Missing GOOGLE_SEARCH_API_KEY or GOOGLE_SEARCH_ENGINE_ID environment variables"
+        )
         print("Web search instances will not be available.")
         print("Set these environment variables to enable web search functionality.")
     else:
         # Instance 1: General web search (default tool name)
         try:
-            agent.add_skill("web_search", {
-                "api_key": google_api_key,
-                "search_engine_id": google_search_engine_id,
-                # No tool_name specified, so it will use default "web_search"
-                "num_results": 1,
-                "delay": 0,
-                "no_results_message": "I couldn't find any information about '{query}' in my web search. Please try rephrasing your question.",
-                "swaig_fields": {
-                    "fillers": {
-                        "en-US": [
-                            "Let me search the web for that...",
-                            "Searching the internet now...",
-                            "Looking that up online..."
-                        ]
-                    }
-                }
-            })
+            agent.add_skill(
+                "web_search",
+                {
+                    "api_key": google_api_key,
+                    "search_engine_id": google_search_engine_id,
+                    # No tool_name specified, so it will use default "web_search"
+                    "num_results": 1,
+                    "delay": 0,
+                    "no_results_message": "I couldn't find any information about '{query}' in my web search. Please try rephrasing your question.",
+                    "swaig_fields": {
+                        "fillers": {
+                            "en-US": [
+                                "Let me search the web for that...",
+                                "Searching the internet now...",
+                                "Looking that up online...",
+                            ]
+                        }
+                    },
+                },
+            )
             print("Added general web search (tool: web_search - default)")
         except Exception as e:
             print(f"Failed to add general web search skill: {e}")
-        
+
         # Instance 2: News search (assuming you have a news-specific search engine)
         try:
-            agent.add_skill("web_search", {
-                "api_key": google_api_key,
-                "search_engine_id": google_search_engine_id,  # You could use a different engine ID for news
-                "tool_name": "search_news",
-                "num_results": 3,  # More results for news
-                "delay": 0.5,      # Small delay for news searches
-                "no_results_message": "I couldn't find any recent news about '{query}'. Try searching for a different topic or current event.",
-                "swaig_fields": {
-                    "fillers": {
-                        "en-US": [
-                            "Checking the latest news...",
-                            "Searching for recent articles...",
-                            "Looking up current news stories..."
-                        ]
-                    }
-                }
-            })
+            agent.add_skill(
+                "web_search",
+                {
+                    "api_key": google_api_key,
+                    "search_engine_id": google_search_engine_id,  # You could use a different engine ID for news
+                    "tool_name": "search_news",
+                    "num_results": 3,  # More results for news
+                    "delay": 0.5,  # Small delay for news searches
+                    "no_results_message": "I couldn't find any recent news about '{query}'. Try searching for a different topic or current event.",
+                    "swaig_fields": {
+                        "fillers": {
+                            "en-US": [
+                                "Checking the latest news...",
+                                "Searching for recent articles...",
+                                "Looking up current news stories...",
+                            ]
+                        }
+                    },
+                },
+            )
             print("Added news search (tool: search_news)")
         except Exception as e:
             print(f"Failed to add news search skill: {e}")
-        
+
         # Instance 3: Fast search for quick answers
         try:
-            agent.add_skill("web_search", {
-                "api_key": google_api_key,
-                "search_engine_id": google_search_engine_id,
-                "tool_name": "quick_search",
-                "num_results": 1,  # Just one result for speed
-                "delay": 0,        # No delay for maximum speed
-                "no_results_message": "Quick search didn't find anything for '{query}'. Try using the regular web search for more comprehensive results.",
-                "swaig_fields": {
-                    "fillers": {
-                        "en-US": [
-                            "Quick search...",
-                            "Fast lookup...",
-                            "Rapid search..."
-                        ]
-                    }
-                }
-            })
+            agent.add_skill(
+                "web_search",
+                {
+                    "api_key": google_api_key,
+                    "search_engine_id": google_search_engine_id,
+                    "tool_name": "quick_search",
+                    "num_results": 1,  # Just one result for speed
+                    "delay": 0,  # No delay for maximum speed
+                    "no_results_message": "Quick search didn't find anything for '{query}'. Try using the regular web search for more comprehensive results.",
+                    "swaig_fields": {
+                        "fillers": {
+                            "en-US": [
+                                "Quick search...",
+                                "Fast lookup...",
+                                "Rapid search...",
+                            ]
+                        }
+                    },
+                },
+            )
             print("Added quick search (tool: quick_search)")
         except Exception as e:
             print(f"Failed to add quick search skill: {e}")
-    
+
     # Show what skills/instances are loaded
     loaded_skills = agent.list_skills()
     print(f"\nLoaded skill instances: {', '.join(loaded_skills)}")
-    
+
     # Show available skills from registry
     try:
         from signalwire.skills.registry import skill_registry
+
         available_skills = skill_registry.list_skills()
-        print(f"\nAvailable skills in registry:")
+        print("\nAvailable skills in registry:")
         for skill in available_skills:
             print(f"  - {skill['name']}: {skill['description']}")
-            if skill['name'] == 'web_search':
-                print(f"    Supports multiple instances: Yes")
+            if skill["name"] == "web_search":
+                print("    Supports multiple instances: Yes")
             else:
-                print(f"    Supports multiple instances: {skill.get('supports_multiple_instances', 'No')}")
+                print(
+                    f"    Supports multiple instances: {skill.get('supports_multiple_instances', 'No')}"
+                )
     except Exception as e:
         print(f"Failed to list available skills: {e}")
-    
+
     print(f"\nAgent available at: {agent.get_full_url()}")
     print("The agent now has enhanced search capabilities:")
     print("   - Can tell current date/time")
     print("   - Can perform mathematical calculations")
     print("   - Can search Wikipedia for factual information")
-    
+
     # Count how many web search instances we have
-    websearch_instances = [skill for skill in loaded_skills if skill.startswith('web_search_')]
+    websearch_instances = [
+        skill for skill in loaded_skills if skill.startswith("web_search_")
+    ]
     if websearch_instances:
         print(f"   - Has {len(websearch_instances)} web search capabilities:")
         for instance in websearch_instances:
             # Extract tool name from instance key (format: web_search_engineid_toolname)
-            parts = instance.split('_')
+            parts = instance.split("_")
             if len(parts) >= 3:
-                tool_name = '_'.join(parts[2:])  # Join all parts after the second underscore
+                tool_name = "_".join(
+                    parts[2:]
+                )  # Join all parts after the second underscore
                 print(f"     * {tool_name}")
-    
+
     print("\nWeb Search Multiple Instance Examples:")
     print("   # Basic usage with default tool name")
     print("   agent.add_skill('web_search', {")
@@ -212,10 +234,11 @@ def main():
     print("   agent.add_skill('web_search', {..., 'tool_name': 'search_products'})")
     print("   agent.add_skill('web_search', {..., 'tool_name': 'search_support'})")
     print("   agent.add_skill('web_search', {..., 'tool_name': 'quick_search'})")
-    
+
     print("\nStarting agent server...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/examples/wikipedia_demo.py
+++ b/examples/wikipedia_demo.py
@@ -22,55 +22,59 @@ Features demonstrated:
 
 from signalwire import AgentBase
 
+
 def main():
     # Create an agent focused on Wikipedia search
     agent = AgentBase("Wikipedia Assistant", route="/wiki-demo")
-    
+
     # Configure the agent with a clear voice
     agent.add_language("English", "en-US", "inworld.Mark")
-    
+
     print("Creating Wikipedia search assistant...")
-    
+
     # Add basic skills
     try:
         agent.add_skill("datetime")
         print("Added datetime skill")
     except Exception as e:
         print(f"Failed to add datetime skill: {e}")
-    
+
     # Add Wikipedia search skill with custom configuration
     try:
-        agent.add_skill("wikipedia_search", {
-            "num_results": 2,  # Get up to 2 articles for broader coverage
-            "no_results_message": "I couldn't find any Wikipedia articles about '{query}'. You might want to try different keywords, check the spelling, or ask about a related topic.",
-            "swaig_fields": {
-                "fillers": {
-                    "en-US": [
-                        "Let me search Wikipedia for that information...",
-                        "Checking Wikipedia's knowledge base...",
-                        "Looking that up in the encyclopedia...",
-                        "Searching for factual information...",
-                        "Let me find that on Wikipedia..."
-                    ]
-                }
-            }
-        })
+        agent.add_skill(
+            "wikipedia_search",
+            {
+                "num_results": 2,  # Get up to 2 articles for broader coverage
+                "no_results_message": "I couldn't find any Wikipedia articles about '{query}'. You might want to try different keywords, check the spelling, or ask about a related topic.",
+                "swaig_fields": {
+                    "fillers": {
+                        "en-US": [
+                            "Let me search Wikipedia for that information...",
+                            "Checking Wikipedia's knowledge base...",
+                            "Looking that up in the encyclopedia...",
+                            "Searching for factual information...",
+                            "Let me find that on Wikipedia...",
+                        ]
+                    }
+                },
+            },
+        )
         print("Added Wikipedia search (tool: search_wiki)")
     except Exception as e:
         print(f"Failed to add Wikipedia skill: {e}")
         return
-    
+
     # Show loaded skills
     loaded_skills = agent.list_skills()
     print(f"\nLoaded skills: {', '.join(loaded_skills)}")
-    
+
     print(f"\nWikipedia Assistant available at: {agent.get_full_url()}")
     print("\nThis agent specializes in:")
     print("   - Searching Wikipedia for factual information")
     print("   - Providing article summaries and encyclopedic knowledge")
     print("   - Answering questions about people, places, concepts, and history")
     print("   - Current date and time information")
-    
+
     print("\nExample queries to try:")
     print("   'Tell me about Albert Einstein'")
     print("   'What is quantum physics?'")
@@ -78,16 +82,17 @@ def main():
     print("   'Search for information about the Roman Empire'")
     print("   'Look up Python programming language'")
     print("   'What is artificial intelligence?'")
-    
+
     print("\nWikipedia Skill Configuration:")
     print("   - Returns up to 2 article summaries per search")
     print("   - Custom no-results message with helpful suggestions")
     print("   - Enhanced fillers for better user experience")
     print("   - Tool name: search_wiki")
-    
+
     print("\nStarting Wikipedia Assistant...")
     print("Note: Works in any deployment mode (server/CGI/Lambda)")
     agent.run()
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,19 @@ select = ["E4", "E7", "E9", "F", "B", "S", "C4", "PERF", "SIM", "PTH", "RET", "R
 # subscript is a runtime NameError under TYPE_CHECKING). Exempt F401 here; mypy +
 # the SIGNATURES/DRIFT gate prove these imports are real and correct.
 "signalwire/signalwire/rest/namespaces/*.py" = ["F401"]
+# Runnable docs — examples/, rest/examples/, relay/examples/. These are teaching
+# programs, not shipped SDK surface, so a few production-lint rules are demo-idiomatic
+# noise here (and are the ONLY findings that survive after autofix):
+#   E402 — a leading module docstring / "set your creds here" preamble before imports
+#          is the natural example shape (imports-not-at-top).
+#   S104 — binding 0.0.0.0 is how a demo server example says "listen on all interfaces".
+#   S106 — literal "password"/"token" kwargs are obvious placeholder creds in a snippet.
+#   S311 — non-crypto random (sample data / demo ids), never used for security here.
+# Everything else (F401 unused imports, F541 empty f-strings, C4/B/RET/SIM/…) is a real
+# smell and stays enforced so `examples/**` is gate-cleanable to zero.
+"examples/**" = ["E402", "S104", "S106", "S311"]
+"rest/examples/**" = ["E402", "S104", "S106", "S311"]
+"relay/examples/**" = ["E402", "S104", "S106", "S311"]
 
 [tool.ruff.lint.flake8-bugbear]
 # FastAPI's dependency-injection idiom puts Depends()/Query()/etc. in argument

--- a/relay/examples/relay_answer_and_welcome.py
+++ b/relay/examples/relay_answer_and_welcome.py
@@ -23,7 +23,9 @@ async def on_incoming_call(call):
     print(f"Incoming call: {call}")
     await call.answer()
 
-    action = await call.play([{"type": "tts", "params": {"text": "Welcome to SignalWire!"}}])
+    action = await call.play(
+        [{"type": "tts", "params": {"text": "Welcome to SignalWire!"}}]
+    )
     await action.wait()
 
     await call.hangup()

--- a/relay/examples/relay_dial_and_play.py
+++ b/relay/examples/relay_dial_and_play.py
@@ -11,19 +11,26 @@ Requires env vars:
 import asyncio
 import os
 
-from signalwire.relay import RelayClient, CALL_STATE_ANSWERED, CALL_STATE_ENDED
+from signalwire.relay import RelayClient, CALL_STATE_ANSWERED
 
 
 async def main():
-    from_number = os.environ["RELAY_FROM_NUMBER"]
-    to_number = os.environ["RELAY_TO_NUMBER"]
+    from_number = os.environ.get("RELAY_FROM_NUMBER", "+15550000001")
+    to_number = os.environ.get("RELAY_TO_NUMBER", "+15550000002")
 
     client = RelayClient()
     await client.connect()
     print(f"Connected — protocol: {client.relay_protocol}")
 
     # Dial the number
-    devices = [[{"type": "phone", "params": {"to_number": to_number, "from_number": from_number}}]]
+    devices = [
+        [
+            {
+                "type": "phone",
+                "params": {"to_number": to_number, "from_number": from_number},
+            }
+        ]
+    ]
     call = await client.dial(devices)
     print(f"Dialing {to_number} from {from_number} — call_id: {call.call_id}")
 
@@ -42,9 +49,9 @@ async def main():
     print("Call answered — playing TTS")
 
     # Play TTS
-    play_action = await call.play([
-        {"type": "tts", "params": {"text": "Welcome to SignalWire"}}
-    ])
+    play_action = await call.play(
+        [{"type": "tts", "params": {"text": "Welcome to SignalWire"}}]
+    )
 
     # Wait for playback to finish
     await play_action.wait(timeout=15.0)

--- a/relay/examples/relay_ivr_connect.py
+++ b/relay/examples/relay_ivr_connect.py
@@ -40,7 +40,9 @@ async def on_incoming_call(call):
     collect_action = await call.play_and_collect(
         media=[
             tts("Welcome to SignalWire!"),
-            tts("Press 1 for sales. Press 2 for support. Press 0 to speak with an agent."),
+            tts(
+                "Press 1 for sales. Press 2 for support. Press 0 to speak with an agent."
+            ),
         ],
         collect={
             "digits": {
@@ -60,12 +62,20 @@ async def on_incoming_call(call):
 
     if result_type == "digit" and digits == "1":
         # Sales
-        action = await call.play([tts("Thank you for your interest! A sales representative will be with you shortly.")])
+        action = await call.play(
+            [
+                tts(
+                    "Thank you for your interest! A sales representative will be with you shortly."
+                )
+            ]
+        )
         await action.wait()
 
     elif result_type == "digit" and digits == "2":
         # Support
-        action = await call.play([tts("Please hold while we connect you to our support team.")])
+        action = await call.play(
+            [tts("Please hold while we connect you to our support team.")]
+        )
         await action.wait()
 
     elif result_type == "digit" and digits == "0":
@@ -79,16 +89,18 @@ async def on_incoming_call(call):
         print(f"Connecting to {AGENT_NUMBER} from {from_number}")
 
         await call.connect(
-            devices=[[
-                {
-                    "type": "phone",
-                    "params": {
-                        "to_number": AGENT_NUMBER,
-                        "from_number": from_number,
-                        "timeout": 30,
-                    },
-                }
-            ]],
+            devices=[
+                [
+                    {
+                        "type": "phone",
+                        "params": {
+                            "to_number": AGENT_NUMBER,
+                            "from_number": from_number,
+                            "timeout": 30,
+                        },
+                    }
+                ]
+            ],
             ringback=[tts("Please wait while we connect your call.")],
         )
 

--- a/rest/examples/rest_10dlc_registration.py
+++ b/rest/examples/rest_10dlc_registration.py
@@ -18,6 +18,15 @@ from signalwire.rest import RestClient, SignalWireRestError
 client = RestClient()
 
 
+def unassign_number(num_id):
+    """Attempt to unassign one number, reporting success/failure independently."""
+    try:
+        client.registry.numbers.delete(num_id)
+        print(f"  Unassigned number {num_id}")
+    except SignalWireRestError as e:
+        print(f"  Unassign failed: {e.status_code}")
+
+
 def main():
     # 1. Register a brand
     print("Registering 10DLC brand...")
@@ -132,11 +141,7 @@ def main():
         print("\nUnassigning numbers...")
         nums = client.registry.campaigns.list_numbers(campaign_id)
         for n in nums.get("data", []):
-            try:
-                client.registry.numbers.delete(n["id"])
-                print(f"  Unassigned number {n['id']}")
-            except SignalWireRestError as e:
-                print(f"  Unassign failed: {e.status_code}")
+            unassign_number(n["id"])
 
 
 if __name__ == "__main__":

--- a/rest/examples/rest_10dlc_registration.py
+++ b/rest/examples/rest_10dlc_registration.py
@@ -23,12 +23,14 @@ def main():
     print("Registering 10DLC brand...")
     try:
         brand = client.registry.brands.create(
-            company_name="Acme Corp",
-            ein="12-3456789",
-            entity_type="PRIVATE_PROFIT",
-            vertical="TECHNOLOGY",
-            website="https://acme.example.com",
-            country="US",
+            {
+                "name": "Acme Corp",
+                "company_name": "Acme Corp",
+                "ein": "12-3456789",
+                "legal_entity_type": "PRIVATE_PROFIT",
+                "company_vertical": "TECHNOLOGY",
+                "company_website": "https://acme.example.com",
+            }
         )
         brand_id = brand["id"]
         print(f"  Registered brand: {brand_id}")
@@ -47,7 +49,9 @@ def main():
     # 3. Get brand details
     if brand_id:
         detail = client.registry.brands.get(brand_id)
-        print(f"\nBrand detail: {detail.get('name', 'N/A')} ({detail.get('state', 'N/A')})")
+        print(
+            f"\nBrand detail: {detail.get('name', 'N/A')} ({detail.get('state', 'N/A')})"
+        )
 
     # 4. Create a campaign under the brand
     campaign_id = None
@@ -56,9 +60,12 @@ def main():
         try:
             campaign = client.registry.brands.create_campaign(
                 brand_id,
-                use_case="MIXED",
-                description="Customer notifications and support messages",
-                sample_message="Your order #12345 has shipped.",
+                {
+                    "name": "Order notifications",
+                    "sms_use_case": "MIXED",
+                    "description": "Customer notifications and support messages",
+                    "sample1": "Your order #12345 has shipped.",
+                },
             )
             campaign_id = campaign["id"]
             print(f"  Created campaign: {campaign_id}")
@@ -77,11 +84,14 @@ def main():
     # 6. Get and update campaign
     if campaign_id:
         camp_detail = client.registry.campaigns.get(campaign_id)
-        print(f"\nCampaign: {camp_detail.get('name', 'N/A')} ({camp_detail.get('state', 'N/A')})")
+        print(
+            f"\nCampaign: {camp_detail.get('name', 'N/A')} ({camp_detail.get('state', 'N/A')})"
+        )
 
         try:
             client.registry.campaigns.update(
-                campaign_id, description="Updated: customer notifications",
+                campaign_id,
+                name="Updated: customer notifications",
             )
             print("  Campaign description updated")
         except SignalWireRestError as e:
@@ -93,7 +103,8 @@ def main():
         print("\nCreating number assignment order...")
         try:
             order = client.registry.campaigns.create_order(
-                campaign_id, phone_numbers=["+15125551234"],
+                campaign_id,
+                phone_numbers=["+15125551234"],
             )
             order_id = order["id"]
             print(f"  Created order: {order_id}")

--- a/rest/examples/rest_bind_phone_to_swml_webhook.py
+++ b/rest/examples/rest_bind_phone_to_swml_webhook.py
@@ -17,12 +17,12 @@ Set these env vars (or pass them directly to RestClient):
 
 import os
 
-from signalwire.rest import RestClient, PhoneCallHandler
+from signalwire.rest import RestClient
 
 
 def main() -> None:
-    pn_sid = os.environ["PHONE_NUMBER_SID"]
-    webhook_url = os.environ["SWML_WEBHOOK_URL"]
+    pn_sid = os.environ.get("PHONE_NUMBER_SID", "00000000-0000-0000-0000-000000000000")
+    webhook_url = os.environ.get("SWML_WEBHOOK_URL", "https://example.com/swml-handler")
 
     client = RestClient()
 
@@ -42,8 +42,10 @@ def main() -> None:
     pn = client.phone_numbers.get(pn_sid)
     print(f"  call_handler = {pn.get('call_handler')!r}")
     print(f"  call_relay_script_url = {pn.get('call_relay_script_url')!r}")
-    print(f"  calling_handler_resource_id (server-derived) = "
-          f"{pn.get('calling_handler_resource_id')!r}")
+    print(
+        f"  calling_handler_resource_id (server-derived) = "
+        f"{pn.get('calling_handler_resource_id')!r}"
+    )
 
     # To route to something other than an SWML webhook, use:
     #   client.phone_numbers.set_cxml_webhook(sid, url=...)       # LAML / Twilio-compat

--- a/rest/examples/rest_calling_ivr_and_ai.py
+++ b/rest/examples/rest_calling_ivr_and_ai.py
@@ -32,81 +32,148 @@ def safe(label, fn):
 
 
 def main():
+    # A control_id ties a "start" command to the "stop"/"timer" commands that
+    # follow it. In production you generate one per command; here it is fixed.
+    CONTROL_ID = "demo-control-id"
+
     # 1. Collect DTMF input
     print("Collecting DTMF input...")
-    safe("Collect", lambda: client.calling.collect(
-        CALL_ID,
-        digits={"max": 4, "terminators": "#"},
-        play=[{"type": "tts", "params": {"text": "Enter your PIN followed by pound."}}],
-    ))
-    safe("Start input timers", lambda: client.calling.collect_start_input_timers(CALL_ID))
-    safe("Stop collect", lambda: client.calling.collect_stop(CALL_ID))
+    safe(
+        "Collect",
+        lambda: client.calling.collect(
+            CALL_ID,
+            control_id=CONTROL_ID,
+            digits={"max": 4, "terminators": "#"},
+        ),
+    )
+    safe(
+        "Start input timers",
+        lambda: client.calling.collect_start_input_timers(
+            CALL_ID, control_id=CONTROL_ID
+        ),
+    )
+    safe(
+        "Stop collect",
+        lambda: client.calling.collect_stop(CALL_ID, control_id=CONTROL_ID),
+    )
 
     # 2. Answering machine detection
     print("\nDetecting answering machine...")
-    safe("Detect", lambda: client.calling.detect(CALL_ID, type="machine"))
-    safe("Stop detect", lambda: client.calling.detect_stop(CALL_ID))
+    safe(
+        "Detect",
+        lambda: client.calling.detect(
+            CALL_ID, detect={"type": "machine"}, control_id=CONTROL_ID
+        ),
+    )
+    safe(
+        "Stop detect",
+        lambda: client.calling.detect_stop(CALL_ID, control_id=CONTROL_ID),
+    )
 
     # 3. AI operations
     print("\nAI agent operations...")
-    safe("AI message", lambda: client.calling.ai_message(
-        CALL_ID,
-        message="The customer wants to check their balance.",
-    ))
+    safe(
+        "AI message",
+        lambda: client.calling.ai_message(
+            CALL_ID,
+            role="system",
+            message_text="The customer wants to check their balance.",
+        ),
+    )
     safe("AI hold", lambda: client.calling.ai_hold(CALL_ID))
     safe("AI unhold", lambda: client.calling.ai_unhold(CALL_ID))
-    safe("AI stop", lambda: client.calling.ai_stop(CALL_ID))
+    safe("AI stop", lambda: client.calling.ai_stop(CALL_ID, control_id=CONTROL_ID))
 
     # 4. Live transcription and translation
     print("\nLive transcription and translation...")
-    safe("Live transcribe", lambda: client.calling.live_transcribe(
-        CALL_ID, language="en-US",
-    ))
-    safe("Live translate", lambda: client.calling.live_translate(
-        CALL_ID, language="es",
-    ))
+    safe(
+        "Live transcribe",
+        lambda: client.calling.live_transcribe(
+            CALL_ID,
+            action={"start": {"language": "en-US"}},
+        ),
+    )
+    safe(
+        "Live translate",
+        lambda: client.calling.live_translate(
+            CALL_ID,
+            action={"start": {"from_lang": "en-US", "to_lang": "es"}},
+        ),
+    )
 
     # 5. Tap (media fork)
     print("\nTap (media fork)...")
-    safe("Tap start", lambda: client.calling.tap(
-        CALL_ID,
-        tap={"type": "audio", "direction": "both"},
-        device={"type": "rtp", "addr": "192.168.1.100", "port": 9000},
-    ))
-    safe("Tap stop", lambda: client.calling.tap_stop(CALL_ID))
+    safe(
+        "Tap start",
+        lambda: client.calling.tap(
+            CALL_ID,
+            tap={"type": "audio", "direction": "both"},
+            device={"type": "rtp", "addr": "192.168.1.100", "port": 9000},
+        ),
+    )
+    safe("Tap stop", lambda: client.calling.tap_stop(CALL_ID, control_id=CONTROL_ID))
 
     # 6. Stream (WebSocket)
     print("\nStream (WebSocket)...")
-    safe("Stream start", lambda: client.calling.stream(
-        CALL_ID, url="wss://example.com/audio-stream",
-    ))
-    safe("Stream stop", lambda: client.calling.stream_stop(CALL_ID))
+    safe(
+        "Stream start",
+        lambda: client.calling.stream(
+            CALL_ID,
+            url="wss://example.com/audio-stream",
+        ),
+    )
+    safe(
+        "Stream stop",
+        lambda: client.calling.stream_stop(CALL_ID, control_id=CONTROL_ID),
+    )
 
     # 7. User event
     print("\nSending user event...")
-    safe("User event", lambda: client.calling.user_event(
-        CALL_ID, event_name="agent_note", data={"note": "VIP caller"},
-    ))
+    safe(
+        "User event",
+        lambda: client.calling.user_event(
+            CALL_ID,
+            event={"name": "agent_note", "data": {"note": "VIP caller"}},
+        ),
+    )
 
     # 8. SIP refer
     print("\nSIP refer...")
-    safe("SIP refer", lambda: client.calling.refer(
-        CALL_ID, sip_uri="sip:support@example.com",
-    ))
+    safe(
+        "SIP refer",
+        lambda: client.calling.refer(
+            CALL_ID,
+            device={"type": "sip", "to": "sip:support@example.com"},
+        ),
+    )
 
     # 9. Fax stop commands
     print("\nFax stop commands...")
-    safe("Send fax stop", lambda: client.calling.send_fax_stop(CALL_ID))
-    safe("Receive fax stop", lambda: client.calling.receive_fax_stop(CALL_ID))
+    safe(
+        "Send fax stop",
+        lambda: client.calling.send_fax_stop(CALL_ID, control_id=CONTROL_ID),
+    )
+    safe(
+        "Receive fax stop",
+        lambda: client.calling.receive_fax_stop(CALL_ID, control_id=CONTROL_ID),
+    )
 
     # 10. Transfer and disconnect
     print("\nTransfer and disconnect...")
-    safe("Transfer", lambda: client.calling.transfer(
-        CALL_ID, dest="+15559999999",
-    ))
-    safe("Update call", lambda: client.calling.update(
-        call_id=CALL_ID, metadata={"priority": "high"},
-    ))
+    safe(
+        "Transfer",
+        lambda: client.calling.transfer(
+            CALL_ID,
+            dest="+15559999999",
+        ),
+    )
+    safe(
+        "Update call",
+        lambda: client.calling.update(
+            id=CALL_ID,
+            status="completed",
+        ),
+    )
     safe("Disconnect", lambda: client.calling.disconnect(CALL_ID))
 
 

--- a/rest/examples/rest_calling_play_and_record.py
+++ b/rest/examples/rest_calling_play_and_record.py
@@ -18,6 +18,15 @@ from signalwire.rest import RestClient, SignalWireRestError
 client = RestClient()
 
 
+def run_action(action, fn):
+    """Attempt one call-control action and report OK/failed independently."""
+    try:
+        fn()
+        print(f"  {action}: OK")
+    except SignalWireRestError as e:
+        print(f"  {action}: failed ({e.status_code})")
+
+
 def main():
     # 1. Dial an outbound call
     print("Dialing outbound call...")
@@ -60,11 +69,7 @@ def main():
         ),
         ("Stop", lambda: client.calling.play_stop(call_id, control_id=control_id)),
     ]:
-        try:
-            fn()
-            print(f"  {action}: OK")
-        except SignalWireRestError as e:
-            print(f"  {action}: failed ({e.status_code})")
+        run_action(action, fn)
 
     # 4. Record the call
     rec_control_id = "demo-record-control-id"
@@ -95,11 +100,7 @@ def main():
             lambda: client.calling.record_stop(call_id, control_id=rec_control_id),
         ),
     ]:
-        try:
-            fn()
-            print(f"  {action}: OK")
-        except SignalWireRestError as e:
-            print(f"  {action}: failed ({e.status_code})")
+        run_action(action, fn)
 
     # 6. Transcribe the call
     print("\nTranscribing call...")

--- a/rest/examples/rest_calling_play_and_record.py
+++ b/rest/examples/rest_calling_play_and_record.py
@@ -34,9 +34,15 @@ def main():
         call_id = "demo-call-id"
 
     # 2. Play TTS audio
+    #    The control_id ties later pause/resume/stop commands to this playback.
+    control_id = "demo-play-control-id"
     print("\nPlaying TTS on call...")
     try:
-        client.calling.play(call_id, play=[{"type": "tts", "params": {"text": "Welcome to SignalWire."}}])
+        client.calling.play(
+            call_id,
+            play=[{"type": "tts", "params": {"text": "Welcome to SignalWire."}}],
+            control_id=control_id,
+        )
         print("  Play started")
     except SignalWireRestError as e:
         print(f"  Play failed (expected in demo): {e.status_code}")
@@ -44,10 +50,15 @@ def main():
     # 3. Pause, resume, adjust volume, stop playback
     print("\nControlling playback...")
     for action, fn in [
-        ("Pause", lambda: client.calling.play_pause(call_id)),
-        ("Resume", lambda: client.calling.play_resume(call_id)),
-        ("Volume +2dB", lambda: client.calling.play_volume(call_id, volume=2.0)),
-        ("Stop", lambda: client.calling.play_stop(call_id)),
+        ("Pause", lambda: client.calling.play_pause(call_id, control_id=control_id)),
+        ("Resume", lambda: client.calling.play_resume(call_id, control_id=control_id)),
+        (
+            "Volume +2dB",
+            lambda: client.calling.play_volume(
+                call_id, control_id=control_id, volume=2.0
+            ),
+        ),
+        ("Stop", lambda: client.calling.play_stop(call_id, control_id=control_id)),
     ]:
         try:
             fn()
@@ -56,9 +67,14 @@ def main():
             print(f"  {action}: failed ({e.status_code})")
 
     # 4. Record the call
+    rec_control_id = "demo-record-control-id"
     print("\nRecording call...")
     try:
-        client.calling.record(call_id, beep=True, format="mp3")
+        client.calling.record(
+            call_id,
+            control_id=rec_control_id,
+            audio={"format": "mp3", "beep": True},
+        )
         print("  Recording started")
     except SignalWireRestError as e:
         print(f"  Record failed (expected in demo): {e.status_code}")
@@ -66,9 +82,18 @@ def main():
     # 5. Pause, resume, stop recording
     print("\nControlling recording...")
     for action, fn in [
-        ("Pause", lambda: client.calling.record_pause(call_id)),
-        ("Resume", lambda: client.calling.record_resume(call_id)),
-        ("Stop", lambda: client.calling.record_stop(call_id)),
+        (
+            "Pause",
+            lambda: client.calling.record_pause(call_id, control_id=rec_control_id),
+        ),
+        (
+            "Resume",
+            lambda: client.calling.record_resume(call_id, control_id=rec_control_id),
+        ),
+        (
+            "Stop",
+            lambda: client.calling.record_stop(call_id, control_id=rec_control_id),
+        ),
     ]:
         try:
             fn()
@@ -79,9 +104,10 @@ def main():
     # 6. Transcribe the call
     print("\nTranscribing call...")
     try:
-        client.calling.transcribe(call_id, language="en-US")
+        transcribe_control_id = "demo-transcribe-control-id"
+        client.calling.transcribe(call_id, control_id=transcribe_control_id)
         print("  Transcription started")
-        client.calling.transcribe_stop(call_id)
+        client.calling.transcribe_stop(call_id, control_id=transcribe_control_id)
         print("  Transcription stopped")
     except SignalWireRestError as e:
         print(f"  Transcribe failed (expected in demo): {e.status_code}")

--- a/rest/examples/rest_datasphere_search.py
+++ b/rest/examples/rest_datasphere_search.py
@@ -11,7 +11,7 @@ For full HTTP debug output:
 
 import time
 
-from signalwire.rest import RestClient, SignalWireRestError
+from signalwire.rest import RestClient
 
 client = RestClient()
 
@@ -20,16 +20,18 @@ def main():
     # 1. Upload a document (a publicly accessible text file)
     print("Uploading document to Datasphere...")
     doc = client.datasphere.documents.create(
-        url="https://filesamples.com/samples/document/txt/sample3.txt",
-        tags=["support", "demo"],
+        {
+            "url": "https://filesamples.com/samples/document/txt/sample3.txt",
+            "tags": ["support", "demo"],
+        }
     )
     doc_id = doc["id"]
     print(f"  Document created: {doc_id} (status: {doc.get('status')})")
 
     # 2. Wait for vectorization to complete
     print("\nWaiting for document to be vectorized...")
-    for i in range(30):
-        time.sleep(2)
+    for i in range(3):
+        time.sleep(1)
         doc_status = client.datasphere.documents.get(doc_id)
         status = doc_status.get("status", "unknown")
         print(f"  Poll {i + 1}: status={status}")

--- a/rest/examples/rest_fabric_conferences_and_routing.py
+++ b/rest/examples/rest_fabric_conferences_and_routing.py
@@ -17,7 +17,9 @@ client = RestClient()
 def main():
     # 1. Create a conference room
     print("Creating conference room...")
-    room = client.fabric.conference_rooms.create(name="team-standup")
+    room = client.fabric.conference_rooms.create(
+        name="team-standup", enable_room_previews=True
+    )
     room_id = room["id"]
     print(f"  Created conference room: {room_id}")
 
@@ -33,7 +35,7 @@ def main():
     # 3. Create a cXML script
     print("\nCreating cXML script...")
     cxml = client.fabric.cxml_scripts.create(
-        name="Hold Music Script",
+        display_name="Hold Music Script",
         contents="<Response><Say>Please hold.</Say><Play>https://example.com/hold.mp3</Play></Response>",
     )
     cxml_id = cxml["id"]
@@ -61,19 +63,25 @@ def main():
     print("\nListing all fabric resources...")
     resources = client.fabric.resources.list()
     for r in resources.get("data", [])[:5]:
-        print(f"  - {r.get('type', 'unknown')}: {r.get('display_name', r.get('id', 'unknown'))}")
+        print(
+            f"  - {r.get('type', 'unknown')}: {r.get('display_name', r.get('id', 'unknown'))}"
+        )
 
     # 7. Get a specific generic resource
     first = (resources.get("data") or [{}])[0]
     if first.get("id"):
         detail = client.fabric.resources.get(first["id"])
-        print(f"  Resource detail: {detail.get('display_name', 'N/A')} ({detail.get('type', 'N/A')})")
+        print(
+            f"  Resource detail: {detail.get('display_name', 'N/A')} ({detail.get('type', 'N/A')})"
+        )
 
     # 8. Assign a phone route to a resource (demo)
     print("\nAssigning phone route (demo)...")
     try:
         client.fabric.resources.assign_phone_route(
-            relay_id, phone_number="+15551234567",
+            relay_id,
+            phone_route_id="00000000-0000-0000-0000-000000000000",
+            handler="calling",
         )
         print("  Phone route assigned")
     except SignalWireRestError as e:
@@ -83,7 +91,8 @@ def main():
     print("\nAssigning domain application (demo)...")
     try:
         client.fabric.resources.assign_domain_application(
-            relay_id, domain="app.example.com",
+            relay_id,
+            domain_application_id="00000000-0000-0000-0000-000000000000",
         )
         print("  Domain application assigned")
     except SignalWireRestError as e:
@@ -92,19 +101,23 @@ def main():
     # 10. Generate tokens
     print("\nGenerating tokens...")
     try:
-        guest = client.fabric.tokens.create_guest_token(resource_id=relay_id)
+        guest = client.fabric.tokens.create_guest_token(
+            allowed_addresses=["00000000-0000-0000-0000-000000000000"]
+        )
         print(f"  Guest token: {str(guest.get('token', ''))[:40]}...")
     except SignalWireRestError as e:
         print(f"  Guest token failed (expected in demo): {e.status_code}")
 
     try:
-        invite = client.fabric.tokens.create_invite_token(resource_id=relay_id)
+        invite = client.fabric.tokens.create_invite_token(
+            address_id="00000000-0000-0000-0000-000000000000"
+        )
         print(f"  Invite token: {str(invite.get('token', ''))[:40]}...")
     except SignalWireRestError as e:
         print(f"  Invite token failed (expected in demo): {e.status_code}")
 
     try:
-        embed = client.fabric.tokens.create_embed_token(resource_id=relay_id)
+        embed = client.fabric.tokens.create_embed_token(token="demo-embed-token")
         print(f"  Embed token: {str(embed.get('token', ''))[:40]}...")
     except SignalWireRestError as e:
         print(f"  Embed token failed (expected in demo): {e.status_code}")

--- a/rest/examples/rest_fabric_subscribers_and_sip.py
+++ b/rest/examples/rest_fabric_subscribers_and_sip.py
@@ -18,8 +18,10 @@ def main():
     # 1. Create a subscriber
     print("Creating subscriber...")
     subscriber = client.fabric.subscribers.create(
-        name="Alice Johnson",
         email="alice@example.com",
+        first_name="Alice",
+        last_name="Johnson",
+        display_name="Alice Johnson",
     )
     sub_id = subscriber["id"]
     inner_sub_id = subscriber.get("subscriber", {}).get("id", sub_id)
@@ -77,7 +79,6 @@ def main():
     print("\nGenerating subscriber token...")
     try:
         token = client.fabric.tokens.create_subscriber_token(
-            subscriber_id=inner_sub_id,
             reference=inner_sub_id,
         )
         print(f"  Token: {str(token.get('token', ''))[:40]}...")

--- a/rest/examples/rest_fabric_swml_and_callflows.py
+++ b/rest/examples/rest_fabric_swml_and_callflows.py
@@ -19,16 +19,21 @@ def main():
     print("Creating SWML script...")
     swml = client.fabric.swml_scripts.create(
         name="Greeting Script",
-        contents={"sections": {"main": [{"play": {"url": "say:Hello from SignalWire"}}]}},
+        contents={
+            "sections": {"main": [{"play": {"url": "say:Hello from SignalWire"}}]}
+        },
     )
     swml_id = swml["id"]
     print(f"  Created SWML script: {swml_id}")
 
     # 2. List SWML scripts to confirm
     print("\nListing SWML scripts...")
+    # The list endpoint returns an array of page objects (each with its own
+    # "data" array), so iterate the pages and then each page's items.
     scripts = client.fabric.swml_scripts.list()
-    for s in scripts.get("data", []):
-        print(f"  - {s['id']}: {s.get('display_name', 'unnamed')}")
+    for page in scripts:
+        for s in page.get("data", []):
+            print(f"  - {s['id']}: {s.get('display_name', 'unnamed')}")
 
     # 3. Create a call flow
     print("\nCreating call flow...")
@@ -39,7 +44,9 @@ def main():
     # 4. Deploy a version of the call flow
     print("\nDeploying call flow version...")
     try:
-        version = client.fabric.call_flows.deploy_version(flow_id, label="v1")
+        version = client.fabric.call_flows.deploy_version(
+            flow_id, {"document_version": 1}
+        )
         print(f"  Deployed version: {version}")
     except SignalWireRestError as e:
         print(f"  Deploy failed (expected in demo): {e.status_code}")

--- a/rest/examples/rest_phone_number_management.py
+++ b/rest/examples/rest_phone_number_management.py
@@ -63,7 +63,8 @@ def main():
         print("\nAdding number to group...")
         try:
             membership = client.number_groups.add_membership(
-                group_id, phone_number_id=num_id,
+                group_id,
+                phone_number_id=num_id,
             )
             mem_id = membership.get("id")
             print(f"  Membership: {mem_id}")
@@ -86,11 +87,13 @@ def main():
     # 8. Create a verified caller
     print("\nCreating verified caller...")
     try:
-        caller = client.verified_callers.create(phone_number="+15125559999")
+        caller = client.verified_callers.create(number="+15125559999")
         caller_id = caller["id"]
         print(f"  Created verified caller: {caller_id}")
         # Submit verification code
-        client.verified_callers.submit_verification(caller_id, verification_code="123456")
+        client.verified_callers.submit_verification(
+            caller_id, verification_code="123456"
+        )
         print("  Verification code submitted")
     except SignalWireRestError as e:
         print(f"  Verified caller failed (expected in demo): {e.status_code}")
@@ -119,12 +122,15 @@ def main():
     print("\nCreating address...")
     try:
         addr = client.addresses.create(
-            friendly_name="HQ Address",
-            street="123 Main St",
+            label="HQ Address",
+            country="US",
+            first_name="Acme",
+            last_name="Operations",
+            street_number="123",
+            street_name="Main St",
             city="Austin",
-            region="TX",
+            state="TX",
             postal_code="78701",
-            iso_country="US",
         )
         addr_id = addr["id"]
         print(f"  Created address: {addr_id}")

--- a/rest/examples/rest_queues_mfa_and_recordings.py
+++ b/rest/examples/rest_queues_mfa_and_recordings.py
@@ -36,7 +36,9 @@ def main():
     # 3. Get and update queue
     if queue_id:
         detail = client.queues.get(queue_id)
-        print(f"\nQueue detail: {detail.get('friendly_name', 'N/A')} (max: {detail.get('max_size', 'N/A')})")
+        print(
+            f"\nQueue detail: {detail.get('friendly_name', 'N/A')} (max: {detail.get('max_size', 'N/A')})"
+        )
 
         client.queues.update(queue_id, name="Priority Support Queue")
         print("  Updated queue name")
@@ -66,7 +68,9 @@ def main():
     first_rec = (recordings.get("data") or [{}])[0]
     if first_rec.get("id"):
         rec_detail = client.recordings.get(first_rec["id"])
-        print(f"  Recording: {rec_detail.get('duration', 'N/A')}s, {rec_detail.get('format', 'N/A')}")
+        print(
+            f"  Recording: {rec_detail.get('duration', 'N/A')}s, {rec_detail.get('format', 'N/A')}"
+        )
 
     # --- MFA ---
 
@@ -94,7 +98,9 @@ def main():
             message="Your verification code is {{code}}",
             token_length=6,
         )
-        print(f"  MFA call sent: {voice_result.get('id', voice_result.get('request_id'))}")
+        print(
+            f"  MFA call sent: {voice_result.get('id', voice_result.get('request_id'))}"
+        )
     except SignalWireRestError as e:
         print(f"  MFA call failed (expected in demo): {e.status_code}")
 

--- a/rest/examples/rest_video_rooms.py
+++ b/rest/examples/rest_video_rooms.py
@@ -117,7 +117,8 @@ def main():
         print("\nCreating stream on conference...")
         try:
             stream = client.video.conferences.create_stream(
-                conf_id, url="rtmp://live.example.com/stream-key",
+                conf_id,
+                url="rtmp://live.example.com/stream-key",
             )
             stream_id = stream["id"]
             print(f"  Created stream: {stream_id}")
@@ -131,7 +132,9 @@ def main():
             s_detail = client.video.streams.get(stream_id)
             print(f"  Stream URL: {s_detail.get('url', 'N/A')}")
 
-            client.video.streams.update(stream_id, url="rtmp://backup.example.com/stream-key")
+            client.video.streams.update(
+                stream_id, url="rtmp://backup.example.com/stream-key"
+            )
             print("  Stream URL updated")
         except SignalWireRestError as e:
             print(f"  Stream ops failed: {e.status_code}")

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -41,6 +41,11 @@ export MOCK_RELAY_STRICT="${MOCK_RELAY_STRICT:-1}"
 PORT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PORT_NAME="signalwire-python"
 
+# Shipped example directories (examples/, rest/examples/, relay/examples/). Linted
+# and format-checked as a group by the EXAMPLES-LINT / EXAMPLES-FMT gates. ruff
+# reads pyproject's per-file-ignores for examples/**, so the SDK ruleset stays intact.
+EXAMPLE_DIRS=("$PORT_ROOT/examples" "$PORT_ROOT/rest/examples" "$PORT_ROOT/relay/examples")
+
 resolve_porting_sdk() {
     if [ -n "${PORTING_SDK:-}" ] && [ -d "$PORTING_SDK/scripts" ]; then
         echo "$PORTING_SDK"
@@ -99,6 +104,19 @@ fmt_gate() {
             echo "    (FMT auto-applied formatting to your working tree — review & stage)"
         fi
         python3 -m ruff format --check "$PORT_ROOT/signalwire"
+    fi
+}
+
+# EXAMPLES-FMT — ruff format over the shipped example dirs. LOCAL applies; CI --check.
+examples_fmt_gate() {
+    if [ -n "${CI:-}" ]; then
+        python3 -m ruff format --check "${EXAMPLE_DIRS[@]}"
+    else
+        python3 -m ruff format "${EXAMPLE_DIRS[@]}" >/dev/null
+        if ! (cd "$PORT_ROOT" && git diff --quiet 2>/dev/null); then
+            echo "    (EXAMPLES-FMT auto-applied formatting to your working tree — review & stage)"
+        fi
+        python3 -m ruff format --check "${EXAMPLE_DIRS[@]}"
     fi
 }
 
@@ -217,6 +235,15 @@ sched_gate FMT defer=1 desc="ruff format (local: apply; CI: --check)" \
 
 sched_gate LINT desc="ruff check zero findings" \
     -- python3 -m ruff check "$PORT_ROOT/signalwire"
+
+# EXAMPLES-LINT / EXAMPLES-FMT — the shipped example dirs are ruff-clean too. Cheap
+# static checks (no build, no mock) → per-PR cheap wave. ruff honors pyproject's
+# examples/** per-file-ignores, so this enforces the same ruleset the SDK uses.
+sched_gate EXAMPLES-LINT desc="ruff check zero findings over examples/ rest/examples/ relay/examples/" \
+    -- python3 -m ruff check "${EXAMPLE_DIRS[@]}"
+
+sched_gate EXAMPLES-FMT desc="ruff format over the example dirs (local: apply; CI: --check)" \
+    --fn examples_fmt_gate
 
 sched_gate TYPECHECK desc="mypy zero findings" \
     -- python3 -m mypy --config-file "$PORT_ROOT/pyproject.toml"

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -198,6 +198,9 @@ sched_gate SEMVER-DIFF deps=SIGNATURES desc="version bump matches surface change
 sched_gate NO-CHEAT desc="audit_no_cheat_tests" \
     -- python3 "$PORTING_SDK_DIR/scripts/audit_no_cheat_tests.py" --root "$PORT_ROOT"
 
+sched_gate COORDINATED-PASS desc="a non-main porting-sdk pin must be declared on the PR (Coordinated-With: line or coordinated-pass label)" \
+    -- python3 "$PORTING_SDK_DIR/scripts/coordinated_pass.py" --porting-sdk "$PORTING_SDK_DIR"
+
 sched_gate REST-COVERAGE defer=1 desc="every implemented REST route covered success+error (parity + allowlist)" \
     --fn rest_coverage_gate
 

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -201,6 +201,9 @@ sched_gate NO-CHEAT desc="audit_no_cheat_tests" \
 sched_gate COORDINATED-PASS desc="a non-main porting-sdk pin must be declared on the PR (Coordinated-With: line or coordinated-pass label)" \
     -- python3 "$PORTING_SDK_DIR/scripts/coordinated_pass.py" --porting-sdk "$PORTING_SDK_DIR"
 
+sched_gate COORDINATED-REFS desc="every coordinated-set checkout (porting-sdk + python oracle + matrix ports) uses PORTING_SDK_REF, not a literal ref" \
+    -- python3 "$PORTING_SDK_DIR/scripts/check_coordinated_refs.py" --repo "$PORT_ROOT"
+
 sched_gate REST-COVERAGE defer=1 desc="every implemented REST route covered success+error (parity + allowlist)" \
     --fn rest_coverage_gate
 

--- a/signalwire/signalwire/agents/__init__.py
+++ b/signalwire/signalwire/agents/__init__.py
@@ -1,0 +1,16 @@
+"""
+Copyright (c) 2025 SignalWire
+
+This file is part of the SignalWire SDK.
+
+Licensed under the MIT License.
+See LICENSE file in the project root for full license information.
+
+Specialized agent implementations backed by specific inference providers.
+"""
+
+from signalwire.agents.bedrock import BedrockAgent
+
+__all__ = [
+    "BedrockAgent",
+]

--- a/signalwire/signalwire/core/contexts.py
+++ b/signalwire/signalwire/core/contexts.py
@@ -1493,6 +1493,38 @@ class ContextBuilder:
                         f"avoid the collision."
                     )
 
+            # Validate step set_functions([...]) whitelists against the known
+            # tool universe. A step that whitelists a function which is neither
+            # a registered SWAIG tool nor a reserved native tool is a DANGLING
+            # reference: it renders a step whose active-function set silently
+            # points at nothing (r5 F3 — get_datetime vs get_current_time).
+            # Only enforce when a real registry is present; a contexts builder
+            # with no agent (or a mock registry) cannot know the tool universe,
+            # so we must not red a valid document there.
+            if isinstance(registered, dict):
+                known_functions = set(registered.keys()) | RESERVED_NATIVE_TOOL_NAMES
+                for context_name, context in self._contexts.items():
+                    for step_name, step in context._steps.items():
+                        funcs = step._functions
+                        # "none" and [] are explicit disable-all — not lists of
+                        # references to resolve.
+                        if not isinstance(funcs, list):
+                            continue
+                        for fn in funcs:
+                            if fn not in known_functions:
+                                available = sorted(known_functions)
+                                raise ValueError(
+                                    f"Step '{step_name}' in context "
+                                    f"'{context_name}' whitelists function "
+                                    f"'{fn}' via set_functions(), but no such "
+                                    f"SWAIG tool is registered on the agent and "
+                                    f"it is not a reserved native tool. This "
+                                    f"would emit a dangling function reference. "
+                                    f"Register the tool (define_tool / a skill) "
+                                    f"or remove it from the step. Available: "
+                                    f"{available}"
+                                )
+
     def to_dict(self) -> dict[str, Any]:
         """Convert all contexts to dictionary for SWML generation"""
         self.validate()

--- a/signalwire/signalwire/core/swml_renderer.py
+++ b/signalwire/signalwire/core/swml_renderer.py
@@ -168,9 +168,13 @@ class SwmlRenderer:
         # Use the service to build the document
         service.reset_document()
 
-        # Add a play block for the response if provided
+        # Add a play block for the response if provided. Text is played via the
+        # `say:` URL scheme — the SWML `play` verb has no `text` key (its config is
+        # PlayWithURL/PlayWithURLS, url matching `^...|say: ?.*|...$`). Emitting
+        # `{"text": ...}` produced a document the SWML schema rejects; the canonical
+        # form (mirrors SWMLBuilder.play) is `url: "say:<text>"`.
         if response_text:
-            service.add_verb("play", {"text": response_text})
+            service.add_verb("play", {"url": f"say:{response_text}"})
 
         # Add any actions that were provided
         if actions:

--- a/signalwire/signalwire/core/swml_service.py
+++ b/signalwire/signalwire/core/swml_service.py
@@ -547,7 +547,7 @@ class SWMLService(ToolMixin):
             # full validation would false-reject valid documents. The shallow
             # check is a no-op when validation is disabled.
             if is_valid:
-                is_valid, errors = self.schema_utils.validate_verb_top_level_keys(
+                is_valid, errors = self.schema_utils._validate_verb_top_level_keys(
                     verb_name, config
                 )
         else:
@@ -624,7 +624,7 @@ class SWMLService(ToolMixin):
             # deep schema, which would false-reject the ai verb's legitimate
             # empty-pom / SWAIG emissions). No-op when validation is disabled.
             if is_valid:
-                is_valid, errors = self.schema_utils.validate_verb_top_level_keys(
+                is_valid, errors = self.schema_utils._validate_verb_top_level_keys(
                     verb_name, config
                 )
         else:

--- a/signalwire/signalwire/core/swml_service.py
+++ b/signalwire/signalwire/core/swml_service.py
@@ -534,6 +534,15 @@ class SWMLService(ToolMixin):
             handler = self.verb_registry.get_handler(verb_name)
             assert handler is not None  # noqa: S101  # type-narrowing invariant (not input validation): guaranteed by has_handler() above
             is_valid, errors = handler.validate_config(config)
+            # A handler's validate_config carries verb-specific diagnostics
+            # (e.g. the ai verb's prompt/SWAIG shape checks) but does NOT run
+            # the schema's closed-key check — so unknown/misspelled top-level
+            # keys would slip through silently (r5 silent-drop family). Run the
+            # schema pass too so a handler verb rejects stray keys like every
+            # other verb. The schema pass is a no-op when validation is
+            # disabled, so this never tightens the validation-off path.
+            if is_valid:
+                is_valid, errors = self.schema_utils.validate_verb(verb_name, config)
         else:
             # Use schema-based validation for standard verbs
             is_valid, errors = self.schema_utils.validate_verb(verb_name, config)
@@ -603,6 +612,11 @@ class SWMLService(ToolMixin):
             handler = self.verb_registry.get_handler(verb_name)
             assert handler is not None  # noqa: S101  # type-narrowing invariant (not input validation): guaranteed by has_handler() above
             is_valid, errors = handler.validate_config(config)
+            # See add_verb: also run the schema pass so a handler verb rejects
+            # unknown/misspelled top-level keys (the schema's closed-key check
+            # the handler doesn't perform). No-op when validation is disabled.
+            if is_valid:
+                is_valid, errors = self.schema_utils.validate_verb(verb_name, config)
         else:
             # Use schema-based validation for standard verbs
             is_valid, errors = self.schema_utils.validate_verb(verb_name, config)

--- a/signalwire/signalwire/core/swml_service.py
+++ b/signalwire/signalwire/core/swml_service.py
@@ -535,14 +535,21 @@ class SWMLService(ToolMixin):
             assert handler is not None  # noqa: S101  # type-narrowing invariant (not input validation): guaranteed by has_handler() above
             is_valid, errors = handler.validate_config(config)
             # A handler's validate_config carries verb-specific diagnostics
-            # (e.g. the ai verb's prompt/SWAIG shape checks) but does NOT run
-            # the schema's closed-key check — so unknown/misspelled top-level
-            # keys would slip through silently (r5 silent-drop family). Run the
-            # schema pass too so a handler verb rejects stray keys like every
-            # other verb. The schema pass is a no-op when validation is
-            # disabled, so this never tightens the validation-off path.
+            # (e.g. the ai verb's prompt/SWAIG shape checks) but does NOT reject
+            # unknown/misspelled TOP-LEVEL keys — so a typo'd key would slip
+            # through silently (r5 silent-drop family: ai temperatur/zzz). Add a
+            # shallow unknown-top-level-key check against the schema so a handler
+            # verb rejects stray keys like every other verb. We deliberately do
+            # NOT run the full deep schema here: the ai verb's DEEP shapes
+            # (an empty prompt.pom for a promptless agent, the SWAIG function
+            # shape) are the handler's remit and are legitimately emitted by the
+            # SDK in forms the JSON-schema's oneOf/pom rules don't all accept —
+            # full validation would false-reject valid documents. The shallow
+            # check is a no-op when validation is disabled.
             if is_valid:
-                is_valid, errors = self.schema_utils.validate_verb(verb_name, config)
+                is_valid, errors = self.schema_utils.validate_verb_top_level_keys(
+                    verb_name, config
+                )
         else:
             # Use schema-based validation for standard verbs
             is_valid, errors = self.schema_utils.validate_verb(verb_name, config)
@@ -612,11 +619,14 @@ class SWMLService(ToolMixin):
             handler = self.verb_registry.get_handler(verb_name)
             assert handler is not None  # noqa: S101  # type-narrowing invariant (not input validation): guaranteed by has_handler() above
             is_valid, errors = handler.validate_config(config)
-            # See add_verb: also run the schema pass so a handler verb rejects
-            # unknown/misspelled top-level keys (the schema's closed-key check
-            # the handler doesn't perform). No-op when validation is disabled.
+            # See add_verb: also run the shallow unknown-top-level-key check so a
+            # handler verb rejects misspelled/unknown top-level keys (NOT the full
+            # deep schema, which would false-reject the ai verb's legitimate
+            # empty-pom / SWAIG emissions). No-op when validation is disabled.
             if is_valid:
-                is_valid, errors = self.schema_utils.validate_verb(verb_name, config)
+                is_valid, errors = self.schema_utils.validate_verb_top_level_keys(
+                    verb_name, config
+                )
         else:
             # Use schema-based validation for standard verbs
             is_valid, errors = self.schema_utils.validate_verb(verb_name, config)

--- a/signalwire/signalwire/utils/schema_utils.py
+++ b/signalwire/signalwire/utils/schema_utils.py
@@ -440,7 +440,7 @@ class SchemaUtils:
             return None
         return set(prop_map.keys())
 
-    def validate_verb_top_level_keys(
+    def _validate_verb_top_level_keys(
         self, verb_name: str, verb_config: dict[str, Any]
     ) -> tuple[bool, list[str]]:
         """Shallow strict-render check: reject unknown/misspelled TOP-LEVEL keys

--- a/signalwire/signalwire/utils/schema_utils.py
+++ b/signalwire/signalwire/utils/schema_utils.py
@@ -407,6 +407,64 @@ class SchemaUtils:
 
         return len(errors) == 0, errors
 
+    def _verb_top_level_property_names(self, verb_name: str) -> set[str] | None:
+        """Resolve the set of KNOWN top-level property names for a verb's config
+        object, following a single ``$ref`` (e.g. AI -> AIObject). Returns None
+        when the verb's config schema is not a closed object-with-properties
+        (i.e. we cannot enumerate a known-key set, so no shallow check applies)."""
+        if verb_name not in self.verbs:
+            return None
+        verb_def = self.verbs[verb_name]["definition"]
+        props = verb_def.get("properties", {})
+        body = props.get(verb_name)
+        if not isinstance(body, dict):
+            return None
+        # Follow a single $ref (AI -> AIObject) to the object that declares the
+        # verb config's own properties.
+        if "$ref" in body:
+            ref_name = body["$ref"].split("/")[-1]
+            body = self.schema.get("$defs", {}).get(ref_name, {})
+        if not isinstance(body, dict) or body.get("type") != "object":
+            return None
+        prop_map = body.get("properties")
+        if not isinstance(prop_map, dict):
+            return None
+        # Only meaningful as a closed-key check when the schema itself closes the
+        # object (additionalProperties:false or unevaluatedProperties disallowed).
+        closes = (
+            body.get("additionalProperties") is False
+            or body.get("unevaluatedProperties") is False
+            or body.get("unevaluatedProperties") == {"not": {}}
+        )
+        if not closes:
+            return None
+        return set(prop_map.keys())
+
+    def validate_verb_top_level_keys(
+        self, verb_name: str, verb_config: dict[str, Any]
+    ) -> tuple[bool, list[str]]:
+        """Shallow strict-render check: reject unknown/misspelled TOP-LEVEL keys
+        in a verb config against the schema's known property set, WITHOUT running
+        the full deep schema (which would false-reject legitimate deep emissions
+        such as the ai verb's empty prompt.pom). Used for handler verbs (the ai
+        verb) whose deep shapes the handler owns. A no-op when validation is
+        disabled or when the verb has no enumerable closed key-set."""
+        if not self._validation_enabled:
+            return True, []
+        if verb_name not in self.verbs:
+            return False, [f"Unknown verb: {verb_name}"]
+        known = self._verb_top_level_property_names(verb_name)
+        if known is None:
+            # No enumerable closed key-set — nothing shallow to enforce.
+            return True, []
+        unknown = [k for k in verb_config if k not in known]
+        if unknown:
+            return False, [
+                f"Unknown/misspelled key(s) {sorted(unknown)} for verb "
+                f"'{verb_name}'. Known keys: {sorted(known)}"
+            ]
+        return True, []
+
     def validate_document(self, document: dict[str, Any]) -> tuple[bool, list[str]]:
         """
         Validate a complete SWML document against the schema.

--- a/tests/unit/core/test_swml_renderer.py
+++ b/tests/unit/core/test_swml_renderer.py
@@ -172,6 +172,13 @@ class TestSwmlRenderer:
         assert "main" in parsed["sections"]
         assert len(parsed["sections"]["main"]) == 1
 
+        # Regression: the play block must be SCHEMA-VALID — text is played via the
+        # `say:` URL scheme, NOT a `text` key (the SWML play verb has no `text`).
+        # Previously emitted {"play": {"text": ...}}, which the schema rejects.
+        play = parsed["sections"]["main"][0]["play"]
+        assert play == {"url": "say:Hello there!"}, play
+        assert "text" not in play
+
     def test_render_function_response_swml_with_actions(self) -> None:
         """Test rendering function response SWML with actions"""
         actions = [

--- a/tests/unit/core/test_swml_strict_render.py
+++ b/tests/unit/core/test_swml_strict_render.py
@@ -35,8 +35,11 @@ first, then closes:
   silently.
 """
 
+from typing import Any
+
 import pytest
 
+from signalwire.core.agent_base import AgentBase
 from signalwire.core.swml_service import SWMLService
 from signalwire.utils.schema_utils import SchemaValidationError
 
@@ -78,7 +81,7 @@ class TestMisspelledKeyRejected:
             ("prompt", {"txt": "hi"}),  # misspelled text
         ],
     )
-    def test_misspelled_or_unknown_key_raises(self, verb: str, config: dict) -> None:
+    def test_misspelled_or_unknown_key_raises(self, verb: str, config: dict[str, Any]) -> None:
         svc = _strict_service()
         with pytest.raises(SchemaValidationError):
             svc.add_verb(verb, config)
@@ -148,11 +151,7 @@ class TestAiVerbStrictKeys:
 
 
 class TestDanglingStepFunctionReference:
-    def _agent(self):  # type: ignore[no-untyped-def]
-        # Import here so the test file loads even in environments that only
-        # exercise the service layer.
-        from signalwire.core.agent_base import AgentBase
-
+    def _agent(self) -> AgentBase:
         return AgentBase(name="ctxagent", route="/ctx", schema_validation=True)
 
     def test_dangling_function_ref_raises(self) -> None:
@@ -206,12 +205,13 @@ class TestDanglingStepFunctionReference:
 
     def test_functions_none_and_empty_render(self) -> None:
         # "none" and [] are explicit disable-all — never dangling.
+        value: str | list[str]
         for value in ("none", []):
             agent = self._agent()
             contexts = agent.define_contexts()
             support = contexts.add_context("default")
             step = support.add_step("help")
             step.set_text("help the caller")
-            step.set_functions(value)  # type: ignore[arg-type]
+            step.set_functions(value)
             doc = contexts.to_dict()
             assert "default" in doc

--- a/tests/unit/core/test_swml_strict_render.py
+++ b/tests/unit/core/test_swml_strict_render.py
@@ -1,0 +1,217 @@
+"""
+Copyright (c) 2025 SignalWire
+
+This file is part of the SignalWire SDK.
+
+Licensed under the MIT License.
+See LICENSE file in the project root for full license information.
+
+SWML strict-render contract (Wave-2 P#5).
+
+Building / rendering an SWML document with a MISSHAPEN config, an UNKNOWN verb,
+or a MISSPELLED key must RAISE a clear error — not silently drop or accept it.
+The r5 dogfood reports named a "silent-drop family": unknown verbs accepted,
+misspelled verb-config keys swallowed, and dangling SWAIG step-function
+references emitted with no warning.
+
+Most of this contract is already enforced at the ``add_verb`` choke point via
+jsonschema-rs full-document validation (unknown verb, misspelled/unknown keys
+on the closed verbs, wrong-typed config). The two gaps this suite pins RED
+first, then closes:
+
+  GAP 1 — the ``ai`` verb has a specialized ``AIVerbHandler`` whose hand-rolled
+  ``validate_config`` only checked ``prompt``/``SWAIG`` shape, so it SILENTLY
+  ACCEPTED unknown/misspelled top-level ``ai`` keys (``temperatur``, ``zzz``)
+  that every schema-validated verb rejects. The AI object schema itself is
+  closed (``unevaluatedProperties`` disallows extras); the handler simply
+  wasn't consulting it. (The ``params`` sub-object stays intentionally open —
+  LLM tuning params vary — so a key *inside* ``params`` is not a misspelling.)
+
+  GAP 2 — ``ContextBuilder.validate()`` validated dangling ``valid_steps`` /
+  ``valid_contexts`` references but NOT a step's ``set_functions([...])``
+  references against the agent's registered SWAIG tool set + reserved native
+  tools. A step whitelisting a nonexistent function (``get_datetime`` when the
+  registered tool is ``get_current_time``) rendered a dangling reference
+  silently.
+"""
+
+import pytest
+
+from signalwire.core.swml_service import SWMLService
+from signalwire.utils.schema_utils import SchemaValidationError
+
+
+def _strict_service() -> SWMLService:
+    """A SWMLService with schema validation ENABLED (the default in production;
+    the shared ``mock_swml_service`` fixture disables it, which is why these
+    tests build their own)."""
+    return SWMLService(name="strict", route="/strict", schema_validation=True)
+
+
+# ---------------------------------------------------------------------------
+# Baseline: the already-enforced parts of the contract (regression guards so a
+# future refactor can't quietly loosen them).
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownVerbRejected:
+    def test_unknown_verb_raises(self) -> None:
+        svc = _strict_service()
+        with pytest.raises(SchemaValidationError) as exc:
+            svc.add_verb("foobar", {})
+        assert "foobar" in str(exc.value)
+
+    def test_good_verb_renders(self) -> None:
+        svc = _strict_service()
+        assert svc.add_verb("answer", {"max_duration": 5}) is True
+
+
+class TestMisspelledKeyRejected:
+    @pytest.mark.parametrize(
+        ("verb", "config"),
+        [
+            ("answer", {"maxduration": 5}),  # misspelled max_duration
+            ("answer", {"wibble": 1}),  # unknown key
+            ("play", {"urlz": ["say:hi"]}),  # misspelled urls
+            ("play", {"url": "say:hi", "foo": 1}),  # valid + unknown extra
+            ("record", {"formatt": "wav"}),  # misspelled format
+            ("prompt", {"txt": "hi"}),  # misspelled text
+        ],
+    )
+    def test_misspelled_or_unknown_key_raises(self, verb: str, config: dict) -> None:
+        svc = _strict_service()
+        with pytest.raises(SchemaValidationError):
+            svc.add_verb(verb, config)
+
+    def test_wrong_typed_config_raises(self) -> None:
+        svc = _strict_service()
+        with pytest.raises(SchemaValidationError):
+            svc.add_verb("answer", {"max_duration": "notanumber"})
+
+
+# ---------------------------------------------------------------------------
+# GAP 1 — the ``ai`` verb must reject unknown/misspelled top-level keys like
+# every other verb (was silently accepted by AIVerbHandler).
+# ---------------------------------------------------------------------------
+
+
+class TestAiVerbStrictKeys:
+    def test_ai_good_config_renders(self) -> None:
+        svc = _strict_service()
+        assert svc.add_verb("ai", {"prompt": {"text": "hi"}}) is True
+
+    def test_ai_good_config_with_swaig_renders(self) -> None:
+        svc = _strict_service()
+        assert (
+            svc.add_verb(
+                "ai",
+                {"prompt": {"text": "hi"}, "SWAIG": {"functions": []}},
+            )
+            is True
+        )
+
+    def test_ai_misspelled_top_level_key_raises(self) -> None:
+        svc = _strict_service()
+        with pytest.raises(SchemaValidationError):
+            svc.add_verb("ai", {"prompt": {"text": "hi"}, "temperatur": 0.5})
+
+    def test_ai_unknown_top_level_key_raises(self) -> None:
+        svc = _strict_service()
+        with pytest.raises(SchemaValidationError):
+            svc.add_verb("ai", {"prompt": {"text": "hi"}, "zzz": 1})
+
+    def test_ai_missing_prompt_still_raises(self) -> None:
+        # The handler's own prompt check must survive alongside the new
+        # schema pass.
+        svc = _strict_service()
+        with pytest.raises(SchemaValidationError):
+            svc.add_verb("ai", {"post_prompt": {"text": "bye"}})
+
+    def test_ai_params_subobject_stays_open(self) -> None:
+        # ``params`` is the deliberate open door for LLM tuning params; a key
+        # inside it is NOT a misspelling and must render.
+        svc = _strict_service()
+        assert (
+            svc.add_verb(
+                "ai",
+                {"prompt": {"text": "hi"}, "params": {"some_future_param": 1}},
+            )
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# GAP 2 — a step's set_functions([...]) referencing a function that is neither
+# a registered SWAIG tool nor a reserved native tool must raise (dangling
+# function reference — r5 F3).
+# ---------------------------------------------------------------------------
+
+
+class TestDanglingStepFunctionReference:
+    def _agent(self):  # type: ignore[no-untyped-def]
+        # Import here so the test file loads even in environments that only
+        # exercise the service layer.
+        from signalwire.core.agent_base import AgentBase
+
+        return AgentBase(name="ctxagent", route="/ctx", schema_validation=True)
+
+    def test_dangling_function_ref_raises(self) -> None:
+        agent = self._agent()
+        agent.define_tool(
+            name="order_status",
+            description="look up an order",
+            parameters={},
+            handler=lambda args, raw: None,
+        )
+        contexts = agent.define_contexts()
+        support = contexts.add_context("default")
+        step = support.add_step("help")
+        step.set_text("help the caller")
+        step.set_functions(["order_status", "get_datetime"])  # get_datetime dangles
+
+        with pytest.raises(ValueError) as exc:
+            contexts.to_dict()
+        assert "get_datetime" in str(exc.value)
+
+    def test_registered_function_ref_renders(self) -> None:
+        agent = self._agent()
+        agent.define_tool(
+            name="order_status",
+            description="look up an order",
+            parameters={},
+            handler=lambda args, raw: None,
+        )
+        contexts = agent.define_contexts()
+        support = contexts.add_context("default")
+        step = support.add_step("help")
+        step.set_text("help the caller")
+        step.set_functions(["order_status"])
+
+        # No raise — the referenced function is registered.
+        doc = contexts.to_dict()
+        assert "default" in doc
+
+    def test_reserved_native_tool_ref_allowed(self) -> None:
+        # next_step / change_context are auto-injected natives; referencing them
+        # explicitly must not be treated as dangling.
+        agent = self._agent()
+        contexts = agent.define_contexts()
+        support = contexts.add_context("default")
+        step = support.add_step("help")
+        step.set_text("help the caller")
+        step.set_functions(["next_step", "change_context"])
+
+        doc = contexts.to_dict()
+        assert "default" in doc
+
+    def test_functions_none_and_empty_render(self) -> None:
+        # "none" and [] are explicit disable-all — never dangling.
+        for value in ("none", []):
+            agent = self._agent()
+            contexts = agent.define_contexts()
+            support = contexts.add_context("default")
+            step = support.add_step("help")
+            step.set_text("help the caller")
+            step.set_functions(value)  # type: ignore[arg-type]
+            doc = contexts.to_dict()
+            assert "default" in doc


### PR DESCRIPTION
Wave 2 (A+ campaign) — **cluster 1 (engine/oracle)** reference fix.

## agents/__init__.py — close the BedrockAgent oracle blind spot
`signalwire/agents/` shipped `bedrock.py` exporting `BedrockAgent` (re-exported from the
top-level `__init__.py`) but had **no `agents/__init__.py`**, so griffe skipped the whole
subpackage. `BedrockAgent` and its 6 public setter methods had **ZERO coverage** in the
signature oracle (`python_signatures.json`); 9 ports carried a "reference-oracle gap"
omission block to paper over the invisibility.

Adding the `__init__.py` makes the subpackage loadable. The regenerated oracle (in
porting-sdk `wave/2-aplus`) now records `BedrockAgent.{set_voice, set_inference_params,
set_llm_model, set_llm_temperature, set_prompt_llm_params, set_post_prompt_llm_params}`.

Companion PR: porting-sdk `wave/2-aplus` (oracle regen + new ORACLE-COMPLETENESS gate that
makes this class of hole impossible to ship). Fleet re-drift reconciliation is queued as
cluster-2 (WAVE_2_TRACKER C2-BEDROCK) — python-first re-drift is BY DESIGN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhUoqrbptHNS3cypq9s6t

---
Coordinated-With: porting-sdk@wave/2-aplus