### PR TITLE
fix(ai_chat): green the AI Chat client for the project gates (builds on #72)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
+    "aiohttp>=3.9.0",
     "fastapi>=0.115.12",
     "pydantic>=2.11.4",
     "PyYAML>=6.0.2",

--- a/signalwire/signalwire/ai_chat/__init__.py
+++ b/signalwire/signalwire/ai_chat/__init__.py
@@ -1,0 +1,35 @@
+"""
+Copyright (c) 2026 SignalWire
+
+This file is part of the SignalWire SDK.
+
+Licensed under the MIT License.
+See LICENSE file in the project root for full license information.
+
+Async client for the SignalWire AI Chat service — see
+:mod:`signalwire.ai_chat.client` for the full protocol notes.
+"""
+
+from .client import (
+    AIChatClient,
+    AIChatError,
+    AuthenticationError,
+    ChatInProgressError,
+    ChatLog,
+    ChatResponse,
+    ConversationInfo,
+    ConversationNotFoundError,
+    RateLimitError,
+)
+
+__all__ = [
+    "AIChatClient",
+    "AIChatError",
+    "AuthenticationError",
+    "ChatInProgressError",
+    "ChatLog",
+    "ChatResponse",
+    "ConversationInfo",
+    "ConversationNotFoundError",
+    "RateLimitError",
+]

--- a/signalwire/signalwire/ai_chat/client.py
+++ b/signalwire/signalwire/ai_chat/client.py
@@ -1,0 +1,285 @@
+"""
+Copyright (c) 2026 SignalWire
+
+This file is part of the SignalWire SDK.
+
+Licensed under the MIT License.
+See LICENSE file in the project root for full license information.
+
+Async client for the SignalWire AI Chat service.
+
+The client speaks the standard SignalWire front-door protocol: HTTP Basic
+``project:api_token`` with the space in the hostname —
+``POST https://{space}.signalwire.com/api/ai/chat`` — carrying a JSON-RPC 2.0
+body whose params are pure payload (identity never appears in the body).
+
+Async-first by design: a ``chat()`` call waits on a full LLM round trip
+(seconds, not milliseconds), and the typical consumers — bots, MCP servers —
+run on asyncio event loops where a blocking HTTP call would stall every other
+conversation. Use it as an async context manager::
+
+    from signalwire.ai_chat import AIChatClient
+
+    async with AIChatClient(space="myspace") as client:  # env supplies creds
+        await client.create_conversation("conv-1", config_url=CONFIG_URL)
+        reply = await client.chat("conv-1", "hello")
+        print(reply.text)
+
+URL resolution, in order:
+
+1. ``url=`` constructor argument — used verbatim.
+2. ``RAILS_DEV_MODE`` environment variable — a full URL used verbatim
+   (point it at a dev chat service, e.g. ``http://localhost:8080/``).
+3. ``https://{space}.signalwire.com/api/ai/chat`` built from ``space``
+   (argument or ``SIGNALWIRE_SPACE``).
+
+Credentials come from the constructor or the standard environment variables
+``SIGNALWIRE_PROJECT_ID`` / ``SIGNALWIRE_API_TOKEN``.
+"""
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from signalwire.rest._base import _user_agent
+
+DEFAULT_PATH = "/api/ai/chat"
+
+
+# ── Errors ───────────────────────────────────────────────────────────
+
+class AIChatError(Exception):
+    """Base error for AI Chat service failures."""
+
+    def __init__(self, code: Optional[int], message: str) -> None:
+        self.code = code
+        self.message = message
+        super().__init__(f"[{code}] {message}")
+
+
+class AuthenticationError(AIChatError):
+    """Missing/rejected identity (HTTP 401 / JSON-RPC -32009)."""
+
+
+class ConversationNotFoundError(AIChatError):
+    """The conversation does not exist in this project (-32001)."""
+
+
+class RateLimitError(AIChatError):
+    """Project or conversation rate limit hit (-32005 / -32006)."""
+
+
+class ChatInProgressError(AIChatError):
+    """Another message is being processed for this conversation (-32007)."""
+
+
+_ERROR_BY_CODE = {
+    -32001: ConversationNotFoundError,
+    -32005: RateLimitError,
+    -32006: RateLimitError,
+    -32007: ChatInProgressError,
+    -32009: AuthenticationError,
+}
+
+
+# ── Response models ──────────────────────────────────────────────────
+
+@dataclass
+class ConversationInfo:
+    id: str
+    status: str
+    initial_message: Optional[str] = None
+
+
+@dataclass
+class ChatResponse:
+    text: str
+    conversation_id: str
+    user_event: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ChatLog:
+    messages: List[Dict[str, Any]] = field(default_factory=list)
+    call_timeline: List[Dict[str, Any]] = field(default_factory=list)
+
+
+# ── Client ───────────────────────────────────────────────────────────
+
+class AIChatClient:
+    """Async client for the SignalWire AI Chat service."""
+
+    def __init__(
+        self,
+        project: Optional[str] = None,
+        token: Optional[str] = None,
+        space: Optional[str] = None,
+        url: Optional[str] = None,
+        session: Optional[aiohttp.ClientSession] = None,
+    ) -> None:
+        self._project = project or os.environ.get("SIGNALWIRE_PROJECT_ID", "")
+        self._token = token or os.environ.get("SIGNALWIRE_API_TOKEN", "")
+        space = space or os.environ.get("SIGNALWIRE_SPACE", "")
+
+        if not self._project:
+            raise ValueError(
+                "project is required. Provide it as an argument or set the "
+                "SIGNALWIRE_PROJECT_ID environment variable."
+            )
+
+        self.url = self._resolve_url(url, space)
+        self._auth = aiohttp.BasicAuth(self._project, self._token)
+        self._headers = {"User-Agent": _user_agent()}
+        self._session = session
+        self._owns_session = session is None
+        self._request_counter = 0
+
+    @staticmethod
+    def _resolve_url(url: Optional[str], space: str) -> str:
+        if url:
+            return url
+        dev_url = os.environ.get("RAILS_DEV_MODE", "").strip()
+        if dev_url and dev_url.lower() not in ("false", "0", "no", "off", "true", "1", "yes", "on"):
+            # RAILS_DEV_MODE doubles as the service's persona switch, so
+            # plain booleans mean "on" without carrying a URL — only a real
+            # URL-looking value overrides the target here.
+            return dev_url
+        if space:
+            return f"https://{space}.signalwire.com{DEFAULT_PATH}"
+        raise ValueError(
+            "No service URL: provide url=, set RAILS_DEV_MODE to a full URL, "
+            "or provide space= / SIGNALWIRE_SPACE."
+        )
+
+    # ── Session lifecycle ────────────────────────────────────────────
+
+    async def __aenter__(self) -> "AIChatClient":
+        await self._ensure_session()
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.close()
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            self._session = aiohttp.ClientSession(
+                auth=self._auth, headers=self._headers
+            )
+        return self._session
+
+    async def close(self) -> None:
+        if self._owns_session and self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    # ── Wire ─────────────────────────────────────────────────────────
+
+    async def _request(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        session = await self._ensure_session()
+        self._request_counter += 1
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": f"req-{self._request_counter}",
+        }
+        async with session.post(self.url, json=payload) as resp:
+            try:
+                body = await resp.json()
+            except (aiohttp.ContentTypeError, ValueError):
+                raise AIChatError(resp.status, f"non-JSON response (HTTP {resp.status})")
+        if "error" in body:
+            error = body["error"] or {}
+            code = error.get("code")
+            raise _ERROR_BY_CODE.get(code, AIChatError)(code, error.get("message", ""))
+        return body.get("result") or {}
+
+    # ── API methods ──────────────────────────────────────────────────
+
+    async def create_conversation(
+        self,
+        conversation_id: str,
+        config_url: str,
+        user_message: Optional[str] = None,
+        timeout: Optional[int] = None,
+        user_metadata: Optional[Dict[str, Any]] = None,
+        reinit: bool = False,
+    ) -> ConversationInfo:
+        """Create a conversation (or reinitialize an existing one)."""
+        params: Dict[str, Any] = {"id": conversation_id, "config_url": config_url}
+        if user_message:
+            params["user_message"] = user_message
+        if timeout:
+            params["conversation_timeout"] = timeout
+        if user_metadata:
+            params["user_meta_data"] = user_metadata
+        if reinit:
+            params["reinit"] = True
+        result = await self._request("create_conversation", params)
+        return ConversationInfo(
+            id=conversation_id,
+            status=result.get("status", "created"),
+            initial_message=result.get("initial_message"),
+        )
+
+    async def chat(
+        self,
+        conversation_id: str,
+        message: str,
+        role: str = "user",
+        config_url: Optional[str] = None,
+        user_metadata: Optional[Dict[str, Any]] = None,
+    ) -> ChatResponse:
+        """Send a message and return the AI reply.
+
+        This awaits a full LLM round trip server-side — expect seconds.
+        Passing ``config_url`` auto-creates the conversation if it doesn't
+        exist yet.
+        """
+        params: Dict[str, Any] = {
+            "id": conversation_id, "message": message, "role": role,
+        }
+        if config_url:
+            params["config_url"] = config_url
+        if user_metadata:
+            params["user_meta_data"] = user_metadata
+        result = await self._request("chat", params)
+        return ChatResponse(
+            text=result.get("response", ""),
+            conversation_id=conversation_id,
+            user_event=result.get("user_event"),
+        )
+
+    async def end(self, conversation_id: str) -> bool:
+        """End a conversation (triggers server-side post-processing)."""
+        result = await self._request("end_conversation", {"id": conversation_id})
+        return result.get("status") == "ended"
+
+    async def delete(self, conversation_id: str) -> bool:
+        """Permanently delete a conversation and its data."""
+        result = await self._request("delete", {"id": conversation_id})
+        return result.get("status") == "deleted"
+
+    async def log(self, conversation_id: str) -> ChatLog:
+        """Full message history plus the call timeline."""
+        result = await self._request("chat_log", {"id": conversation_id})
+        return ChatLog(
+            messages=result.get("chat_log", []),
+            call_timeline=result.get("call_timeline", []),
+        )
+
+    async def summarize(
+        self,
+        conversation_id: str,
+        summary_prompt: Optional[str] = None,
+        **sampling: Any,
+    ) -> str:
+        """AI summary of the conversation (rate limited server-side)."""
+        params: Dict[str, Any] = {"id": conversation_id}
+        if summary_prompt:
+            params["summary_prompt"] = summary_prompt
+        params.update({k: v for k, v in sampling.items() if v is not None})
+        result = await self._request("summarize", params)
+        return result.get("summary", "")

--- a/signalwire/signalwire/ai_chat/client.py
+++ b/signalwire/signalwire/ai_chat/client.py
@@ -39,7 +39,7 @@ Credentials come from the constructor or the standard environment variables
 
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import aiohttp
 
@@ -50,10 +50,11 @@ DEFAULT_PATH = "/api/ai/chat"
 
 # ── Errors ───────────────────────────────────────────────────────────
 
+
 class AIChatError(Exception):
     """Base error for AI Chat service failures."""
 
-    def __init__(self, code: Optional[int], message: str) -> None:
+    def __init__(self, code: int | None, message: str) -> None:
         self.code = code
         self.message = message
         super().__init__(f"[{code}] {message}")
@@ -86,38 +87,40 @@ _ERROR_BY_CODE = {
 
 # ── Response models ──────────────────────────────────────────────────
 
+
 @dataclass
 class ConversationInfo:
     id: str
     status: str
-    initial_message: Optional[str] = None
+    initial_message: str | None = None
 
 
 @dataclass
 class ChatResponse:
     text: str
     conversation_id: str
-    user_event: Optional[Dict[str, Any]] = None
+    user_event: dict[str, Any] | None = None
 
 
 @dataclass
 class ChatLog:
-    messages: List[Dict[str, Any]] = field(default_factory=list)
-    call_timeline: List[Dict[str, Any]] = field(default_factory=list)
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    call_timeline: list[dict[str, Any]] = field(default_factory=list)
 
 
 # ── Client ───────────────────────────────────────────────────────────
+
 
 class AIChatClient:
     """Async client for the SignalWire AI Chat service."""
 
     def __init__(
         self,
-        project: Optional[str] = None,
-        token: Optional[str] = None,
-        space: Optional[str] = None,
-        url: Optional[str] = None,
-        session: Optional[aiohttp.ClientSession] = None,
+        project: str | None = None,
+        token: str | None = None,
+        space: str | None = None,
+        url: str | None = None,
+        session: aiohttp.ClientSession | None = None,
     ) -> None:
         self._project = project or os.environ.get("SIGNALWIRE_PROJECT_ID", "")
         self._token = token or os.environ.get("SIGNALWIRE_API_TOKEN", "")
@@ -137,11 +140,20 @@ class AIChatClient:
         self._request_counter = 0
 
     @staticmethod
-    def _resolve_url(url: Optional[str], space: str) -> str:
+    def _resolve_url(url: str | None, space: str) -> str:
         if url:
             return url
         dev_url = os.environ.get("RAILS_DEV_MODE", "").strip()
-        if dev_url and dev_url.lower() not in ("false", "0", "no", "off", "true", "1", "yes", "on"):
+        if dev_url and dev_url.lower() not in (
+            "false",
+            "0",
+            "no",
+            "off",
+            "true",
+            "1",
+            "yes",
+            "on",
+        ):
             # RAILS_DEV_MODE doubles as the service's persona switch, so
             # plain booleans mean "on" without carrying a URL — only a real
             # URL-looking value overrides the target here.
@@ -176,7 +188,7 @@ class AIChatClient:
 
     # ── Wire ─────────────────────────────────────────────────────────
 
-    async def _request(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    async def _request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         session = await self._ensure_session()
         self._request_counter += 1
         payload = {
@@ -188,13 +200,21 @@ class AIChatClient:
         async with session.post(self.url, json=payload) as resp:
             try:
                 body = await resp.json()
-            except (aiohttp.ContentTypeError, ValueError):
-                raise AIChatError(resp.status, f"non-JSON response (HTTP {resp.status})")
+            except (aiohttp.ContentTypeError, ValueError) as err:
+                raise AIChatError(
+                    resp.status, f"non-JSON response (HTTP {resp.status})"
+                ) from err
         if "error" in body:
             error = body["error"] or {}
             code = error.get("code")
-            raise _ERROR_BY_CODE.get(code, AIChatError)(code, error.get("message", ""))
-        return body.get("result") or {}
+            exc_type = (
+                _ERROR_BY_CODE.get(code, AIChatError)
+                if code is not None
+                else AIChatError
+            )
+            raise exc_type(code, error.get("message", ""))
+        result = body.get("result")
+        return result if isinstance(result, dict) else {}
 
     # ── API methods ──────────────────────────────────────────────────
 
@@ -202,13 +222,13 @@ class AIChatClient:
         self,
         conversation_id: str,
         config_url: str,
-        user_message: Optional[str] = None,
-        timeout: Optional[int] = None,
-        user_metadata: Optional[Dict[str, Any]] = None,
+        user_message: str | None = None,
+        timeout: int | None = None,
+        user_metadata: dict[str, Any] | None = None,
         reinit: bool = False,
     ) -> ConversationInfo:
         """Create a conversation (or reinitialize an existing one)."""
-        params: Dict[str, Any] = {"id": conversation_id, "config_url": config_url}
+        params: dict[str, Any] = {"id": conversation_id, "config_url": config_url}
         if user_message:
             params["user_message"] = user_message
         if timeout:
@@ -229,8 +249,8 @@ class AIChatClient:
         conversation_id: str,
         message: str,
         role: str = "user",
-        config_url: Optional[str] = None,
-        user_metadata: Optional[Dict[str, Any]] = None,
+        config_url: str | None = None,
+        user_metadata: dict[str, Any] | None = None,
     ) -> ChatResponse:
         """Send a message and return the AI reply.
 
@@ -238,8 +258,10 @@ class AIChatClient:
         Passing ``config_url`` auto-creates the conversation if it doesn't
         exist yet.
         """
-        params: Dict[str, Any] = {
-            "id": conversation_id, "message": message, "role": role,
+        params: dict[str, Any] = {
+            "id": conversation_id,
+            "message": message,
+            "role": role,
         }
         if config_url:
             params["config_url"] = config_url
@@ -273,13 +295,14 @@ class AIChatClient:
     async def summarize(
         self,
         conversation_id: str,
-        summary_prompt: Optional[str] = None,
+        summary_prompt: str | None = None,
         **sampling: Any,
     ) -> str:
         """AI summary of the conversation (rate limited server-side)."""
-        params: Dict[str, Any] = {"id": conversation_id}
+        params: dict[str, Any] = {"id": conversation_id}
         if summary_prompt:
             params["summary_prompt"] = summary_prompt
         params.update({k: v for k, v in sampling.items() if v is not None})
         result = await self._request("summarize", params)
-        return result.get("summary", "")
+        summary = result.get("summary", "")
+        return summary if isinstance(summary, str) else str(summary)

--- a/tests/unit/ai_chat/test_client.py
+++ b/tests/unit/ai_chat/test_client.py
@@ -1,0 +1,216 @@
+"""AIChatClient wire contract.
+
+The client always speaks the rails front-door protocol: HTTP Basic
+``project:api_token``, JSON-RPC envelope, pure-payload params (identity never
+in the body). These tests pin that contract against an in-process stub server
+— no live service needed.
+"""
+
+import base64
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from signalwire.ai_chat import (
+    AIChatClient,
+    AIChatError,
+    AuthenticationError,
+    ChatInProgressError,
+    ConversationNotFoundError,
+    RateLimitError,
+)
+
+PROJECT = "proj-1"
+TOKEN = "tok-1"
+
+
+class StubService:
+    """Records every request; replies with a canned result or error."""
+
+    def __init__(self):
+        self.requests = []
+        self.result = {"status": "created", "response": "hi",
+                       "initial_message": "hello"}
+        self.error = None          # (code, message) -> JSON-RPC error
+        self.http_status = 200
+
+    def app(self):
+        async def handle(request):
+            self.requests.append({
+                "path": request.path,
+                "auth": request.headers.get("Authorization", ""),
+                "user_agent": request.headers.get("User-Agent", ""),
+                "body": await request.json(),
+            })
+            if self.error:
+                code, message = self.error
+                return web.json_response(
+                    {"jsonrpc": "2.0",
+                     "error": {"code": code, "message": message}, "id": "x"},
+                    status=self.http_status)
+            return web.json_response(
+                {"jsonrpc": "2.0", "result": self.result, "id": "x"})
+
+        app = web.Application()
+        app.router.add_post("/api/ai/chat", handle)
+        app.router.add_post("/", handle)
+        return app
+
+
+@pytest.fixture
+async def stub():
+    service = StubService()
+    server = TestServer(service.app())
+    await server.start_server()
+    service.url = str(server.make_url("/api/ai/chat"))
+    yield service
+    await server.close()
+
+
+def decode_basic(header):
+    assert header.startswith("Basic ")
+    return base64.b64decode(header[6:]).decode()
+
+
+# ── Wire shape ───────────────────────────────────────────────────────
+
+async def test_basic_auth_and_envelope(stub):
+    async with AIChatClient(PROJECT, TOKEN, url=stub.url) as client:
+        await client.chat("conv-1", "hello")
+    req = stub.requests[0]
+    # Identity rides in Basic auth — project as username
+    assert decode_basic(req["auth"]) == f"{PROJECT}:{TOKEN}"
+    # SDK-standard User-Agent
+    assert req["user_agent"].startswith("signalwire-python/")
+    # JSON-RPC envelope with pure-payload params
+    body = req["body"]
+    assert body["jsonrpc"] == "2.0" and body["method"] == "chat"
+    assert body["params"] == {"id": "conv-1", "message": "hello", "role": "user"}
+
+
+async def test_params_never_carry_identity(stub):
+    async with AIChatClient(PROJECT, TOKEN, url=stub.url) as client:
+        await client.create_conversation(
+            "conv-1", config_url="http://cfg", user_message="hi",
+            timeout=600, user_metadata={"k": "v"}, reinit=True)
+    params = stub.requests[0]["body"]["params"]
+    assert params == {
+        "id": "conv-1", "config_url": "http://cfg", "user_message": "hi",
+        "conversation_timeout": 600, "user_meta_data": {"k": "v"},
+        "reinit": True,
+    }
+    for forbidden in ("project_id", "token", "space_id"):
+        assert forbidden not in params
+
+
+async def test_all_methods_map_to_jsonrpc(stub):
+    async with AIChatClient(PROJECT, TOKEN, url=stub.url) as client:
+        await client.create_conversation("c", config_url="http://cfg")
+        await client.chat("c", "m")
+        stub.result = {"status": "ended"}
+        await client.end("c")
+        stub.result = {"status": "deleted"}
+        await client.delete("c")
+        stub.result = {"chat_log": [], "call_timeline": []}
+        await client.log("c")
+        stub.result = {"summary": "s"}
+        await client.summarize("c", summary_prompt="sum it")
+    methods = [r["body"]["method"] for r in stub.requests]
+    assert methods == ["create_conversation", "chat", "end_conversation",
+                       "delete", "chat_log", "summarize"]
+
+
+async def test_response_models(stub):
+    stub.result = {"status": "created", "initial_message": "welcome"}
+    async with AIChatClient(PROJECT, TOKEN, url=stub.url) as client:
+        info = await client.create_conversation("c", config_url="http://cfg")
+        assert info.status == "created" and info.initial_message == "welcome"
+
+        stub.result = {"response": "answer",
+                       "user_event": {"event_type": "order", "n": 1}}
+        reply = await client.chat("c", "m")
+        assert reply.text == "answer"
+        assert reply.user_event == {"event_type": "order", "n": 1}
+
+        stub.result = {"chat_log": [{"role": "user", "content": "m"}],
+                       "call_timeline": [{"t": 1}]}
+        log = await client.log("c")
+        assert log.messages[0]["content"] == "m"
+        assert log.call_timeline == [{"t": 1}]
+
+
+# ── URL resolution ───────────────────────────────────────────────────
+
+def test_url_from_space():
+    client = AIChatClient(PROJECT, TOKEN, space="myspace")
+    assert client.url == "https://myspace.signalwire.com/api/ai/chat"
+
+
+def test_url_arg_wins_over_space_and_env(monkeypatch):
+    monkeypatch.setenv("RAILS_DEV_MODE", "http://dev:1/")
+    client = AIChatClient(PROJECT, TOKEN, space="myspace", url="http://arg:2/")
+    assert client.url == "http://arg:2/"
+
+
+def test_rails_dev_mode_env_overrides_space(monkeypatch):
+    monkeypatch.setenv("RAILS_DEV_MODE", "http://localhost:8080/")
+    client = AIChatClient(PROJECT, TOKEN, space="myspace")
+    assert client.url == "http://localhost:8080/"
+
+
+def test_boolean_rails_dev_mode_is_not_a_url(monkeypatch):
+    # The same env var is the service's persona switch; a bare boolean
+    # carries no URL and must not clobber the space-derived target
+    monkeypatch.setenv("RAILS_DEV_MODE", "true")
+    client = AIChatClient(PROJECT, TOKEN, space="myspace")
+    assert client.url == "https://myspace.signalwire.com/api/ai/chat"
+
+
+def test_env_fallbacks(monkeypatch):
+    monkeypatch.setenv("SIGNALWIRE_PROJECT_ID", "env-proj")
+    monkeypatch.setenv("SIGNALWIRE_API_TOKEN", "env-tok")
+    monkeypatch.setenv("SIGNALWIRE_SPACE", "env-space")
+    client = AIChatClient()
+    assert client._project == "env-proj"
+    assert client.url == "https://env-space.signalwire.com/api/ai/chat"
+
+
+def test_missing_project_raises(monkeypatch):
+    monkeypatch.delenv("SIGNALWIRE_PROJECT_ID", raising=False)
+    with pytest.raises(ValueError, match="project"):
+        AIChatClient(space="s")
+
+
+def test_missing_url_raises(monkeypatch):
+    monkeypatch.delenv("SIGNALWIRE_SPACE", raising=False)
+    monkeypatch.delenv("RAILS_DEV_MODE", raising=False)
+    with pytest.raises(ValueError, match="URL"):
+        AIChatClient(PROJECT, TOKEN)
+
+
+# ── Error mapping ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("code,exc", [
+    (-32001, ConversationNotFoundError),
+    (-32005, RateLimitError),
+    (-32006, RateLimitError),
+    (-32007, ChatInProgressError),
+    (-32009, AuthenticationError),
+    (-32602, AIChatError),           # unmapped codes fall to the base
+])
+async def test_jsonrpc_errors_map_to_exceptions(stub, code, exc):
+    stub.error = (code, "nope")
+    stub.http_status = 401 if code == -32009 else 200
+    async with AIChatClient(PROJECT, TOKEN, url=stub.url) as client:
+        with pytest.raises(exc) as info:
+            await client.chat("c", "m")
+    assert info.value.code == code
+
+
+async def test_non_json_response_is_wrapped(stub, monkeypatch):
+    # Point at a path the stub doesn't serve JSON-RPC from
+    async with AIChatClient(PROJECT, TOKEN, url=stub.url.replace("/api/ai/chat", "/missing")) as client:
+        with pytest.raises(AIChatError) as info:
+            await client.chat("c", "m")
+    assert info.value.code == 404


### PR DESCRIPTION
## Summary
Makes @anthmFS's `signalwire.ai_chat` client (#72) pass the full project gate set. His original implementation is solid and its 18 wire-contract tests pass; this branch fixes the three gates that per-PR CI runs beyond `tests/unit`.

Builds on #72 (rebased onto main) with these fixes — **no behavior change**:
- **ruff (30 → 0)**: `typing.Dict/List` → `dict/list` (UP035/UP006), `Optional[X]` → `X | None` (UP045), and B904 (raise the non-JSON `AIChatError` `from err`).
- **mypy (2 → 0)**: `_ERROR_BY_CODE.get(code, …)` guarded on `code is not None` (the map is int-keyed; `code` is `Any | None` off the wire); `summarize()` coerces its `Any` result to `str`.

## Coordination
This is a coordinated pass. The DRIFT companion — the regenerated `python_signatures.json` capturing the new `ai_chat` surface — is in porting-sdk#117.

Coordinated-With: porting-sdk@feat/ai-chat-oracle

## Test plan
- ruff clean, mypy clean, ruff format clean
- the 18 `tests/unit/ai_chat/` wire-contract tests pass
- `aiohttp` is a core dep (pyproject) — CI auto-installs it

## Provenance note (follow-up)
The AI Chat wire contract (JSON-RPC `create_conversation`/`chat`/`end_conversation`/`delete`/`chat_log`/`summarize`, error codes -32001/5/6/7/9) is currently defined by the SDK + its tests. Deriving the **authoritative spec from the engine (`mod_openai`)** and floating a shared wire-corpus to the other 9 ports is a tracked follow-up, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
