### PR TITLE
fix(tests): Windows portability — sqlite handles, path assertions, permission bits, UTF-8 encoding

### DIFF
--- a/signalwire/signalwire/cli/dokku.py
+++ b/signalwire/signalwire/cli/dokku.py
@@ -1961,7 +1961,11 @@ class DokkuProjectGenerator:
         """Write a file to the project directory."""
         file_path = self.project_dir / path
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text(content)
+        # Always UTF-8, never the platform default. Several templates embed
+        # box-drawing characters (U+2500/U+2550) and arrows, which the Windows
+        # default codec (cp1252) cannot encode -- writing without an explicit
+        # encoding raises UnicodeEncodeError there.
+        file_path.write_text(content, encoding="utf-8")
 
         if executable:
             file_path.chmod(0o755)
@@ -2101,7 +2105,7 @@ def cmd_deploy(args: argparse.Namespace) -> int:
 
         try:
             with open(  # noqa: PTH123  # tests patch builtins.open while mocking Path; Path.open() would bypass the mock seam
-                "app.json"
+                "app.json", encoding="utf-8"
             ) as f:
                 app_json = json.load(f)
                 app_name = app_json.get("name")
@@ -2232,7 +2236,7 @@ def _get_app_name() -> str:
 
         try:
             with open(  # noqa: PTH123  # tests patch builtins.open while mocking Path; Path.open() would bypass the mock seam
-                "app.json"
+                "app.json", encoding="utf-8"
             ) as f:
                 # json.load() is typed -> Any; the "name" field is a string
                 # (default "" when absent). Coerce to satisfy the str return.

--- a/signalwire/signalwire/cli/init_project.py
+++ b/signalwire/signalwire/cli/init_project.py
@@ -1915,17 +1915,19 @@ class ProjectGenerator:
 
         # handler.py
         handler_code = AWS_HANDLER_TEMPLATE.format(**template_vars)
-        (self.project_dir / "handler.py").write_text(handler_code)
+        (self.project_dir / "handler.py").write_text(handler_code, encoding="utf-8")
         print_success("Created handler.py")
 
         # requirements.txt
-        (self.project_dir / "requirements.txt").write_text(AWS_REQUIREMENTS_TEMPLATE)
+        (self.project_dir / "requirements.txt").write_text(
+            AWS_REQUIREMENTS_TEMPLATE, encoding="utf-8"
+        )
         print_success("Created requirements.txt")
 
         # deploy.sh
         deploy_code = AWS_DEPLOY_TEMPLATE.format(**template_vars)
         deploy_path = self.project_dir / "deploy.sh"
-        deploy_path.write_text(deploy_code)
+        deploy_path.write_text(deploy_code, encoding="utf-8")
         deploy_path.chmod(0o755)
         print_success("Created deploy.sh")
 
@@ -1933,7 +1935,9 @@ class ProjectGenerator:
         self._create_cloud_env_example("aws")
 
         # .gitignore
-        (self.project_dir / ".gitignore").write_text(TEMPLATE_GITIGNORE)
+        (self.project_dir / ".gitignore").write_text(
+            TEMPLATE_GITIGNORE, encoding="utf-8"
+        )
         print_success("Created .gitignore")
 
         # README.md
@@ -1951,17 +1955,19 @@ class ProjectGenerator:
 
         # main.py
         main_code = GCP_MAIN_TEMPLATE.format(**template_vars)
-        (self.project_dir / "main.py").write_text(main_code)
+        (self.project_dir / "main.py").write_text(main_code, encoding="utf-8")
         print_success("Created main.py")
 
         # requirements.txt
-        (self.project_dir / "requirements.txt").write_text(GCP_REQUIREMENTS_TEMPLATE)
+        (self.project_dir / "requirements.txt").write_text(
+            GCP_REQUIREMENTS_TEMPLATE, encoding="utf-8"
+        )
         print_success("Created requirements.txt")
 
         # deploy.sh
         deploy_code = GCP_DEPLOY_TEMPLATE.format(**template_vars)
         deploy_path = self.project_dir / "deploy.sh"
-        deploy_path.write_text(deploy_code)
+        deploy_path.write_text(deploy_code, encoding="utf-8")
         deploy_path.chmod(0o755)
         print_success("Created deploy.sh")
 
@@ -1969,7 +1975,9 @@ class ProjectGenerator:
         self._create_cloud_env_example("gcp")
 
         # .gitignore
-        (self.project_dir / ".gitignore").write_text(TEMPLATE_GITIGNORE)
+        (self.project_dir / ".gitignore").write_text(
+            TEMPLATE_GITIGNORE, encoding="utf-8"
+        )
         print_success("Created .gitignore")
 
         # README.md
@@ -1991,31 +1999,37 @@ class ProjectGenerator:
 
         # function_app/__init__.py
         init_code = AZURE_INIT_TEMPLATE.format(**template_vars)
-        (function_dir / "__init__.py").write_text(init_code)
+        (function_dir / "__init__.py").write_text(init_code, encoding="utf-8")
         print_success("Created function_app/__init__.py")
 
         # function_app/function.json
-        (function_dir / "function.json").write_text(AZURE_FUNCTION_JSON_TEMPLATE)
+        (function_dir / "function.json").write_text(
+            AZURE_FUNCTION_JSON_TEMPLATE, encoding="utf-8"
+        )
         print_success("Created function_app/function.json")
 
         # host.json
-        (self.project_dir / "host.json").write_text(AZURE_HOST_JSON_TEMPLATE)
+        (self.project_dir / "host.json").write_text(
+            AZURE_HOST_JSON_TEMPLATE, encoding="utf-8"
+        )
         print_success("Created host.json")
 
         # local.settings.json
         (self.project_dir / "local.settings.json").write_text(
-            AZURE_LOCAL_SETTINGS_TEMPLATE
+            AZURE_LOCAL_SETTINGS_TEMPLATE, encoding="utf-8"
         )
         print_success("Created local.settings.json")
 
         # requirements.txt
-        (self.project_dir / "requirements.txt").write_text(AZURE_REQUIREMENTS_TEMPLATE)
+        (self.project_dir / "requirements.txt").write_text(
+            AZURE_REQUIREMENTS_TEMPLATE, encoding="utf-8"
+        )
         print_success("Created requirements.txt")
 
         # deploy.sh
         deploy_code = AZURE_DEPLOY_TEMPLATE.format(**template_vars)
         deploy_path = self.project_dir / "deploy.sh"
-        deploy_path.write_text(deploy_code)
+        deploy_path.write_text(deploy_code, encoding="utf-8")
         deploy_path.chmod(0o755)
         print_success("Created deploy.sh")
 
@@ -2023,7 +2037,9 @@ class ProjectGenerator:
         self._create_cloud_env_example("azure")
 
         # .gitignore
-        (self.project_dir / ".gitignore").write_text(TEMPLATE_GITIGNORE)
+        (self.project_dir / ".gitignore").write_text(
+            TEMPLATE_GITIGNORE, encoding="utf-8"
+        )
         print_success("Created .gitignore")
 
         # README.md
@@ -2073,7 +2089,7 @@ class ProjectGenerator:
 SWML_BASIC_AUTH_USER=admin
 SWML_BASIC_AUTH_PASSWORD=your-secure-password
 """
-        (self.project_dir / ".env.example").write_text(env_content)
+        (self.project_dir / ".env.example").write_text(env_content, encoding="utf-8")
         print_success("Created .env.example")
 
     def _create_cloud_readme(self, platform: str) -> None:
@@ -2269,7 +2285,7 @@ curl -X POST https://YOUR-APP.azurewebsites.net/api/function_app/swaig \\
 Set your phone number's SWML URL to the endpoint URL shown after deployment.
 """
 
-        (self.project_dir / "README.md").write_text(readme)
+        (self.project_dir / "README.md").write_text(readme, encoding="utf-8")
         print_success("Created README.md")
 
     def _create_directories(self) -> None:
@@ -2291,24 +2307,26 @@ Set your phone number's SWML URL to the endpoint URL shown after deployment.
         agents_dir = self.project_dir / "agents"
 
         # __init__.py
-        (agents_dir / "__init__.py").write_text(TEMPLATE_AGENTS_INIT)
+        (agents_dir / "__init__.py").write_text(TEMPLATE_AGENTS_INIT, encoding="utf-8")
         print_success("Created agents/__init__.py")
 
         # main_agent.py
         agent_code = get_agent_template(
             self.config.get("agent_type", "basic"), self.features
         )
-        (agents_dir / "main_agent.py").write_text(agent_code)
+        (agents_dir / "main_agent.py").write_text(agent_code, encoding="utf-8")
         print_success("Created agents/main_agent.py")
 
         # skills/__init__.py
-        (self.project_dir / "skills" / "__init__.py").write_text(TEMPLATE_SKILLS_INIT)
+        (self.project_dir / "skills" / "__init__.py").write_text(
+            TEMPLATE_SKILLS_INIT, encoding="utf-8"
+        )
         print_success("Created skills/__init__.py")
 
     def _create_app_file(self) -> None:
         """Create main app.py entry point."""
         app_code = get_app_template(self.features)
-        (self.project_dir / "app.py").write_text(app_code)
+        (self.project_dir / "app.py").write_text(app_code, encoding="utf-8")
         print_success("Created app.py")
 
     def _create_config_files(self) -> None:
@@ -2342,43 +2360,49 @@ SWML_PROXY_URL_BASE=
 DEBUG_WEBHOOK_LEVEL=1
 """
 
-        (self.project_dir / ".env").write_text(env_content)
+        (self.project_dir / ".env").write_text(env_content, encoding="utf-8")
         print_success("Created .env")
 
         # .env.example
-        (self.project_dir / ".env.example").write_text(TEMPLATE_ENV_EXAMPLE)
+        (self.project_dir / ".env.example").write_text(
+            TEMPLATE_ENV_EXAMPLE, encoding="utf-8"
+        )
         print_success("Created .env.example")
 
         # .gitignore
-        (self.project_dir / ".gitignore").write_text(TEMPLATE_GITIGNORE)
+        (self.project_dir / ".gitignore").write_text(
+            TEMPLATE_GITIGNORE, encoding="utf-8"
+        )
         print_success("Created .gitignore")
 
         # requirements.txt
-        (self.project_dir / "requirements.txt").write_text(TEMPLATE_REQUIREMENTS)
+        (self.project_dir / "requirements.txt").write_text(
+            TEMPLATE_REQUIREMENTS, encoding="utf-8"
+        )
         print_success("Created requirements.txt")
 
     def _create_test_files(self) -> None:
         """Create test files."""
         tests_dir = self.project_dir / "tests"
 
-        (tests_dir / "__init__.py").write_text(TEMPLATE_TESTS_INIT)
+        (tests_dir / "__init__.py").write_text(TEMPLATE_TESTS_INIT, encoding="utf-8")
         print_success("Created tests/__init__.py")
 
         test_code = get_test_template(self.features.get("example_tool", True))
-        (tests_dir / "test_agent.py").write_text(test_code)
+        (tests_dir / "test_agent.py").write_text(test_code, encoding="utf-8")
         print_success("Created tests/test_agent.py")
 
     def _create_web_files(self) -> None:
         """Create web UI files."""
         web_dir = self.project_dir / "web"
 
-        (web_dir / "index.html").write_text(get_web_index_template())
+        (web_dir / "index.html").write_text(get_web_index_template(), encoding="utf-8")
         print_success("Created web/index.html")
 
     def _create_readme(self) -> None:
         """Create README.md."""
         readme = get_readme_template(self.project_name, self.features)
-        (self.project_dir / "README.md").write_text(readme)
+        (self.project_dir / "README.md").write_text(readme, encoding="utf-8")
         print_success("Created README.md")
 
     def _create_virtualenv(self) -> None:

--- a/signalwire/signalwire/search/index_builder.py
+++ b/signalwire/signalwire/search/index_builder.py
@@ -10,6 +10,7 @@ See LICENSE file in the project root for full license information.
 import sqlite3
 import json
 import hashlib
+from contextlib import closing
 from datetime import datetime
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
@@ -779,39 +780,44 @@ class IndexBuilder:
             return {"valid": False, "error": "Index file does not exist"}
 
         try:
-            conn = sqlite3.connect(index_file)
-            cursor = conn.cursor()
+            # `closing` (not `with sqlite3.connect(...)`) — a Connection used as a
+            # context manager commits/rolls back the transaction but does NOT close
+            # the handle. On Windows an unclosed handle makes the file undeletable
+            # (PermissionError/WinError 32), so every exit path must close.
+            with closing(sqlite3.connect(index_file)) as conn:
+                cursor = conn.cursor()
 
-            # Check schema
-            cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
-            tables = [row[0] for row in cursor.fetchall()]
+                # Check schema
+                cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+                tables = [row[0] for row in cursor.fetchall()]
 
-            required_tables = ["chunks", "chunks_fts", "synonyms", "config"]
-            missing_tables = [t for t in required_tables if t not in tables]
+                required_tables = ["chunks", "chunks_fts", "synonyms", "config"]
+                missing_tables = [t for t in required_tables if t not in tables]
 
-            if missing_tables:
-                return {"valid": False, "error": f"Missing tables: {missing_tables}"}
+                if missing_tables:
+                    return {
+                        "valid": False,
+                        "error": f"Missing tables: {missing_tables}",
+                    }
 
-            # Get config
-            cursor.execute("SELECT key, value FROM config")
-            config = dict(cursor.fetchall())
+                # Get config
+                cursor.execute("SELECT key, value FROM config")
+                config = dict(cursor.fetchall())
 
-            # Get chunk count
-            cursor.execute("SELECT COUNT(*) FROM chunks")
-            chunk_count = cursor.fetchone()[0]
+                # Get chunk count
+                cursor.execute("SELECT COUNT(*) FROM chunks")
+                chunk_count = cursor.fetchone()[0]
 
-            # Get file count
-            cursor.execute("SELECT COUNT(DISTINCT filename) FROM chunks")
-            file_count = cursor.fetchone()[0]
+                # Get file count
+                cursor.execute("SELECT COUNT(DISTINCT filename) FROM chunks")
+                file_count = cursor.fetchone()[0]
 
-            conn.close()
-
-            return {
-                "valid": True,
-                "chunk_count": chunk_count,
-                "file_count": file_count,
-                "config": config,
-            }
+                return {
+                    "valid": True,
+                    "chunk_count": chunk_count,
+                    "file_count": file_count,
+                    "config": config,
+                }
 
         except Exception as e:
             return {"valid": False, "error": str(e)}

--- a/signalwire/signalwire/search/migration.py
+++ b/signalwire/signalwire/search/migration.py
@@ -9,6 +9,7 @@ See LICENSE file in the project root for full license information.
 
 import sqlite3
 import json
+from contextlib import closing
 from typing import Any, TYPE_CHECKING
 
 from signalwire.core.logging_config import get_logger
@@ -449,21 +450,21 @@ class SearchIndexMigrator:
             info["type"] = "sqlite"
             info["path"] = index_path
 
-            conn = sqlite3.connect(index_path)
-            cursor = conn.cursor()
+            # `closing` so the handle is released even when a query raises —
+            # an unclosed handle makes the file undeletable on Windows.
+            with closing(sqlite3.connect(index_path)) as conn:
+                cursor = conn.cursor()
 
-            # Get config
-            cursor.execute("SELECT key, value FROM config")
-            info["config"] = dict(cursor.fetchall())
+                # Get config
+                cursor.execute("SELECT key, value FROM config")
+                info["config"] = dict(cursor.fetchall())
 
-            # Get stats
-            cursor.execute("SELECT COUNT(*) FROM chunks")
-            info["total_chunks"] = cursor.fetchone()[0]
+                # Get stats
+                cursor.execute("SELECT COUNT(*) FROM chunks")
+                info["total_chunks"] = cursor.fetchone()[0]
 
-            cursor.execute("SELECT COUNT(DISTINCT filename) FROM chunks")
-            info["total_files"] = cursor.fetchone()[0]
-
-            conn.close()
+                cursor.execute("SELECT COUNT(DISTINCT filename) FROM chunks")
+                info["total_files"] = cursor.fetchone()[0]
 
         else:
             info["type"] = "unknown"

--- a/signalwire/signalwire/search/search_service.py
+++ b/signalwire/signalwire/search/search_service.py
@@ -436,12 +436,14 @@ class SearchService:
         # SQLite backend
         try:
             import sqlite3
+            from contextlib import closing
 
-            conn = sqlite3.connect(index_path)
-            cursor = conn.cursor()
-            cursor.execute("SELECT value FROM config WHERE key = 'embedding_model'")
-            result = cursor.fetchone()
-            conn.close()
+            # `closing` so the handle is released even when the query raises —
+            # an unclosed handle makes the file undeletable on Windows.
+            with closing(sqlite3.connect(index_path)) as conn:
+                cursor = conn.cursor()
+                cursor.execute("SELECT value FROM config WHERE key = 'embedding_model'")
+                result = cursor.fetchone()
             return result[0] if result else "sentence-transformers/all-mpnet-base-v2"
         except Exception as e:
             logger.warning(f"Could not get model name from index: {e}")

--- a/tests/unit/cli/test_dokku.py
+++ b/tests/unit/cli/test_dokku.py
@@ -274,9 +274,14 @@ class TestDokkuProjectGeneratorInit:
         gen = DokkuProjectGenerator("myapp", {})
         assert gen.project_dir == Path("./myapp")
 
-    def test_custom_project_dir(self) -> None:
-        gen = DokkuProjectGenerator("myapp", {'project_dir': '/tmp/custom'})
-        assert str(gen.project_dir) == "/tmp/custom"
+    def test_custom_project_dir(self, tmp_path: Path) -> None:
+        # Compare Path objects, not str() against a POSIX literal: `str(Path)`
+        # renders with the platform separator, so a hardcoded "/tmp/custom" can
+        # never match on Windows (it yields "\tmp\custom"). Using `tmp_path`
+        # also keeps the test off a hardcoded /tmp.
+        custom = tmp_path / "custom"
+        gen = DokkuProjectGenerator("myapp", {'project_dir': str(custom)})
+        assert gen.project_dir == custom
 
 
 class TestDokkuProjectGeneratorGenerate:
@@ -327,18 +332,46 @@ class TestDokkuProjectGeneratorWriteFile:
         gen = DokkuProjectGenerator("testapp", {'project_dir': str(tmp_path)})
         gen._write_file('hello.txt', 'Hello World')
         assert (tmp_path / 'hello.txt').exists()
-        assert (tmp_path / 'hello.txt').read_text() == 'Hello World'
+        assert (tmp_path / 'hello.txt').read_text(encoding="utf-8") == 'Hello World'
 
     def test_write_file_creates_nested_dirs(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("testapp", {'project_dir': str(tmp_path)})
         gen._write_file('a/b/c.txt', 'nested')
         assert (tmp_path / 'a' / 'b' / 'c.txt').exists()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX permission bits: Windows has no execute bit, so st_mode never "
+               "carries 0o755 (it reports 0o666/0o444 from the read-only attribute). "
+               "The Windows-side behaviour is covered by "
+               "test_write_file_executable_requests_chmod below.",
+    )
     def test_write_file_executable(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("testapp", {'project_dir': str(tmp_path)})
         gen._write_file('script.sh', '#!/bin/bash', executable=True)
         mode = (tmp_path / 'script.sh').stat().st_mode
         assert mode & 0o755 == 0o755
+
+    def test_write_file_executable_requests_chmod(self, tmp_path: Path) -> None:
+        """`executable=True` must chmod 0o755 -- assertable on every platform.
+
+        Windows drops the POSIX bits, so the observable-mode assertion above cannot
+        run there. Asserting the *request* keeps the contract covered on Windows and
+        catches a regression that silently stopped chmod-ing.
+        """
+        gen = DokkuProjectGenerator("testapp", {'project_dir': str(tmp_path)})
+        with patch.object(Path, 'chmod', autospec=True) as mock_chmod:
+            gen._write_file('script.sh', '#!/bin/bash', executable=True)
+        assert (tmp_path / 'script.sh').exists()
+        mock_chmod.assert_called_once()
+        assert mock_chmod.call_args[0][1] == 0o755
+
+    def test_write_file_not_executable_does_not_chmod(self, tmp_path: Path) -> None:
+        """The default path must not chmod at all (guards the flag's meaning)."""
+        gen = DokkuProjectGenerator("testapp", {'project_dir': str(tmp_path)})
+        with patch.object(Path, 'chmod', autospec=True) as mock_chmod:
+            gen._write_file('plain.txt', 'data')
+        mock_chmod.assert_not_called()
 
 
 class TestDokkuProjectGeneratorCoreFIles:
@@ -356,7 +389,7 @@ class TestDokkuProjectGeneratorCoreFIles:
         assert (tmp_path / 'app.json').exists()
         assert (tmp_path / 'app.py').exists()
         # Standard template used (not web)
-        content = (tmp_path / 'app.py').read_text()
+        content = (tmp_path / 'app.py').read_text(encoding="utf-8")
         assert 'AgentBase' in content
         assert 'AgentServer' not in content
 
@@ -366,40 +399,40 @@ class TestDokkuProjectGeneratorCoreFIles:
             'web': True
         })
         gen._write_core_files()
-        content = (tmp_path / 'app.py').read_text()
+        content = (tmp_path / 'app.py').read_text(encoding="utf-8")
         assert 'AgentServer' in content
         assert (tmp_path / 'web' / 'index.html').exists()
 
     def test_procfile_content(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("myapp", {'project_dir': str(tmp_path)})
         gen._write_core_files()
-        content = (tmp_path / 'Procfile').read_text()
+        content = (tmp_path / 'Procfile').read_text(encoding="utf-8")
         assert 'gunicorn' in content
         assert 'uvicorn' in content
 
     def test_runtime_content(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("myapp", {'project_dir': str(tmp_path)})
         gen._write_core_files()
-        content = (tmp_path / 'runtime.txt').read_text()
+        content = (tmp_path / 'runtime.txt').read_text(encoding="utf-8")
         assert 'python-3.11' in content
 
     def test_env_example_contains_app_name(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("my-cool-app", {'project_dir': str(tmp_path)})
         gen._write_core_files()
-        content = (tmp_path / '.env.example').read_text()
+        content = (tmp_path / '.env.example').read_text(encoding="utf-8")
         assert 'my-cool-app' in content
 
     def test_app_json_contains_app_name(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("testbot", {'project_dir': str(tmp_path)})
         gen._write_core_files()
-        content = (tmp_path / 'app.json').read_text()
+        content = (tmp_path / 'app.json').read_text(encoding="utf-8")
         data = json.loads(content)
         assert data['name'] == 'testbot'
 
     def test_app_py_uses_correct_class_name(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("my-agent", {'project_dir': str(tmp_path)})
         gen._write_core_files()
-        content = (tmp_path / 'app.py').read_text()
+        content = (tmp_path / 'app.py').read_text(encoding="utf-8")
         assert 'class MyAgentAgent' in content
         assert 'name="my-agent"' in content
 
@@ -417,6 +450,12 @@ class TestDokkuProjectGeneratorSimpleFiles:
         assert (tmp_path / 'deploy.sh').exists()
         assert (tmp_path / 'README.md').exists()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX permission bits: Windows has no execute bit, so st_mode never "
+               "carries 0o755. Windows-side coverage is "
+               "test_deploy_script_requests_executable_mode below.",
+    )
     def test_deploy_script_is_executable(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("myapp", {
             'project_dir': str(tmp_path),
@@ -427,6 +466,22 @@ class TestDokkuProjectGeneratorSimpleFiles:
         mode = (tmp_path / 'deploy.sh').stat().st_mode
         assert mode & 0o755 == 0o755
 
+    def test_deploy_script_requests_executable_mode(self, tmp_path: Path) -> None:
+        """deploy.sh must be written with executable=True on every platform."""
+        gen = DokkuProjectGenerator("myapp", {
+            'project_dir': str(tmp_path),
+            'dokku_host': 'dokku.example.com',
+            'route': 'swaig'
+        })
+        with patch.object(Path, 'chmod', autospec=True) as mock_chmod:
+            gen._write_simple_files()
+        chmodded = {
+            Path(c[0][0]).name: c[0][1] for c in mock_chmod.call_args_list
+        }
+        assert chmodded == {'deploy.sh': 0o755}, (
+            "deploy.sh (and only it) must be made executable"
+        )
+
     def test_deploy_script_contains_host(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("myapp", {
             'project_dir': str(tmp_path),
@@ -434,7 +489,7 @@ class TestDokkuProjectGeneratorSimpleFiles:
             'route': 'swaig'
         })
         gen._write_simple_files()
-        content = (tmp_path / 'deploy.sh').read_text()
+        content = (tmp_path / 'deploy.sh').read_text(encoding="utf-8")
         assert 'dokku.myhost.com' in content
 
     def test_readme_contains_app_name(self, tmp_path: Path) -> None:
@@ -444,7 +499,7 @@ class TestDokkuProjectGeneratorSimpleFiles:
             'route': 'swaig'
         })
         gen._write_simple_files()
-        content = (tmp_path / 'README.md').read_text()
+        content = (tmp_path / 'README.md').read_text(encoding="utf-8")
         assert 'myapp' in content
 
     def test_default_dokku_host(self, tmp_path: Path) -> None:
@@ -452,8 +507,93 @@ class TestDokkuProjectGeneratorSimpleFiles:
             'project_dir': str(tmp_path),
         })
         gen._write_simple_files()
-        content = (tmp_path / 'deploy.sh').read_text()
+        content = (tmp_path / 'deploy.sh').read_text(encoding="utf-8")
         assert 'dokku.yourdomain.com' in content
+
+
+class TestGeneratedFilesAreUtf8:
+    """Generated files must be written as UTF-8 regardless of platform locale.
+
+    Several templates embed box-drawing characters (U+2500 '-', U+2550 '=') and
+    arrows (U+2192). `Path.write_text()` without an explicit `encoding` uses the
+    platform default, which on Windows is cp1252 -- it cannot represent those
+    code points and raises `UnicodeEncodeError: 'charmap' codec can't encode
+    characters in position ...` (nightly Multi-OS run 30238061313, windows-latest;
+    8 direct failures plus 4 more surfacing as `generate()` returning False).
+
+    These assertions are platform-independent: they check the bytes on disk are
+    valid UTF-8 and round-trip to the original text, which is what an explicit
+    `encoding="utf-8"` guarantees and what the platform default does not.
+    """
+
+    def _non_ascii(self, text: str) -> set[str]:
+        return {c for c in text if ord(c) > 127}
+
+    def test_deploy_script_round_trips_as_utf8(self, tmp_path: Path) -> None:
+        gen = DokkuProjectGenerator("myapp", {
+            'project_dir': str(tmp_path),
+            'dokku_host': 'dokku.example.com',
+            'route': 'swaig',
+        })
+        gen._write_simple_files()
+
+        script = tmp_path / 'deploy.sh'
+        raw = script.read_bytes()
+        # Decodes as UTF-8 (would raise if written in cp1252 or latin-1)...
+        text = raw.decode('utf-8')
+        # ...and matches what the template intended, byte for byte.
+        assert text == script.read_text(encoding='utf-8')
+        # Guard the premise: this file really does carry the characters that
+        # break the Windows default codec. If a template edit removes them the
+        # test still passes but stops proving anything -- so assert they exist.
+        assert self._non_ascii(text), "expected non-ASCII content in deploy.sh"
+
+    def test_generated_content_is_not_cp1252_encodable(self, tmp_path: Path) -> None:
+        """The regression premise: this content genuinely cannot be cp1252.
+
+        Without this, an `encoding="utf-8"` fix could silently become untested if
+        the templates were ever reduced to pure ASCII.
+        """
+        gen = DokkuProjectGenerator("myapp", {
+            'project_dir': str(tmp_path),
+            'dokku_host': 'dokku.example.com',
+            'route': 'swaig',
+        })
+        gen._write_simple_files()
+        gen._write_cicd_files()
+
+        offenders = []
+        for path in sorted(tmp_path.rglob('*')):
+            if not path.is_file():
+                continue
+            text = path.read_text(encoding='utf-8')  # must not raise
+            try:
+                text.encode('cp1252')
+            except UnicodeEncodeError:
+                offenders.append(path.name)
+
+        assert offenders, (
+            "no generated file contains cp1252-hostile characters -- the UTF-8 "
+            "regression this guards is no longer reachable; re-check the templates"
+        )
+
+    def test_all_generated_files_decode_as_utf8(self, tmp_path: Path) -> None:
+        """Every file a full generate() produces must be valid UTF-8."""
+        gen = DokkuProjectGenerator("myapp", {
+            'project_dir': str(tmp_path / 'proj'),
+            'dokku_host': 'dokku.example.com',
+            'route': 'swaig',
+            'cicd': True,
+            'web': True,
+        })
+        assert gen.generate() is True
+
+        checked = 0
+        for path in sorted((tmp_path / 'proj').rglob('*')):
+            if path.is_file():
+                path.read_bytes().decode('utf-8')  # raises on a mis-encoded write
+                checked += 1
+        assert checked > 0, "generate() produced no files to check"
 
 
 class TestDokkuProjectGeneratorCicdFiles:
@@ -471,35 +611,35 @@ class TestDokkuProjectGeneratorCicdFiles:
     def test_deploy_workflow_content(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("myapp", {'project_dir': str(tmp_path)})
         gen._write_cicd_files()
-        content = (tmp_path / '.github' / 'workflows' / 'deploy.yml').read_text()
+        content = (tmp_path / '.github' / 'workflows' / 'deploy.yml').read_text(encoding="utf-8")
         assert 'Deploy' in content
         assert 'dokku-deploy-system' in content
 
     def test_preview_workflow_content(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("myapp", {'project_dir': str(tmp_path)})
         gen._write_cicd_files()
-        content = (tmp_path / '.github' / 'workflows' / 'preview.yml').read_text()
+        content = (tmp_path / '.github' / 'workflows' / 'preview.yml').read_text(encoding="utf-8")
         assert 'Preview' in content
         assert 'pull_request' in content
 
     def test_config_yml_content(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("myapp", {'project_dir': str(tmp_path)})
         gen._write_cicd_files()
-        content = (tmp_path / '.dokku' / 'config.yml').read_text()
+        content = (tmp_path / '.dokku' / 'config.yml').read_text(encoding="utf-8")
         assert 'resources:' in content
         assert 'healthcheck:' in content
 
     def test_services_yml_content(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("myapp", {'project_dir': str(tmp_path)})
         gen._write_cicd_files()
-        content = (tmp_path / '.dokku' / 'services.yml').read_text()
+        content = (tmp_path / '.dokku' / 'services.yml').read_text(encoding="utf-8")
         assert 'postgres:' in content
         assert 'redis:' in content
 
     def test_cicd_readme_contains_app_name(self, tmp_path: Path) -> None:
         gen = DokkuProjectGenerator("superbot", {'project_dir': str(tmp_path)})
         gen._write_cicd_files()
-        content = (tmp_path / 'README.md').read_text()
+        content = (tmp_path / 'README.md').read_text(encoding="utf-8")
         assert 'superbot' in content
 
 
@@ -521,7 +661,7 @@ class TestDokkuProjectGeneratorWebFiles:
             'route': 'swaig'
         })
         gen._write_web_files()
-        content = (tmp_path / 'web' / 'index.html').read_text()
+        content = (tmp_path / 'web' / 'index.html').read_text(encoding="utf-8")
         assert 'Cool Bot' in content
 
 
@@ -574,7 +714,7 @@ class TestDokkuProjectGeneratorFullGenerate:
         result = gen.generate()
         assert result is True
         assert (out / 'web' / 'index.html').exists()
-        content = (out / 'app.py').read_text()
+        content = (out / 'app.py').read_text(encoding="utf-8")
         assert 'AgentServer' in content
 
 
@@ -703,7 +843,7 @@ class TestCmdInit:
         mock_path_instance.exists.return_value = False
         mock_path_cls.return_value = mock_path_instance
 
-        args = self._make_args(host='dokku.example.com', dir_val='/tmp/custom')
+        args = self._make_args(host='dokku.example.com', dir_val='build/custom')
         result = cmd_init(args)
         assert result == 0
 
@@ -1180,12 +1320,12 @@ class TestMain:
         assert args.force is True
 
     @patch('signalwire.cli.dokku.cmd_init', return_value=0)
-    @patch('sys.argv', ['sw-agent-dokku', 'init', 'myapp', '--dir', '/tmp/out'])
+    @patch('sys.argv', ['sw-agent-dokku', 'init', 'myapp', '--dir', 'build/out'])
     def test_main_init_custom_dir(self, mock_cmd_init: MagicMock) -> None:
         result = main()
         assert result == 0
         args = mock_cmd_init.call_args[0][0]
-        assert args.dir == '/tmp/out'
+        assert args.dir == 'build/out'
 
     @patch('signalwire.cli.dokku.cmd_deploy', return_value=0)
     @patch('sys.argv', ['sw-agent-dokku', 'deploy', '--app', 'myapp', '--host', 'dokku.test.com'])
@@ -1447,7 +1587,7 @@ class TestEdgeCases:
 
     @patch('signalwire.cli.dokku.cmd_init', return_value=0)
     @patch('sys.argv', ['sw-agent-dokku', 'init', 'my-app', '--cicd', '--web',
-                        '--host', 'h', '--dir', '/tmp/d', '-f'])
+                        '--host', 'h', '--dir', 'build/d', '-f'])
     def test_main_all_init_flags(self, mock_cmd_init: MagicMock) -> None:
         """All init flags can be passed together."""
         result = main()
@@ -1457,5 +1597,5 @@ class TestEdgeCases:
         assert args.cicd is True
         assert args.web is True
         assert args.host == 'h'
-        assert args.dir == '/tmp/d'
+        assert args.dir == 'build/d'
         assert args.force is True

--- a/tests/unit/cli/test_dokku.py
+++ b/tests/unit/cli/test_dokku.py
@@ -538,14 +538,26 @@ class TestGeneratedFilesAreUtf8:
         gen._write_simple_files()
 
         script = tmp_path / 'deploy.sh'
-        raw = script.read_bytes()
-        # Decodes as UTF-8 (would raise if written in cp1252 or latin-1)...
-        text = raw.decode('utf-8')
-        # ...and matches what the template intended, byte for byte.
-        assert text == script.read_text(encoding='utf-8')
-        # Guard the premise: this file really does carry the characters that
-        # break the Windows default codec. If a template edit removes them the
-        # test still passes but stops proving anything -- so assert they exist.
+        # Decodes as UTF-8 -- raises if the file was written in cp1252/latin-1.
+        text = script.read_bytes().decode('utf-8')
+
+        # Compare against the source template, NOT against a second read of the
+        # file: text-mode writes translate "\n" -> "\r\n" on Windows and
+        # `read_text` translates it back (universal newlines), so
+        # `read_bytes().decode()` and `read_text()` legitimately differ there.
+        # Line endings are not what this test is about -- the encoding of the
+        # non-ASCII characters is. (Comparing those two reads is what made this
+        # test fail on the Windows runner while the encoding fix itself was fine.)
+        expected = DEPLOY_SCRIPT_TEMPLATE.format(
+            app_name='myapp', dokku_host='dokku.example.com', route='swaig'
+        )
+        assert text.splitlines() == expected.splitlines()
+
+        # The characters that break the Windows default codec must survive
+        # byte-for-byte -- this is the actual regression being guarded.
+        assert self._non_ascii(text) == self._non_ascii(expected)
+        # Guard the premise: if a template edit ever removed these, the test
+        # would still pass but stop proving anything.
         assert self._non_ascii(text), "expected non-ASCII content in deploy.sh"
 
     def test_generated_content_is_not_cp1252_encodable(self, tmp_path: Path) -> None:

--- a/tests/unit/cli/test_init_project.py
+++ b/tests/unit/cli/test_init_project.py
@@ -359,9 +359,13 @@ class TestProjectGenerator:
     """Tests for the ProjectGenerator class."""
 
     def _make_config(self, platform: str = 'local', **overrides: Any) -> dict[str, Any]:
+        # Relative, not '/tmp/...': the project rule forbids a hardcoded /tmp, and a
+        # rooted POSIX path is not portable anyway. Nothing here touches the disk --
+        # every generation path is mocked -- so no real directory is needed. Tests
+        # that assert on the value pass an explicit `tmp_path`-derived override.
         config: dict[str, Any] = {
             'project_name': 'test-agent',
-            'project_dir': '/tmp/test-agent',  # noqa: S108
+            'project_dir': 'test-agent',
             'platform': platform,
             'agent_type': 'basic',
             'features': {
@@ -379,12 +383,13 @@ class TestProjectGenerator:
         config.update(overrides)
         return config
 
-    def test_constructor(self) -> None:
-        config = self._make_config()
+    def test_constructor(self, tmp_path: Path) -> None:
+        target = tmp_path / 'test-agent'
+        config = self._make_config(project_dir=str(target))
         gen = ProjectGenerator(config)
         assert gen.project_name == 'test-agent'
         assert gen.platform == 'local'
-        assert gen.project_dir == Path('/tmp/test-agent')  # noqa: S108
+        assert gen.project_dir == target
 
     @patch.object(ProjectGenerator, '_generate_local', return_value=True)
     def test_generate_dispatches_to_local(self, mock_gen: MagicMock) -> None:
@@ -578,16 +583,21 @@ class TestMain:
         assert config['platform'] == 'aws'
 
     @patch('signalwire.cli.init_project.ProjectGenerator')
-    @patch('sys.argv', ['sw-agent-init', 'testproject', '--no-venv', '--dir', '/tmp/custom'])  # noqa: S108
-    def test_main_custom_dir(self, mock_gen_class: MagicMock) -> None:
+    def test_main_custom_dir(self, mock_gen_class: MagicMock, tmp_path: Path) -> None:
         mock_gen = Mock()
         mock_gen.generate.return_value = True
         mock_gen_class.return_value = mock_gen
 
-        main()
+        custom = tmp_path / 'custom'
+        with patch('sys.argv',
+                   ['sw-agent-init', 'testproject', '--no-venv', '--dir', str(custom)]):
+            main()
 
         config = mock_gen_class.call_args[0][0]
-        assert '/tmp/custom' in config['project_dir']  # noqa: S108
+        # main() builds `(Path(args.dir) / args.name).absolute()`. Compare Paths --
+        # a substring check against a POSIX literal fails on Windows, where the
+        # separator is `\` and a rooted POSIX path gains a drive letter.
+        assert Path(config['project_dir']) == (custom / 'testproject').absolute()
 
     @patch('signalwire.cli.init_project.ProjectGenerator')
     @patch('sys.argv', ['sw-agent-init', 'testproject', '--no-venv'])

--- a/tests/unit/search/test_index_builder.py
+++ b/tests/unit/search/test_index_builder.py
@@ -16,6 +16,8 @@ import tempfile
 import os
 import sqlite3
 import json
+from contextlib import closing
+from typing import Any
 from unittest.mock import Mock, patch, MagicMock, mock_open
 from pathlib import Path
 
@@ -500,11 +502,117 @@ class TestIndexBuilderIndexValidation:
         with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
             self.temp_db = f.name
             f.write(b"invalid sqlite data")
-        
+
         result = self.builder.validate_index(self.temp_db)
-        
+
         assert result["valid"] is False
         assert "error" in result
+
+
+class TestValidateIndexClosesConnection:
+    """`validate_index` must close its sqlite connection on EVERY return path.
+
+    A leaked handle is invisible on POSIX (unlink succeeds regardless) but on
+    Windows it makes the file undeletable -- `PermissionError: [WinError 32] The
+    process cannot access the file because it is being used by another process`,
+    which is how this surfaced (nightly Multi-OS run 30238061313, windows-latest).
+
+    These tests assert the platform-independent invariant -- that every connection
+    opened is also closed -- so the Windows-only bug is provable on POSIX too.
+    """
+
+    def _connect_spy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> list[sqlite3.Connection]:
+        """Record every Connection validate_index opens, so we can assert it closed."""
+        opened: list[sqlite3.Connection] = []
+        real_connect = sqlite3.connect
+
+        def spy(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+            # `sqlite3.connect` is overloaded, so calling it through *args widens
+            # the result to Any; annotate to keep the spy's return type honest.
+            conn: sqlite3.Connection = real_connect(*args, **kwargs)
+            opened.append(conn)
+            return conn
+
+        monkeypatch.setattr(
+            "signalwire.search.index_builder.sqlite3.connect", spy
+        )
+        return opened
+
+    @staticmethod
+    def _is_closed(conn: sqlite3.Connection) -> bool:
+        """A closed Connection raises ProgrammingError on any further use."""
+        try:
+            conn.execute("SELECT 1")
+        except sqlite3.ProgrammingError:
+            return True
+        return False
+
+    def test_missing_tables_path_closes_connection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The `Missing tables` early return must not leak the handle."""
+        db = tmp_path / "missing_tables.db"
+        with closing(sqlite3.connect(str(db))) as setup:
+            setup.execute("CREATE TABLE chunks (id INTEGER)")
+            setup.commit()
+
+        opened = self._connect_spy(monkeypatch)
+        result = IndexBuilder().validate_index(str(db))
+
+        assert result["valid"] is False
+        assert "Missing tables" in result["error"]
+        assert len(opened) == 1, "expected validate_index to open exactly one connection"
+        assert self._is_closed(opened[0]), "connection leaked on the missing-tables path"
+
+        # The operation Windows refuses when a handle is still open.
+        db.unlink()
+
+    def test_database_error_path_closes_connection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exception path must not leak the handle either.
+
+        `sqlite3.connect` is lazy, so it succeeds on a non-database file and the
+        failure surfaces from the first query -- inside the `try`, after the
+        connection exists.
+        """
+        db = tmp_path / "not_a_database.db"
+        db.write_bytes(b"invalid sqlite data")
+
+        opened = self._connect_spy(monkeypatch)
+        result = IndexBuilder().validate_index(str(db))
+
+        assert result["valid"] is False
+        assert "error" in result
+        assert len(opened) == 1, "expected validate_index to open exactly one connection"
+        assert self._is_closed(opened[0]), "connection leaked on the error path"
+
+        db.unlink()
+
+    def test_valid_index_path_closes_connection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The success path must close too (it did before; guard against regression)."""
+        db = tmp_path / "valid.db"
+        builder = IndexBuilder()
+        builder._create_database(
+            str(db),
+            [{"content": "Test", "filename": "t.txt", "embedding": b"data"}],
+            ["en"],
+            ["/src"],
+            ["txt"],
+        )
+
+        opened = self._connect_spy(monkeypatch)
+        result = builder.validate_index(str(db))
+
+        assert result["valid"] is True
+        assert len(opened) == 1
+        assert self._is_closed(opened[0]), "connection leaked on the success path"
+
+        db.unlink()
 
 
 class TestIndexBuilderBuildMethods:
@@ -563,10 +671,12 @@ class TestIndexBuilderBuildMethods:
             mock_create_db.assert_called_once()
             assert mock_model.encode.call_count == 2
     
-    def test_build_index_from_sources_no_files(self) -> None:
+    def test_build_index_from_sources_no_files(self, tmp_path: Path) -> None:
         """Test index building with no files found"""
-        # Don't create temp file since method should return early
-        temp_db = "/tmp/nonexistent.db"
+        # A path inside tmp_path that is deliberately never created: the method
+        # must return early. (`tmp_path`, not a hardcoded /tmp -- project rule,
+        # and it guarantees a clean directory.)
+        temp_db = str(tmp_path / "nonexistent.db")
         
         with patch.object(self.builder, '_discover_files_from_sources', return_value=[]):
             sources = [Path("/empty/dir")]
@@ -578,10 +688,10 @@ class TestIndexBuilderBuildMethods:
             # Database should not be created
             assert not os.path.exists(temp_db)
     
-    def test_build_index_from_sources_no_chunks(self) -> None:
+    def test_build_index_from_sources_no_chunks(self, tmp_path: Path) -> None:
         """Test index building with no chunks created"""
-        # Don't create temp file since method should return early
-        temp_db = "/tmp/nonexistent2.db"
+        # Deliberately-absent path; the method must return early.
+        temp_db = str(tmp_path / "nonexistent2.db")
         
         mock_files = [Path("test.txt")]
         

--- a/tests/unit/search/test_search_engine.py
+++ b/tests/unit/search/test_search_engine.py
@@ -16,6 +16,7 @@ import sqlite3
 import json
 import tempfile
 import os
+from contextlib import closing
 from unittest.mock import Mock, patch, MagicMock
 from pathlib import Path
 
@@ -26,11 +27,14 @@ from typing import Any
 class TestSearchEngineInit:
     """Test SearchEngine initialization"""
     
-    def test_init_with_valid_index(self) -> None:
+    def test_init_with_valid_index(self, tmp_path: Path) -> None:
         """Test initialization with valid index file"""
-        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as tmp:
-            # Create a minimal database
-            conn = sqlite3.connect(tmp.name)
+        # `tmp_path`, not NamedTemporaryFile(delete=False): the latter keeps its own
+        # OS handle open for the life of the `with` block, and on Windows a file with
+        # a live handle cannot be unlinked (PermissionError/WinError 32).
+        db_path = str(tmp_path / 'valid_index.db')
+        # Create a minimal database
+        with closing(sqlite3.connect(db_path)) as conn:
             cursor = conn.cursor()
             cursor.execute('''
                 CREATE TABLE config (key TEXT, value TEXT)
@@ -39,28 +43,23 @@ class TestSearchEngineInit:
                 INSERT INTO config (key, value) VALUES ('embedding_dimensions', '768')
             ''')
             conn.commit()
-            conn.close()
-            
-            engine = SearchEngine(backend='sqlite', index_path=tmp.name)
-            assert engine.index_path == tmp.name
-            assert engine.embedding_dim == 768
-            assert engine.config['embedding_dimensions'] == '768'
 
-            os.unlink(tmp.name)
+        engine = SearchEngine(backend='sqlite', index_path=db_path)
+        assert engine.index_path == db_path
+        assert engine.embedding_dim == 768
+        assert engine.config['embedding_dimensions'] == '768'
 
-    def test_init_with_missing_config(self) -> None:
+    def test_init_with_missing_config(self, tmp_path: Path) -> None:
         """Test initialization with missing config table"""
-        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as tmp:
-            # Create empty database
-            conn = sqlite3.connect(tmp.name)
-            conn.close()
+        db_path = str(tmp_path / 'missing_config.db')
+        # Create empty database
+        with closing(sqlite3.connect(db_path)):
+            pass
 
-            engine = SearchEngine(backend='sqlite', index_path=tmp.name)
-            assert engine.index_path == tmp.name
-            assert engine.embedding_dim == 768  # Default value
-            assert engine.config == {}
-
-            os.unlink(tmp.name)
+        engine = SearchEngine(backend='sqlite', index_path=db_path)
+        assert engine.index_path == db_path
+        assert engine.embedding_dim == 768  # Default value
+        assert engine.config == {}
 
     def test_init_with_nonexistent_file(self) -> None:
         """Test initialization with nonexistent index file"""
@@ -535,15 +534,15 @@ class TestSearchEngineUtilities:
 class TestSearchEngineEdgeCases:
     """Test edge cases and error handling"""
     
-    def test_fallback_search(self) -> None:
+    def test_fallback_search(self, tmp_path: Path) -> None:
         """Test fallback search functionality"""
-        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as tmp:
-            # Create database with fallback search capability
-            conn = sqlite3.connect(tmp.name)
+        db_path = str(tmp_path / 'fallback.db')
+        # Create database with fallback search capability
+        with closing(sqlite3.connect(db_path)) as conn:
             cursor = conn.cursor()
-            
+
             cursor.execute('CREATE TABLE config (key TEXT, value TEXT)')
-            
+
             cursor.execute('''
                 CREATE TABLE chunks (
                     id INTEGER PRIMARY KEY,
@@ -555,23 +554,20 @@ class TestSearchEngineEdgeCases:
                     processed_content TEXT
                 )
             ''')
-            
+
             cursor.execute('''
                 INSERT INTO chunks (content, filename, section, tags, metadata, processed_content)
                 VALUES (?, ?, ?, ?, ?, ?)
             ''', ('Python tutorial content', 'tutorial.md', 'intro', '["python"]', '{}', 'python tutorial content'))
-            
+
             conn.commit()
-            conn.close()
-            
-            engine = SearchEngine(backend='sqlite', index_path=tmp.name)
-            results = engine._fallback_search('Python', count=1)
-            
-            assert len(results) == 1
-            assert 'Python' in results[0]['content']
-            assert results[0]['search_type'] == 'fallback'
-            
-            os.unlink(tmp.name)
+
+        engine = SearchEngine(backend='sqlite', index_path=db_path)
+        results = engine._fallback_search('Python', count=1)
+
+        assert len(results) == 1
+        assert 'Python' in results[0]['content']
+        assert results[0]['search_type'] == 'fallback'
     
     def test_fallback_search_database_error(self) -> None:
         """Test fallback search with database error"""


### PR DESCRIPTION
Four **distinct** cross-platform defects in the Windows job, each with its own mechanism. All four were measured from nightly Multi-OS run [30238061313](https://github.com/signalwire/signalwire-python/actions/runs/30238061313), job `windows-latest`, step TEST — which reported **36 failed / 2 errors / 5671 passed** and were all still live on `main`.

Two of the four turned out to be **product bugs, not test bugs**.

---

## 1. sqlite handle outlives the temp file — `PermissionError [WinError 32]`

**Product bug.** `search/index_builder.py::validate_index()` called `conn.close()` **only on the success path**. Both other exits leaked the handle:

- the `Missing tables` early return
- the `except Exception` return (`sqlite3.connect` is lazy, so it succeeds on a non-database file and the failure surfaces from the first query — *after* the connection exists)

Windows refuses to delete a file that still has a live handle, so the fixture's `os.remove()` raised at teardown of `test_validate_index_missing_tables` and `…_database_error`.

Fixed with `contextlib.closing` — deliberately **not** `with sqlite3.connect(...)`, because a `Connection` used as a context manager commits/rolls back the transaction but **does not close the handle**.

I then audited **all 14 `sqlite3.connect` sites** under `search/` and found **two more** unguarded on their error paths, which would have bitten next:

- `migration.py::get_index_info()`
- `search_service.py::_get_model_name()`

Also fixed the **test-side** leak in `test_search_engine.py` (3 sites): `NamedTemporaryFile(delete=False)` keeps its own OS handle open for the life of the `with` block, and `os.unlink(tmp.name)` was being called *inside* that block. Replaced with `tmp_path`.

**Files:** `signalwire/search/index_builder.py`, `signalwire/search/migration.py`, `signalwire/search/search_service.py`, `tests/unit/search/test_index_builder.py`, `tests/unit/search/test_search_engine.py`

## 2. Hardcoded POSIX path assertion

`assert str(gen.project_dir) == "/tmp/custom"` → on Windows `str(Path)` renders with the platform separator, giving `\tmp\custom`. A `str()`-ed path compared to a POSIX literal can never match there.

Fixed **both** problems: compare `Path` objects (platform-correct on both), and drop the `/tmp` usage itself per the standing project rule, using `tmp_path`.

`tests/unit/cli/test_init_project.py::test_main_custom_dir` failed the same way — `assert '/tmp/custom' in 'D:\tmp\custom\testproject'` — and is fixed the same way. Note `main()` builds `(Path(args.dir) / args.name).absolute()`, so the assertion now compares against exactly that.

**Files:** `tests/unit/cli/test_dokku.py`, `tests/unit/cli/test_init_project.py`

## 3. POSIX permission bits

`assert mode & 0o755 == 0o755` → Windows reports `(33206 & 493) == 493` false. Windows has no execute bit; `st_mode` reflects only the read-only attribute (`0o666`/`0o444`).

The two observable-mode assertions are now `skipif(sys.platform == "win32")` with the mechanism recorded in the reason. **Nothing was deleted or weakened on POSIX.** Additionally, the contract those tests were actually checking — that the generator makes the script executable — is now asserted **platform-independently** by new tests that verify `chmod(0o755)` is requested, and that it is requested for `deploy.sh` *and only* `deploy.sh`. So Windows keeps real coverage of the behaviour instead of losing it to a skip.

**Files:** `tests/unit/cli/test_dokku.py`

## 4. `UnicodeEncodeError: 'charmap'`

**Product bug.** `cli/dokku.py:1964` wrote every generated file via `file_path.write_text(content)` — no `encoding=`, so the platform default, which is **cp1252** on Windows.

The templates embed box-drawing rules (**U+2500 `─`** ×1694, **U+2550 `═`** ×1124) and arrows (**U+2192 `→`** ×17). cp1252 cannot represent any of them. The rules are 59-character runs, which is exactly the width of the failing ranges in the log (`position 130-188`).

This accounted for **14 of the 17** `test_dokku.py` failures: 8 direct `UnicodeEncodeError`s, plus 4 more that surfaced as `generate()` returning `False` with `Failed to generate project: 'charmap' codec can't encode characters in position 2-80`.

Fixed at `_write_file` (the single funnel for all dokku writes) plus the two `open("app.json")` reads. While auditing, `cli/init_project.py` proved to have the **same latent defect** — 98 cp1252-hostile characters (box-drawing tree glyphs `├ └ │ ─`) across **29 unguarded `write_text` sites** — so those are fixed too, before they bite. The test-side `read_text()` calls got explicit `encoding="utf-8"` as well, since they read those files back.

**Files:** `signalwire/cli/dokku.py`, `signalwire/cli/init_project.py`, `tests/unit/cli/test_dokku.py`

---

## What is proven on POSIX vs pending on Windows

Three of these four are invisible on POSIX, so "the suite is green on macOS" would prove almost nothing by itself. Two of the four are nonetheless **provable** on POSIX, and I made them so rather than deferring to CI:

**Defect 1 — proven.** Three new tests assert the platform-independent invariant (*every connection opened is also closed*) using a `sqlite3.connect` spy, which is what Windows enforces via undeletability. Verified they **fail against the unfixed product code** and pass with it:

```
FAILED …::test_missing_tables_path_closes_connection - connection leaked on the missing-tables path
FAILED …::test_database_error_path_closes_connection
2 failed, 1 passed
```

**Defect 4 — proven.** I reproduced the Windows failure class on macOS by forcing a non-UTF-8 platform default (`LC_ALL=C … python -X utf8=0`):

```
Failed to generate project: 'ascii' codec can't encode characters in position 2-80
```

— the **same position range 2-80** as CI's `'charmap' codec can't encode characters in position 2-80`. The three new UTF-8 round-trip tests fail without the fix; **with** the fix all 210 `cli` tests pass even under that hostile locale. One of the new tests also asserts the *premise* (that generated content genuinely is cp1252-hostile), so the fix cannot silently become untested if a template is later reduced to ASCII.

**Defects 2 and 3 — pending Windows CI.** These are structural (`Path` comparison; platform skip). `Path` comparison is correct on both platforms by construction, but neither the `\`-separator behaviour nor the absent execute bit can be exercised on POSIX. They need the real runner.

## Local verification

Full gate run, not a `--rules` subset:

```
$ bash scripts/run-ci.sh
… 37 gates …
==> CI PASS          (exit 0)
```

Unit suite: **5621 passed, 100 skipped** on macOS (Python 3.13).

## Heads-up: PACKAGE-SMOKE will run on Windows for the first time

The Windows TEST step failing is what kept PACKAGE-SMOKE from executing on that job at all (sequencing confirmed in the run: `TEST: failure` → `PACKAGE-SMOKE: skipped`). If TEST now passes, PACKAGE-SMOKE will execute on Windows for the first time and may surface **new, unrelated** failures. That is progress, not a regression from this PR, and it should be triaged separately rather than absorbed here.

## Separately noted, deliberately not fixed here

`grep` finds **46** `/tmp` literals across `tests/` in files unrelated to these four defects (`test_web_service.py`, `test_mcp_manager.py`, `test_native_vector_search_skill.py`, `test_build_search.py`, `test_gateway_service.py`, …). They are mostly inert strings in mocked paths, so they do not fail on Windows, but they do violate the standing no-`/tmp` rule. Left out to keep this PR scoped to the four defects; worth its own sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFKJhLvfV8yGrASwqxdgaf
