### PR TITLE
fix(ci): declare `build` — multi-OS PACKAGE-SMOKE never had the module it needs

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -59,8 +59,13 @@ jobs:
       # deleted livewire member stops resolving instead of staying excused by a stale
       # committed file. Mirrors run-ci.sh's SURFACE-NATIVE gate (DOC-AUDIT deps on it).
       - name: Regenerate the native-only doc-audit sidecar
+        # `python` (the setup-python shim), not bare `python3` — see the PACKAGE-SMOKE
+        # note in multi-os.yml. This job is ubuntu-only, where setup-python front-loads
+        # its dir so both names currently resolve to the toolcache; using the shim keeps
+        # that true if this workflow ever gains a macOS runner, where bare `python3`
+        # resolves to the framework Python instead.
         run: |
-          python3 signalwire-python/scripts/emit_surface_native.py \
+          python signalwire-python/scripts/emit_surface_native.py \
             --out signalwire-python/port_surface_native.json
 
       - name: Run audit_docs.py against the Python surface
@@ -68,7 +73,7 @@ jobs:
         # surface oracle by design, but livewire/ docs are in this perimeter, so its
         # real members only resolve via the sidecar. See scripts/emit_surface_native.py.
         run: |
-          python3 porting-sdk/scripts/audit_docs.py \
+          python porting-sdk/scripts/audit_docs.py \
             --root signalwire-python \
             --surface porting-sdk/python_surface.json \
             --ignore signalwire-python/DOC_AUDIT_IGNORE.md \

--- a/.github/workflows/multi-os.yml
+++ b/.github/workflows/multi-os.yml
@@ -65,13 +65,16 @@ jobs:
       - name: PACKAGE-SMOKE (build + install + import from the built artifact)
         shell: bash
         working-directory: signalwire-python
-        # `python`, NOT `python3` — `python` is the shim actions/setup-python puts on
-        # PATH, so it is the 3.12 interpreter provisioned above (and the one the
-        # `pip install` step installed `build` into). Bare `python3` on the macOS
-        # runner resolves to /Library/Frameworks/Python.framework/Versions/3.12/bin/
-        # python3 — the PRE-INSTALLED framework Python, ahead of the toolcache — a
-        # different interpreter with no `build` module. That is the nightly failure
-        # (run 30238061313, macos-latest): "No module named build". package_smoke.py
-        # is not at fault; it correctly uses sys.executable, so it faithfully used
-        # whichever interpreter this line handed it.
+        # `python`, not `python3`: use the SAME name `pip` above pairs with, so this
+        # step provably runs the interpreter the deps were installed into. (On the
+        # macOS/arm64 runner BOTH names resolve to the pre-installed framework Python
+        # — setup-python does not win PATH there — and `pip` is that Python's pip, so
+        # the whole job is consistently one interpreter. Pinning the name keeps it that
+        # way if the image's precedence ever changes.)
+        #
+        # The nightly failure (run 30238061313, macos-latest) was
+        # "No module named build" — NOT an interpreter mismatch: `build` was never a
+        # declared dependency at all, so the gate silently relied on the runner image
+        # shipping it. Now declared in requirements-dev.txt, which the step above
+        # installs. package_smoke.py is not at fault; it correctly uses sys.executable.
         run: python ../porting-sdk/scripts/package_smoke.py --port python --repo .

--- a/.github/workflows/multi-os.yml
+++ b/.github/workflows/multi-os.yml
@@ -65,4 +65,13 @@ jobs:
       - name: PACKAGE-SMOKE (build + install + import from the built artifact)
         shell: bash
         working-directory: signalwire-python
-        run: python3 ../porting-sdk/scripts/package_smoke.py --port python --repo .
+        # `python`, NOT `python3` — `python` is the shim actions/setup-python puts on
+        # PATH, so it is the 3.12 interpreter provisioned above (and the one the
+        # `pip install` step installed `build` into). Bare `python3` on the macOS
+        # runner resolves to /Library/Frameworks/Python.framework/Versions/3.12/bin/
+        # python3 — the PRE-INSTALLED framework Python, ahead of the toolcache — a
+        # different interpreter with no `build` module. That is the nightly failure
+        # (run 30238061313, macos-latest): "No module named build". package_smoke.py
+        # is not at fault; it correctly uses sys.executable, so it faithfully used
+        # whichever interpreter this line handed it.
+        run: python ../porting-sdk/scripts/package_smoke.py --port python --repo .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,6 +17,12 @@ factory-boy>=3.3.0    # For test data factories
 faker>=19.0.0         # For generating fake data
 httpx>=0.24.0         # For async HTTP testing
 aiofiles>=23.0.0      # For async file operations in tests
+build>=1.0.0          # PACKAGE-SMOKE gate runs `python -m build --wheel` (see
+                      # porting-sdk/scripts/package_smoke.py plan_python). It was
+                      # never declared, so the gate depended on the runner image
+                      # happening to ship it — and failed on macOS/Windows, where it
+                      # does not (AGENT_RULES §7: a tool a gate needs is DECLARED,
+                      # not assumed present).
 
 # Optional-feature deps required by tests under tests/unit/search/.
 # These mirror the [search-queryonly] extra in pyproject.toml so the


### PR DESCRIPTION
## Measured mechanism

Nightly run [30238061313](https://github.com/signalwire/signalwire-python/actions/runs/30238061313), job `macos-latest`, step PACKAGE-SMOKE:

```
[FAIL] build: exit 1
    /Library/Frameworks/Python.framework/Versions/3.12/bin/python3: No module named build
```

**`build` is not a declared dependency anywhere** — not `requirements-dev.txt`, not `requirements.txt`, not `pyproject.toml`. The PACKAGE-SMOKE gate runs `python -m build --wheel` (`porting-sdk/scripts/package_smoke.py`, `plan_python`), so it has been relying on the runner image happening to ship the module.

`package_smoke.py` is **not** at fault: it correctly uses `sys.executable`, and faithfully reported the interpreter it was given.

### The interpreter-mismatch theory was tested and disproved

The initial read of this failure — bare `python3` bypassing `setup-python`'s toolcache — was plausible from the log alone, so it was fixed first and **dispatched**. That is how it was caught: with `python` instead of `python3`, run [30240024761](https://github.com/signalwire/signalwire-python/actions/runs/30240024761) failed **identically**, one word different:

```
/Library/Frameworks/Python.framework/Versions/3.12/bin/python: No module named build
```

The *same* framework interpreter, reached via the other name. On the macOS/arm64 runner **both** names resolve to the pre-installed framework Python — `setup-python` does not win PATH there.

And the same log shows `pip` is that framework Python's pip; every dependency installs to:

```
Requirement already satisfied: starlette==1.3.1 in
  /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages
```

So the job is **consistently one interpreter** and there was never a mismatch to repair. The module was simply never installed.

## Fix

`requirements-dev.txt` gains `build>=1.0.0` — the "Install harnesses + SDK" step already installs that file, so the gate now gets the module it has always needed.

This is **not** "`pip install build` into the wrong interpreter" (which the brief rightly forbids as masking a resolution bug): there is no wrong interpreter here, and declaring a genuinely undeclared dev dependency is the repair, not a mask. Per AGENT_RULES §7 — a tool a gate needs is *declared*, not assumed present.

### Sites changed

| file | change |
|---|---|
| `requirements-dev.txt` | **+`build>=1.0.0`** — the actual fix |
| `.github/workflows/multi-os.yml` | `python3` → `python` (line 68) + comment stating the true mechanism |
| `.github/workflows/doc-audit.yml` | `python3` → `python` (lines 63, 71) |

`python` is kept on its own merits: it is the same name `pip` pairs with, so the step provably runs the interpreter the deps went into, and it stays correct if the image's PATH precedence ever changes. It is not load-bearing for this fix.

### This gate has never passed for python, on any OS

`multi-os.yml` is the **only** place PACKAGE-SMOKE runs for this port — `nightly.yml` and `scripts/run-ci.sh` do not invoke it. So the "ubuntu ships `build`" path was never exercised either; this was red from the day it was added.

### Sweep of the sibling workflows

- **`nightly.yml`** — calls setup-python (line 100), no bare `python3`; ubuntu-only.
- **`live-smoke.yml`** — calls setup-python (line 42), no bare `python3`; ubuntu-only.
- `publish-dev.yml`, `publish-release.yml`, `reference-docs.yml`, `test.yml` — all call setup-python, none has a bare `python3` `run:` line.

`doc-audit.yml`'s two sites were the only other ones. They are ubuntu-only and green either way (setup-python does front-load its dir there); switched for consistency so the trap cannot activate if that job ever gains a macOS runner.

## How this was proved

```
$ grep -rn "^build\b\|^build[=><]" requirements-dev.txt requirements.txt pyproject.toml
# (before) no match — 'build' undeclared
```

```
$ grep -n '\bpython3\b' .github/workflows/*.yml
# only explanatory comments remain; no executable line invokes bare python3
```

`actionlint` on both changed workflows reports the same **6** pre-existing shellcheck `info`/`style` findings as before (all at `doc-audit.yml`'s untouched Summary step) — verified by stash/compare, so no new findings.

The decisive proof is the dispatched run, since the behaviour is specific to the runner image — the same method that caught the first attempt. Run [30258224912](https://github.com/signalwire/signalwire-python/actions/runs/30258224912), job `macos-latest`, step **PACKAGE-SMOKE: success**:

```
[package-smoke] python: real build+install+import in .../.sw-tmp/package-smoke-python-3088
    [PASS] build: Successfully built signalwire_sdk-3.3.0-py3-none-any.whl
    [PASS] install: (no stdout)
    [PASS] smoke: smoke-ok: signalwire.rest.RestClient constructed
[package-smoke] python: clean (artifact builds, installs, imports).
```

The step that emitted `No module named build` in both prior runs now builds the wheel and imports from it. Every macOS step is green.

## Windows is red for an unrelated, separately-assigned reason

The `windows-latest` job fails in the **TEST** step, before PACKAGE-SMOKE runs, so it cannot confirm this fix either way. Those are the four test-portability defects triaged as RED 3 (assigned elsewhere):

- `PermissionError [WinError 32]` on `…\Temp\tmp*.db` — sqlite connection not closed before the temp file is unlinked (2 teardowns);
- `assert str(gen.project_dir) == "/tmp/custom"` → `'\\tmp\\custom'`;
- `assert mode & 0o755 == 0o755` → `(33206 & 493) == 493` (Windows has no POSIX mode bits);
- `UnicodeEncodeError: 'charmap'` ×≥8 — UTF-8 text written with the cp1252 default.

Not touched here.

## Needs an owner call — deliberately not changed

`scripts/run-ci.sh` uses bare `python3` in **51** places. Both workflows that invoke it are ubuntu-only (latent, not live), and that script also runs on developer machines where `python3` is the correct name and `python` may not exist. A blanket rename is a behaviour change beyond this fix.
